### PR TITLE
build: bump SDK to 37 and optimize Gradle build performance

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,13 +87,14 @@ abstract class RenameApkTask : DefaultTask() {
 
 android {
     namespace = "com.eltavine.duckdetector"
-    compileSdk = 36
+    compileSdk = 37
+    compileSdkMinor = 0
     ndkVersion = "30.0.14904198 rc1"
 
     defaultConfig {
         applicationId = "com.eltavine.duckdetector"
         minSdk = 29
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 214
         versionName = "26.3.14-alpha"
         buildConfigField("String", "BUILD_TIME_UTC", "\"$buildTimeUtc\"")
@@ -155,11 +156,11 @@ androidComponents {
     onVariants(selector().all()) { variant ->
         val taskName = "rename${
             variant.name.replaceFirstChar { firstChar ->
-            if (firstChar.isLowerCase()) {
-                firstChar.titlecase()
-            } else {
-                firstChar.toString()
-            }
+                if (firstChar.isLowerCase()) {
+                    firstChar.titlecase()
+                } else {
+                    firstChar.toString()
+                }
             }
         }Apk"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,10 +6,16 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8g -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+android.nonTransitiveRClass=true
+android.r8.maxWorkers=4
+android.r8.optimizedResourceShrinking=true
+org.gradle.configuration-cache=true
+org.gradle.configureondemand=true
+android.suppressUnsupportedCompileSdk=37.0


### PR DESCRIPTION
Update the project to target Android SDK 37 and apply several build system optimizations to improve compilation speed and resource management.

Why:
- To leverage the latest Android SDK features and stay current with platform requirements.
- To reduce build times and improve developer productivity by enabling modern Gradle and R8 performance features.

What changed:
- Updated `compileSdk` and `targetSdk` to 37 in `app/build.gradle.kts`.
- Increased Gradle JVM heap size from 2GB to 8GB (`-Xmx8g`).
- Enabled Gradle parallel execution, configuration caching, and configuration on demand in `gradle.properties`.
- Configured R8 to use 4 max workers and enabled optimized resource shrinking.
- Enabled non-transitive R classes (`android.nonTransitiveRClass`) to improve build isolation and speed.
- Added `android.suppressUnsupportedCompileSdk=37.0` to handle early SDK 37 adoption.
- Fixed minor indentation in the APK renaming task logic.

Behavioral impact:
- None on the application logic. Developers should notice faster incremental builds and improved resource handling during the build process.

Files changed:
- `app/build.gradle.kts`
- `gradle.properties`