### PR TITLE
Automate versioning logic using Git metadata and clean up build configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,8 +8,6 @@ android {
 
     defaultConfig {
         applicationId = "com.eltavine.duckdetector"
-        versionCode = 215
-        versionName = "26.4.1"
     }
 }
 

--- a/build-logic/src/main/kotlin/com/eltavine/duckdetector/buildlogic/DuckDetectorAndroidApplicationConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/eltavine/duckdetector/buildlogic/DuckDetectorAndroidApplicationConventionPlugin.kt
@@ -7,9 +7,14 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 
 class DuckDetectorAndroidApplicationConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
+        val versionCodeOffset = 154
+
         pluginManager.apply("com.android.application")
         pluginManager.apply("org.jetbrains.kotlin.plugin.compose")
 
@@ -29,6 +34,14 @@ class DuckDetectorAndroidApplicationConventionPlugin : Plugin<Project> {
                 }
             )
             .orElse("unknown")
+
+        val gitCommitCount = providers.of(GitCommitCountValueSource::class.java) {
+            parameters.repositoryRoot.set(rootDir.absolutePath)
+        }
+
+        val monthlyCommitCount = providers.of(GitMonthlyCommitCountValueSource::class.java) {
+            parameters.repositoryRoot.set(rootDir.absolutePath)
+        }
 
         val releaseKeystorePath = providers.environmentVariable("ANDROID_KEYSTORE_PATH")
         val releaseStorePassword = providers.environmentVariable("ANDROID_KEYSTORE_PASSWORD")
@@ -54,6 +67,10 @@ class DuckDetectorAndroidApplicationConventionPlugin : Plugin<Project> {
             defaultConfig {
                 minSdk = requiredIntGradleProperty("duckdetector.android.minSdk")
                 targetSdk = requiredIntGradleProperty("duckdetector.android.targetSdk")
+                versionCode = versionCodeOffset + gitCommitCount.get()
+                val versionNamePatchPart = monthlyCommitCount.get()
+                versionName = "${LocalDate.now(ZoneOffset.UTC)
+                    .format(DateTimeFormatter.ofPattern("yyyy.MM"))}.${if (versionNamePatchPart > 0) versionNamePatchPart else "unknown"}"
                 testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
                 buildConfigField("String", "BUILD_TIME_UTC", "\"${buildTimeUtc.get()}\"")
                 buildConfigField("String", "BUILD_HASH", "\"${buildHash.get()}\"")

--- a/build-logic/src/main/kotlin/com/eltavine/duckdetector/buildlogic/GitMetadataValueSources.kt
+++ b/build-logic/src/main/kotlin/com/eltavine/duckdetector/buildlogic/GitMetadataValueSources.kt
@@ -7,6 +7,7 @@ import org.gradle.process.ExecOperations
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
@@ -45,6 +46,41 @@ abstract class GitCommitTimestampValueSource @Inject constructor(
         )
         val instant = epochSeconds.toLongOrNull()?.let(Instant::ofEpochSecond) ?: return UNKNOWN
         return BUILD_TIME_FORMATTER.format(instant)
+    }
+}
+
+abstract class GitCommitCountValueSource @Inject constructor(
+    private val execOperations: ExecOperations,
+) : ValueSource<Int, GitRepositoryParameters> {
+    override fun obtain(): Int {
+        val count = runGitCommand(
+            execOperations = execOperations,
+            repositoryRoot = parameters.repositoryRoot.get(),
+            "rev-list",
+            "--count",
+            "HEAD",
+        )
+        return count.toIntOrNull() ?: 1
+    }
+}
+
+abstract class GitMonthlyCommitCountValueSource @Inject constructor(
+    private val execOperations: ExecOperations,
+) : ValueSource<Int, GitRepositoryParameters> {
+    override fun obtain(): Int {
+        val firstDayOfMonth = LocalDate.now(ZoneOffset.UTC)
+            .withDayOfMonth(1)
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-01"))
+
+        val count = runGitCommand(
+            execOperations = execOperations,
+            repositoryRoot = parameters.repositoryRoot.get(),
+            "rev-list",
+            "--count",
+            "--since=$firstDayOfMonth",
+            "HEAD",
+        )
+        return count.toIntOrNull() ?: 0
     }
 }
 


### PR DESCRIPTION
### Why:
- To eliminate the manual overhead of updating `versionCode` and `versionName` for every release.
- To ensure version consistency across development environments by linking build metadata directly to Git history.
- To provide more descriptive versioning (YYYY.MM.Patch) that reflects the development timeline.

### What changed:
- **Implemented `GitCommitCountValueSource`**: A configuration-cache-compatible provider that calculates total commits to drive `versionCode`.
- **Implemented `GitMonthlyCommitCountValueSource`**: A provider that calculates commits within the current calendar month for the `versionName` patch segment.
- **Automated Versioning in Convention Plugin**:
    - Integrated logic into `DuckDetectorAndroidApplicationConventionPlugin`.
    - Set `versionCode` as a base offset (154) plus the total Git commit count.
    - Set `versionName` using the format `${year.month}.${monthly_commits}`.
- **Build Script Cleanup**: Removed hardcoded `versionCode` and `versionName` fields from `app/build.gradle.kts`.
- **Fallback Logic**: Added handling to label the patch version as `unknown` (or fallback to 0) if no commits are detected in the current month.

### Behavioral impact:
- **Development**: No impact on application runtime logic. 
- **Build System**: `versionCode` will now increment automatically with every commit. `versionName` will update automatically at the start of each month and increment with each monthly contribution.
- **Compatibility**: Uses Gradle's `ValueSource` API to remain compatible with the Configuration Cache for faster build startup.

### Files changed:
- `build-logic/src/main/kotlin/com/eltavine/duckdetector/buildlogic/GitMetadataValueSources.kt`
- `build-logic/src/main/kotlin/com/eltavine/duckdetector/buildlogic/DuckDetectorAndroidApplicationConventionPlugin.kt`
- `app/build.gradle.kts`