### PR TITLE
feat(selinux): integrate advanced app_zygote and DirtySepolicy probes

### DIFF
--- a/app/src/main/cpp/selinux/context_validity_native_bridge.cpp
+++ b/app/src/main/cpp/selinux/context_validity_native_bridge.cpp
@@ -61,6 +61,24 @@ namespace {
         }
         output << "CARRIER_MATCHES_EXPECTED=" << (snapshot.carrier_matches_expected ? '1' : '0')
                << '\n';
+        if (snapshot.selinux_enabled.has_value()) {
+            output << "SELINUX_ENABLED=" << (*snapshot.selinux_enabled ? '1' : '0') << '\n';
+        }
+        if (snapshot.selinux_enforced.has_value()) {
+            output << "SELINUX_ENFORCED=" << (*snapshot.selinux_enforced ? '1' : '0') << '\n';
+        }
+        if (snapshot.pid_context_matches_current.has_value()) {
+            output << "PID_CONTEXT_MATCHES_CURRENT="
+                   << (*snapshot.pid_context_matches_current ? '1' : '0') << '\n';
+        }
+        if (snapshot.proc_self_context_matches_current.has_value()) {
+            output << "PROC_SELF_CONTEXT_MATCHES_CURRENT="
+                   << (*snapshot.proc_self_context_matches_current ? '1' : '0') << '\n';
+        }
+        if (snapshot.dyntransition_check_passed.has_value()) {
+            output << "DYNTRANSITION_CHECK_PASSED="
+                   << (*snapshot.dyntransition_check_passed ? '1' : '0') << '\n';
+        }
         if (snapshot.carrier_control_valid.has_value()) {
             output << "CARRIER_CONTROL_VALID=" << (*snapshot.carrier_control_valid ? '1' : '0')
                    << '\n';
@@ -88,9 +106,6 @@ namespace {
         }
         if (snapshot.ksu_file_valid.has_value()) {
             output << "KSU_FILE_VALID=" << (*snapshot.ksu_file_valid ? '1' : '0') << '\n';
-        }
-        if (snapshot.magisk_file_valid.has_value()) {
-            output << "MAGISK_FILE_VALID=" << (*snapshot.magisk_file_valid ? '1' : '0') << '\n';
         }
         output << "DIRTY_POLICY_AVAILABLE=" << (snapshot.dirty_policy.available ? '1' : '0')
                << '\n';
@@ -121,17 +136,37 @@ namespace {
             output << "DIRTY_POLICY_SYSTEM_SERVER_EXECMEM_ALLOWED="
                    << (*snapshot.dirty_policy.system_server_execmem_allowed ? '1' : '0') << '\n';
         }
+        if (snapshot.dirty_policy.fsck_sys_admin_allowed.has_value()) {
+            output << "DIRTY_POLICY_FSCK_SYS_ADMIN_ALLOWED="
+                   << (*snapshot.dirty_policy.fsck_sys_admin_allowed ? '1' : '0') << '\n';
+        }
+        if (snapshot.dirty_policy.shell_su_transition_allowed.has_value()) {
+            output << "DIRTY_POLICY_SHELL_SU_TRANSITION_ALLOWED="
+                   << (*snapshot.dirty_policy.shell_su_transition_allowed ? '1' : '0') << '\n';
+        }
+        if (snapshot.dirty_policy.adbd_adbroot_binder_call_allowed.has_value()) {
+            output << "DIRTY_POLICY_ADBD_ADBROOT_BINDER_CALL_ALLOWED="
+                   << (*snapshot.dirty_policy.adbd_adbroot_binder_call_allowed ? '1' : '0') << '\n';
+        }
         if (snapshot.dirty_policy.magisk_binder_call_allowed.has_value()) {
             output << "DIRTY_POLICY_MAGISK_BINDER_CALL_ALLOWED="
                    << (*snapshot.dirty_policy.magisk_binder_call_allowed ? '1' : '0') << '\n';
         }
-        if (snapshot.dirty_policy.ksu_binder_call_allowed.has_value()) {
-            output << "DIRTY_POLICY_KSU_BINDER_CALL_ALLOWED="
-                   << (*snapshot.dirty_policy.ksu_binder_call_allowed ? '1' : '0') << '\n';
+        if (snapshot.dirty_policy.ksu_file_read_allowed.has_value()) {
+            output << "DIRTY_POLICY_KSU_FILE_READ_ALLOWED="
+                   << (*snapshot.dirty_policy.ksu_file_read_allowed ? '1' : '0') << '\n';
         }
         if (snapshot.dirty_policy.lsposed_file_read_allowed.has_value()) {
             output << "DIRTY_POLICY_LSPOSED_FILE_READ_ALLOWED="
                    << (*snapshot.dirty_policy.lsposed_file_read_allowed ? '1' : '0') << '\n';
+        }
+        if (snapshot.dirty_policy.xposed_data_file_read_allowed.has_value()) {
+            output << "DIRTY_POLICY_XPOSED_DATA_FILE_READ_ALLOWED="
+                   << (*snapshot.dirty_policy.xposed_data_file_read_allowed ? '1' : '0') << '\n';
+        }
+        if (snapshot.dirty_policy.zygote_adb_data_search_allowed.has_value()) {
+            output << "DIRTY_POLICY_ZYGOTE_ADB_DATA_SEARCH_ALLOWED="
+                   << (*snapshot.dirty_policy.zygote_adb_data_search_allowed ? '1' : '0') << '\n';
         }
         if (!snapshot.dirty_policy.failure_reason.empty()) {
             output << "DIRTY_POLICY_FAILURE_REASON="
@@ -193,14 +228,14 @@ namespace {
 }  // namespace
 
 extern "C" JNIEXPORT jstring JNICALL
-Java_com_eltavine_duckdetector_features_selinux_data_native_SelinuxContextValidityBridge_nativeCollectContextValiditySnapshot(
+Java_com_eltavine_duckdetector_features_selinux_data_native_SelinuxContextValidityBridge_nativeCollectContextValiditySnapshotInternal(
         JNIEnv *env,
         jclass clazz) {
     try {
         return to_jstring(
                 env,
                 encode_snapshot(
-                        duckdetector::selinux::collect_context_validity_snapshot(env)
+                        duckdetector::selinux::collect_context_validity_snapshot()
                 )
         );
     } catch (const std::exception &error) {

--- a/app/src/main/cpp/selinux/context_validity_probe.cpp
+++ b/app/src/main/cpp/selinux/context_validity_probe.cpp
@@ -18,11 +18,14 @@
 
 #include <cerrno>
 #include <cstddef>
+#include <cstdlib>
 #include <cstring>
-#include <exception>
+#include <dlfcn.h>
 #include <fcntl.h>
 #include <fstream>
+#include <optional>
 #include <string>
+#include <sys/system_properties.h>
 #include <utility>
 #include <unistd.h>
 
@@ -32,25 +35,68 @@ namespace duckdetector::selinux {
         constexpr const char *kProcAttrCurrentPath = "/proc/self/attr/current";
         constexpr const char *kSelinuxContextPath = "/sys/fs/selinux/context";
         constexpr const char *kExpectedCarrierType = "app_zygote";
+        constexpr const char *kExpectedCarrierPrefix = "u:r:app_zygote:s0";
+        constexpr const char *kIsolatedAppContext = "u:r:isolated_app:s0";
         constexpr const char *kKsuContext = "u:r:ksu:s0";
         constexpr const char *kKsuFileContext = "u:object_r:ksu_file:s0";
-        constexpr const char *magiskFileContext = "u:object_r:magisk_file:s0";
         constexpr const char *kNegativeControlContext = "u:r:duckdetector_context_oracle_sentinel:s0";
         constexpr const char *kStockFileControlContext = "u:object_r:system_data_file:s0";
         constexpr const char *kNegativeFileControlContext =
                 "u:object_r:duckdetector_context_oracle_sentinel_file:s0";
         constexpr const char *kQueryMethod = "raw selinuxfs write";
-        constexpr const char *kDirtyPolicyQueryMethod =
-                "android.os.SELinux.checkSELinuxAccess";
-        constexpr const char *kSelinuxClassName = "android/os/SELinux";
-        constexpr const char *kAppZygoteContext = "u:r:app_zygote:s0";
-        constexpr const char *kIsolatedAppContext = "u:r:isolated_app:s0";
-        constexpr const char *kUntrustedAppContext = "u:r:untrusted_app:s0";
-        constexpr const char *kDirtyPolicySentinelFileContext =
-                "u:object_r:duckdetector_dirty_policy_sentinel:s0";
+        constexpr const char *kDirtyPolicyQueryMethod = "android.os.SELinux.checkSELinuxAccess";
+        constexpr const char *kProcessClass = "process";
+        constexpr const char *kDyntransitionPermission = "dyntransition";
+        constexpr const char *kCapabilityClass = "capability";
+        constexpr const char *kBinderClass = "binder";
+        constexpr const char *kFileClass = "file";
+        constexpr const char *kDirClass = "dir";
+        constexpr const char *kReadPermission = "read";
+        constexpr const char *kCallPermission = "call";
+        constexpr const char *kExecmemPermission = "execmem";
+        constexpr const char *kTransitionPermission = "transition";
+        constexpr const char *kSearchPermission = "search";
+        constexpr const char *kSysAdminPermission = "sys_admin";
         constexpr const char *kSystemServerContext = "u:r:system_server:s0";
+        constexpr const char *kFsckUntrustedContext = "u:r:fsck_untrusted:s0";
+        constexpr const char *kShellContext = "u:r:shell:s0";
+        constexpr const char *kSuContext = "u:r:su:s0";
+        constexpr const char *kAdbdContext = "u:r:adbd:s0";
+        constexpr const char *kAdbrootContext = "u:r:adbroot:s0";
+        constexpr const char *kUntrustedAppContext = "u:r:untrusted_app:s0";
         constexpr const char *kMagiskContext = "u:r:magisk:s0";
         constexpr const char *kLsposedFileContext = "u:object_r:lsposed_file:s0";
+        constexpr const char *kXposedDataContext = "u:object_r:xposed_data:s0";
+        constexpr const char *kZygoteContext = "u:r:zygote:s0";
+        constexpr const char *kAdbDataFileContext = "u:object_r:adb_data_file:s0";
+        constexpr const char *kDirtyPolicyNegativeControlContext =
+                "u:r:duckdetector_dirty_policy_sentinel:s0";
+
+        using IsSelinuxEnabledFn = int (*)();
+        using SecurityGetEnforceFn = int (*)();
+        using GetConFn = int (*)(char **);
+        using GetPidConFn = int (*)(pid_t, char **);
+        using GetFileConFn = int (*)(const char *, char **);
+        using FreeConFn = void (*)(char *);
+        using SelinuxCheckAccessFn = int (*)(
+                const char *scon,
+                const char *tcon,
+                const char *tclass,
+                const char *perm,
+                void *auditdata
+        );
+
+        struct LoadedSelinuxSymbols {
+            void *handle = nullptr;
+            bool owns_handle = false;
+            IsSelinuxEnabledFn is_selinux_enabled = nullptr;
+            SecurityGetEnforceFn security_getenforce = nullptr;
+            GetConFn getcon = nullptr;
+            GetPidConFn getpidcon = nullptr;
+            GetFileConFn getfilecon = nullptr;
+            FreeConFn freecon = nullptr;
+            SelinuxCheckAccessFn check_access = nullptr;
+        };
 
         struct ContextCheckResult {
             std::optional<bool> valid;
@@ -63,16 +109,9 @@ namespace duckdetector::selinux {
             bool stable = false;
         };
 
-        struct DirtyPolicySymbols {
-            jclass selinux_class = nullptr;
-            jmethodID check_access = nullptr;
-            jmethodID is_enabled = nullptr;
-            jmethodID is_enforced = nullptr;
-            std::string failure_reason;
-        };
-
-        struct DirtyPolicyStableAccessCheck {
-            std::optional<bool> value;
+        struct AccessPairResult {
+            std::optional<bool> first;
+            std::optional<bool> second;
             bool stable = false;
         };
 
@@ -86,6 +125,114 @@ namespace duckdetector::selinux {
                    (value.front() == ' ' || value.front() == '\t')) {
                 value.erase(value.begin());
             }
+            return value;
+        }
+
+        template<typename T>
+        T resolve_symbol(
+                void *handle,
+                const char *symbol
+        ) {
+            return reinterpret_cast<T>(dlsym(handle, symbol));
+        }
+
+        LoadedSelinuxSymbols load_selinux_symbols() {
+            LoadedSelinuxSymbols symbols;
+            symbols.is_selinux_enabled = resolve_symbol<IsSelinuxEnabledFn>(RTLD_DEFAULT,
+                                                                            "is_selinux_enabled");
+            symbols.security_getenforce = resolve_symbol<SecurityGetEnforceFn>(RTLD_DEFAULT,
+                                                                               "security_getenforce");
+            symbols.getcon = resolve_symbol<GetConFn>(RTLD_DEFAULT, "getcon");
+            symbols.getpidcon = resolve_symbol<GetPidConFn>(RTLD_DEFAULT, "getpidcon");
+            symbols.getfilecon = resolve_symbol<GetFileConFn>(RTLD_DEFAULT, "getfilecon");
+            symbols.freecon = resolve_symbol<FreeConFn>(RTLD_DEFAULT, "freecon");
+            symbols.check_access = resolve_symbol<SelinuxCheckAccessFn>(RTLD_DEFAULT,
+                                                                        "selinux_check_access");
+            if (symbols.is_selinux_enabled != nullptr &&
+                symbols.security_getenforce != nullptr &&
+                symbols.getcon != nullptr &&
+                symbols.getpidcon != nullptr &&
+                symbols.getfilecon != nullptr &&
+                symbols.freecon != nullptr &&
+                symbols.check_access != nullptr) {
+                return symbols;
+            }
+#ifdef RTLD_NOLOAD
+            symbols.handle = dlopen("libselinux.so", RTLD_NOW | RTLD_NOLOAD);
+#else
+            symbols.handle = nullptr;
+#endif
+            if (symbols.handle == nullptr) {
+                return symbols;
+            }
+            symbols.owns_handle = true;
+            symbols.is_selinux_enabled = resolve_symbol<IsSelinuxEnabledFn>(symbols.handle,
+                                                                            "is_selinux_enabled");
+            symbols.security_getenforce = resolve_symbol<SecurityGetEnforceFn>(symbols.handle,
+                                                                               "security_getenforce");
+            symbols.getcon = resolve_symbol<GetConFn>(symbols.handle, "getcon");
+            symbols.getpidcon = resolve_symbol<GetPidConFn>(symbols.handle, "getpidcon");
+            symbols.getfilecon = resolve_symbol<GetFileConFn>(symbols.handle, "getfilecon");
+            symbols.freecon = resolve_symbol<FreeConFn>(symbols.handle, "freecon");
+            symbols.check_access = resolve_symbol<SelinuxCheckAccessFn>(symbols.handle,
+                                                                        "selinux_check_access");
+            return symbols;
+        }
+
+        std::optional<std::string> call_context_getter(
+                const LoadedSelinuxSymbols &symbols,
+                int (*getter)(char **)
+        ) {
+            if (getter == nullptr || symbols.freecon == nullptr) {
+                return std::nullopt;
+            }
+            char *raw = nullptr;
+            if (getter(&raw) != 0 || raw == nullptr) {
+                if (raw != nullptr) {
+                    symbols.freecon(raw);
+                }
+                return std::nullopt;
+            }
+            std::string value = trim(raw);
+            symbols.freecon(raw);
+            return value;
+        }
+
+        std::optional<std::string> call_pid_context_getter(
+                const LoadedSelinuxSymbols &symbols,
+                pid_t pid
+        ) {
+            if (symbols.getpidcon == nullptr || symbols.freecon == nullptr) {
+                return std::nullopt;
+            }
+            char *raw = nullptr;
+            if (symbols.getpidcon(pid, &raw) != 0 || raw == nullptr) {
+                if (raw != nullptr) {
+                    symbols.freecon(raw);
+                }
+                return std::nullopt;
+            }
+            std::string value = trim(raw);
+            symbols.freecon(raw);
+            return value;
+        }
+
+        std::optional<std::string> call_file_context_getter(
+                const LoadedSelinuxSymbols &symbols,
+                const char *path
+        ) {
+            if (symbols.getfilecon == nullptr || symbols.freecon == nullptr) {
+                return std::nullopt;
+            }
+            char *raw = nullptr;
+            if (symbols.getfilecon(path, &raw) != 0 || raw == nullptr) {
+                if (raw != nullptr) {
+                    symbols.freecon(raw);
+                }
+                return std::nullopt;
+            }
+            std::string value = trim(raw);
+            symbols.freecon(raw);
             return value;
         }
 
@@ -118,30 +265,8 @@ namespace duckdetector::selinux {
 
         void append_note(ContextValidityProbeSnapshot &snapshot, std::string note) {
             if (!note.empty()) {
-                note += '\n';
                 snapshot.notes.push_back(std::move(note));
             }
-        }
-
-        void append_dirty_note(DirtyPolicyProbeSnapshot &snapshot, std::string note) {
-            if (!note.empty()) {
-                snapshot.notes.push_back(std::move(note));
-            }
-        }
-
-        void append_dirty_boolean_note(
-                DirtyPolicyProbeSnapshot &snapshot,
-                const char *label,
-                const std::optional<bool> &value
-        ) {
-            std::string line(label);
-            line += '=';
-            if (value.has_value()) {
-                line += *value ? "true" : "false";
-            } else {
-                line += "unavailable";
-            }
-            append_dirty_note(snapshot, std::move(line));
         }
 
         void append_boolean_note(
@@ -165,396 +290,6 @@ namespace duckdetector::selinux {
         }
 
         ContextCheckResult check_context_validity(const char *context);
-        DirtyPolicyProbeSnapshot collect_dirty_policy_snapshot(
-                JNIEnv *env,
-                const std::string &carrier_context
-        );
-
-        void clear_pending_exception(JNIEnv *env) {
-            if (env != nullptr && env->ExceptionCheck()) {
-                env->ExceptionClear();
-            }
-        }
-
-        DirtyPolicySymbols load_dirty_policy_symbols(JNIEnv *env) {
-            DirtyPolicySymbols symbols;
-            if (env == nullptr) {
-                symbols.failure_reason = "android.os.SELinux.checkSELinuxAccess unavailable.";
-                return symbols;
-            }
-
-            symbols.selinux_class = static_cast<jclass>(env->FindClass(kSelinuxClassName));
-            if (symbols.selinux_class == nullptr || env->ExceptionCheck()) {
-                clear_pending_exception(env);
-                symbols.failure_reason = "android.os.SELinux.checkSELinuxAccess unavailable.";
-                return symbols;
-            }
-
-            symbols.check_access = env->GetStaticMethodID(
-                    symbols.selinux_class,
-                    "checkSELinuxAccess",
-                    "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z"
-            );
-            if (symbols.check_access == nullptr || env->ExceptionCheck()) {
-                clear_pending_exception(env);
-                env->DeleteLocalRef(symbols.selinux_class);
-                symbols.selinux_class = nullptr;
-                symbols.failure_reason = "android.os.SELinux.checkSELinuxAccess unavailable.";
-                return symbols;
-            }
-
-            symbols.is_enabled = env->GetStaticMethodID(
-                    symbols.selinux_class,
-                    "isSELinuxEnabled",
-                    "()Z"
-            );
-            if (symbols.is_enabled == nullptr || env->ExceptionCheck()) {
-                clear_pending_exception(env);
-                symbols.is_enabled = nullptr;
-            }
-
-            symbols.is_enforced = env->GetStaticMethodID(
-                    symbols.selinux_class,
-                    "isSELinuxEnforced",
-                    "()Z"
-            );
-            if (symbols.is_enforced == nullptr || env->ExceptionCheck()) {
-                clear_pending_exception(env);
-                symbols.is_enforced = nullptr;
-            }
-
-            return symbols;
-        }
-
-        DirtyPolicyProbeSnapshot dirty_policy_failure(std::string message) {
-            DirtyPolicyProbeSnapshot snapshot;
-            snapshot.query_method = kDirtyPolicyQueryMethod;
-            snapshot.failure_reason = message;
-            snapshot.notes.push_back(std::move(message));
-            return snapshot;
-        }
-
-        DirtyPolicyProbeSnapshot safe_collect_dirty_policy_snapshot(
-                JNIEnv *env,
-                const std::string &carrier_context
-        ) {
-            try {
-                return collect_dirty_policy_snapshot(env, carrier_context);
-            } catch (const std::exception &error) {
-                return dirty_policy_failure(
-                        std::string("Dirty policy probe failed: ") + error.what()
-                );
-            } catch (...) {
-                return dirty_policy_failure(
-                        "Dirty policy probe failed with an unknown native exception."
-                );
-            }
-        }
-
-        std::optional<bool> dirty_policy_access_allowed(
-                JNIEnv *env,
-                const DirtyPolicySymbols &symbols,
-                const char *source_context,
-                const char *target_context,
-                const char *class_name,
-                const char *permission
-        ) {
-            if (env == nullptr || symbols.selinux_class == nullptr || symbols.check_access == nullptr) {
-                return std::nullopt;
-            }
-
-            jstring source = env->NewStringUTF(source_context);
-            jstring target = env->NewStringUTF(target_context);
-            jstring class_name_value = env->NewStringUTF(class_name);
-            jstring permission_value = env->NewStringUTF(permission);
-            if (source == nullptr || target == nullptr || class_name_value == nullptr || permission_value == nullptr) {
-                if (source != nullptr) {
-                    env->DeleteLocalRef(source);
-                }
-                if (target != nullptr) {
-                    env->DeleteLocalRef(target);
-                }
-                if (class_name_value != nullptr) {
-                    env->DeleteLocalRef(class_name_value);
-                }
-                if (permission_value != nullptr) {
-                    env->DeleteLocalRef(permission_value);
-                }
-                clear_pending_exception(env);
-                return std::nullopt;
-            }
-
-            const jboolean allowed = env->CallStaticBooleanMethod(
-                    symbols.selinux_class,
-                    symbols.check_access,
-                    source,
-                    target,
-                    class_name_value,
-                    permission_value
-            );
-            const bool has_exception = env->ExceptionCheck();
-
-            env->DeleteLocalRef(source);
-            env->DeleteLocalRef(target);
-            env->DeleteLocalRef(class_name_value);
-            env->DeleteLocalRef(permission_value);
-
-            if (has_exception) {
-                clear_pending_exception(env);
-                return std::nullopt;
-            }
-
-            return allowed == JNI_TRUE;
-        }
-
-        DirtyPolicyStableAccessCheck repeat_dirty_policy_access_check(
-                JNIEnv *env,
-                const DirtyPolicySymbols &symbols,
-                const char *source_context,
-                const char *target_context,
-                const char *class_name,
-                const char *permission
-        ) {
-            const std::optional<bool> first = dirty_policy_access_allowed(
-                    env,
-                    symbols,
-                    source_context,
-                    target_context,
-                    class_name,
-                    permission
-            );
-            const std::optional<bool> second = dirty_policy_access_allowed(
-                    env,
-                    symbols,
-                    source_context,
-                    target_context,
-                    class_name,
-                    permission
-            );
-            const bool stable = first.has_value() &&
-                                second.has_value() &&
-                                *first == *second;
-            return {
-                    .value = stable ? first : std::nullopt,
-                    .stable = stable,
-            };
-        }
-
-        std::optional<bool> dirty_policy_static_boolean(
-                JNIEnv *env,
-                const DirtyPolicySymbols &symbols,
-                jmethodID method
-        ) {
-            if (env == nullptr || symbols.selinux_class == nullptr || method == nullptr) {
-                return std::nullopt;
-            }
-
-            const jboolean value = env->CallStaticBooleanMethod(symbols.selinux_class, method);
-            if (env->ExceptionCheck()) {
-                clear_pending_exception(env);
-                return std::nullopt;
-            }
-            return value == JNI_TRUE;
-        }
-
-        void release_dirty_policy_symbols(
-                JNIEnv *env,
-                DirtyPolicySymbols &symbols
-        ) {
-            if (env != nullptr && symbols.selinux_class != nullptr) {
-                env->DeleteLocalRef(symbols.selinux_class);
-                symbols.selinux_class = nullptr;
-            }
-        }
-
-        DirtyPolicyProbeSnapshot collect_dirty_policy_snapshot(
-                JNIEnv *env,
-                const std::string &carrier_context
-        ) {
-            DirtyPolicyProbeSnapshot snapshot;
-            snapshot.query_method = kDirtyPolicyQueryMethod;
-
-            DirtyPolicySymbols symbols = load_dirty_policy_symbols(env);
-            if (symbols.check_access == nullptr) {
-                return dirty_policy_failure(symbols.failure_reason);
-            }
-            snapshot.available = true;
-
-            const std::optional<bool> selinux_enabled =
-                    dirty_policy_static_boolean(env, symbols, symbols.is_enabled);
-            if (selinux_enabled == false) {
-                snapshot.failure_reason = "SELinux is disabled.";
-                append_dirty_note(snapshot, snapshot.failure_reason);
-                release_dirty_policy_symbols(env, symbols);
-                return snapshot;
-            }
-            const std::optional<bool> selinux_enforced =
-                    dirty_policy_static_boolean(env, symbols, symbols.is_enforced);
-            if (selinux_enforced == false) {
-                snapshot.failure_reason = "SELinux is permissive.";
-                append_dirty_note(snapshot, snapshot.failure_reason);
-                release_dirty_policy_symbols(env, symbols);
-                return snapshot;
-            }
-
-            if (carrier_context.empty()) {
-                snapshot.failure_reason = "Current process SELinux context unreadable.";
-                append_dirty_note(snapshot, snapshot.failure_reason);
-                release_dirty_policy_symbols(env, symbols);
-                return snapshot;
-            }
-
-            snapshot.carrier_context = carrier_context;
-            snapshot.carrier_matches_expected = context_type(carrier_context) == kExpectedCarrierType;
-            append_dirty_note(snapshot, std::string("Carrier context: ") + carrier_context);
-            append_dirty_note(snapshot, std::string("Expected carrier type: ") + kExpectedCarrierType);
-            append_dirty_note(snapshot, std::string("Query method: ") + kDirtyPolicyQueryMethod);
-
-            if (!snapshot.carrier_matches_expected) {
-                snapshot.failure_reason = "Carrier context is not app_zygote.";
-                append_dirty_note(snapshot, snapshot.failure_reason);
-                release_dirty_policy_symbols(env, symbols);
-                return snapshot;
-            }
-
-            snapshot.probe_attempted = true;
-
-            const DirtyPolicyStableAccessCheck access_control =
-                    repeat_dirty_policy_access_check(
-                            env,
-                            symbols,
-                            kAppZygoteContext,
-                            kIsolatedAppContext,
-                            "process",
-                            "dyntransition"
-                    );
-            const DirtyPolicyStableAccessCheck negative_control =
-                    repeat_dirty_policy_access_check(
-                            env,
-                            symbols,
-                            kUntrustedAppContext,
-                            kDirtyPolicySentinelFileContext,
-                            "file",
-                            "read"
-                    );
-
-            snapshot.access_control_allowed = access_control.value;
-            snapshot.negative_control_rejected =
-                    negative_control.value.has_value()
-                    ? std::optional<bool>(!*negative_control.value)
-                    : std::nullopt;
-            snapshot.controls_passed =
-                    access_control.stable &&
-                    negative_control.stable &&
-                    access_control.value == true &&
-                    negative_control.value == false;
-
-            if (!access_control.stable || !negative_control.stable) {
-                snapshot.failure_reason = "Dirty policy oracle self-test failed.";
-                append_dirty_note(
-                        snapshot,
-                        std::string("Positive control stable=") +
-                        (access_control.stable ? "true" : "false")
-                );
-                append_dirty_note(
-                        snapshot,
-                        std::string("Negative control stable=") +
-                        (negative_control.stable ? "true" : "false")
-                );
-                append_dirty_note(
-                        snapshot,
-                        "The SELinux access oracle was not trusted because its controls were unstable."
-                );
-            }
-
-            if (!snapshot.controls_passed) {
-                if (snapshot.failure_reason.empty()) {
-                    snapshot.failure_reason = "Dirty policy oracle self-test failed.";
-                }
-                append_dirty_boolean_note(
-                        snapshot,
-                        "Positive control accepted",
-                        access_control.value
-                );
-                append_dirty_boolean_note(
-                        snapshot,
-                        "Negative control rejected",
-                        snapshot.negative_control_rejected
-                );
-                append_dirty_note(snapshot, "The SELinux access oracle did not pass its self-test.");
-            }
-
-            const DirtyPolicyStableAccessCheck system_server_execmem =
-                    repeat_dirty_policy_access_check(
-                            env,
-                            symbols,
-                            kSystemServerContext,
-                            kSystemServerContext,
-                            "process",
-                            "execmem"
-                    );
-            const DirtyPolicyStableAccessCheck magisk_binder_call =
-                    repeat_dirty_policy_access_check(
-                            env,
-                            symbols,
-                            kUntrustedAppContext,
-                            kMagiskContext,
-                            "binder",
-                            "call"
-                    );
-            const DirtyPolicyStableAccessCheck ksu_binder_call =
-                    repeat_dirty_policy_access_check(
-                            env,
-                            symbols,
-                            kUntrustedAppContext,
-                            kKsuContext,
-                            "binder",
-                            "call"
-                    );
-            const DirtyPolicyStableAccessCheck lsposed_file_read =
-                    repeat_dirty_policy_access_check(
-                            env,
-                            symbols,
-                            kUntrustedAppContext,
-                            kLsposedFileContext,
-                            "file",
-                            "read"
-                    );
-
-            snapshot.stable = system_server_execmem.stable &&
-                              magisk_binder_call.stable &&
-                              ksu_binder_call.stable &&
-                              lsposed_file_read.stable;
-
-            append_dirty_boolean_note(snapshot, "Positive control accepted", access_control.value);
-            append_dirty_boolean_note(
-                    snapshot,
-                    "Negative control rejected",
-                    snapshot.negative_control_rejected
-            );
-            append_dirty_boolean_note(snapshot, "system_server execmem", system_server_execmem.value);
-            append_dirty_boolean_note(snapshot, "Magisk binder call", magisk_binder_call.value);
-            append_dirty_boolean_note(snapshot, "KernelSU binder call", ksu_binder_call.value);
-            append_dirty_boolean_note(snapshot, "LSPosed file read", lsposed_file_read.value);
-
-            snapshot.system_server_execmem_allowed = system_server_execmem.value;
-            snapshot.magisk_binder_call_allowed = magisk_binder_call.value;
-            snapshot.ksu_binder_call_allowed = ksu_binder_call.value;
-            snapshot.lsposed_file_read_allowed = lsposed_file_read.value;
-
-            if (!snapshot.stable) {
-                if (snapshot.failure_reason.empty()) {
-                    snapshot.failure_reason = "Dirty policy oracle repeatability failed.";
-                }
-                append_dirty_note(
-                        snapshot,
-                        "One or more dirty policy queries were unstable across repeated checks."
-                );
-            }
-
-            release_dirty_policy_symbols(env, symbols);
-            return snapshot;
-        }
 
         bool pair_matches_expected(
                 const ControlPairResult &pair,
@@ -579,12 +314,194 @@ namespace duckdetector::selinux {
             return !*pair.first.valid;
         }
 
+        std::optional<bool> pair_allowed_value(const AccessPairResult &pair) {
+            if (!pair.stable || !pair.first.has_value()) {
+                return std::nullopt;
+            }
+            return pair.first;
+        }
+
         ControlPairResult check_context_pair_validity(const char *context) {
             ControlPairResult result;
             result.first = check_context_validity(context);
             result.second = check_context_validity(context);
             result.stable = stable_result(result.first, result.second);
             return result;
+        }
+
+        std::optional<bool> check_access_rule(
+                const LoadedSelinuxSymbols &symbols,
+                const char *source,
+                const char *target,
+                const char *target_class,
+                const char *permission
+        ) {
+            if (symbols.check_access == nullptr) {
+                return std::nullopt;
+            }
+            errno = 0;
+            const int result = symbols.check_access(source, target, target_class, permission, nullptr);
+            if (result == 0) {
+                return true;
+            }
+            if (errno == EACCES || errno == EPERM) {
+                return false;
+            }
+            return std::nullopt;
+        }
+
+        AccessPairResult check_access_rule_pair(
+                const LoadedSelinuxSymbols &symbols,
+                const char *source,
+                const char *target,
+                const char *target_class,
+                const char *permission
+        ) {
+            AccessPairResult result;
+            result.first = check_access_rule(symbols, source, target, target_class, permission);
+            result.second = check_access_rule(symbols, source, target, target_class, permission);
+            result.stable = result.first.has_value() == result.second.has_value() &&
+                            (!result.first.has_value() || *result.first == *result.second);
+            return result;
+        }
+
+        void append_access_note(
+                DirtyPolicyProbeSnapshot &snapshot,
+                const char *label,
+                const AccessPairResult &result
+        ) {
+            std::string line(label);
+            line += '=';
+            if (result.first.has_value()) {
+                line += *result.first ? "allowed" : "denied";
+            } else {
+                line += "unavailable";
+            }
+            if (!result.stable) {
+                line += " (unstable)";
+            }
+            snapshot.notes.push_back(std::move(line));
+        }
+
+        bool is_user_build() {
+            char value[PROP_VALUE_MAX] = {};
+            if (__system_property_get("ro.build.type", value) > 0) {
+                return std::strcmp(value, "user") == 0;
+            }
+            return false;
+        }
+
+        DirtyPolicyProbeSnapshot collect_dirty_policy_snapshot(
+                const LoadedSelinuxSymbols &symbols,
+                const std::string &carrier_context,
+                const bool carrier_matches_expected,
+                const std::optional<bool> &dyntransition_check_passed
+        ) {
+            DirtyPolicyProbeSnapshot snapshot;
+            snapshot.query_method = kDirtyPolicyQueryMethod;
+            snapshot.available = symbols.check_access != nullptr;
+            snapshot.carrier_context = carrier_context;
+            snapshot.carrier_matches_expected = carrier_matches_expected;
+            snapshot.notes.push_back(std::string("Carrier context: ") + carrier_context);
+            snapshot.notes.push_back(std::string("Query method: ") + kDirtyPolicyQueryMethod);
+
+            if (!snapshot.available) {
+                snapshot.failure_reason = "selinux_check_access unavailable from the current carrier.";
+                return snapshot;
+            }
+            if (!carrier_matches_expected || carrier_context.rfind(kExpectedCarrierPrefix, 0) != 0) {
+                snapshot.failure_reason = "Carrier context is not app_zygote.";
+                snapshot.notes.push_back("Dirty policy access checks require the dedicated app_zygote carrier.");
+                return snapshot;
+            }
+            if (dyntransition_check_passed.has_value() && !*dyntransition_check_passed) {
+                snapshot.failure_reason = "app_zygote dyntransition self-check failed.";
+                snapshot.notes.push_back("Dirty policy access checks were skipped because the carrier could not confirm app_zygote -> isolated_app dyntransition.");
+                return snapshot;
+            }
+
+            snapshot.probe_attempted = true;
+
+            const AccessPairResult access_control = check_access_rule_pair(
+                    symbols,
+                    kExpectedCarrierPrefix,
+                    kIsolatedAppContext,
+                    kProcessClass,
+                    kDyntransitionPermission
+            );
+            const AccessPairResult negative_control = check_access_rule_pair(
+                    symbols,
+                    kUntrustedAppContext,
+                    kDirtyPolicyNegativeControlContext,
+                    kBinderClass,
+                    kCallPermission
+            );
+
+            snapshot.access_control_allowed = pair_allowed_value(access_control);
+            if (const auto negative_allowed = pair_allowed_value(negative_control); negative_allowed.has_value()) {
+                snapshot.negative_control_rejected = !*negative_allowed;
+            }
+            snapshot.controls_passed = access_control.stable && negative_control.stable &&
+                                       access_control.first == std::optional<bool>(true) &&
+                                       negative_control.first == std::optional<bool>(false);
+            snapshot.stable = access_control.stable && negative_control.stable;
+
+            append_access_note(snapshot, "Access control", access_control);
+            append_access_note(snapshot, "Negative control", negative_control);
+
+            const AccessPairResult system_server_execmem = check_access_rule_pair(symbols, kSystemServerContext, kSystemServerContext, kProcessClass, kExecmemPermission);
+            const AccessPairResult fsck_sys_admin = check_access_rule_pair(symbols, kFsckUntrustedContext, kFsckUntrustedContext, kCapabilityClass, kSysAdminPermission);
+            const AccessPairResult shell_su_transition = check_access_rule_pair(symbols, kShellContext, kSuContext, kProcessClass, kTransitionPermission);
+            const AccessPairResult adbd_adbroot_binder_call = check_access_rule_pair(symbols, kAdbdContext, kAdbrootContext, kBinderClass, kCallPermission);
+            const AccessPairResult magisk_binder_call = check_access_rule_pair(symbols, kUntrustedAppContext, kMagiskContext, kBinderClass, kCallPermission);
+            const AccessPairResult ksu_file_read = check_access_rule_pair(symbols, kUntrustedAppContext, kKsuFileContext, kFileClass, kReadPermission);
+            const AccessPairResult lsposed_file_read = check_access_rule_pair(symbols, kUntrustedAppContext, kLsposedFileContext, kFileClass, kReadPermission);
+            const AccessPairResult xposed_data_file_read = check_access_rule_pair(symbols, kUntrustedAppContext, kXposedDataContext, kFileClass, kReadPermission);
+            const AccessPairResult zygote_adb_data_search = check_access_rule_pair(symbols, kZygoteContext, kAdbDataFileContext, kDirClass, kSearchPermission);
+
+            snapshot.system_server_execmem_allowed = pair_allowed_value(system_server_execmem);
+            snapshot.fsck_sys_admin_allowed = pair_allowed_value(fsck_sys_admin);
+            if (is_user_build()) {
+                snapshot.shell_su_transition_allowed = pair_allowed_value(shell_su_transition);
+            }
+            snapshot.adbd_adbroot_binder_call_allowed = pair_allowed_value(adbd_adbroot_binder_call);
+            snapshot.magisk_binder_call_allowed = pair_allowed_value(magisk_binder_call);
+            snapshot.ksu_file_read_allowed = pair_allowed_value(ksu_file_read);
+            snapshot.lsposed_file_read_allowed = pair_allowed_value(lsposed_file_read);
+            snapshot.xposed_data_file_read_allowed = pair_allowed_value(xposed_data_file_read);
+            snapshot.zygote_adb_data_search_allowed = pair_allowed_value(zygote_adb_data_search);
+
+            snapshot.stable = snapshot.stable &&
+                              system_server_execmem.stable &&
+                              fsck_sys_admin.stable &&
+                              adbd_adbroot_binder_call.stable &&
+                              magisk_binder_call.stable &&
+                              ksu_file_read.stable &&
+                              lsposed_file_read.stable &&
+                              xposed_data_file_read.stable &&
+                              zygote_adb_data_search.stable &&
+                              (!is_user_build() || shell_su_transition.stable);
+
+            append_access_note(snapshot, "system_server execmem", system_server_execmem);
+            append_access_note(snapshot, "fsck_untrusted sys_admin", fsck_sys_admin);
+            if (is_user_build()) {
+                append_access_note(snapshot, "shell -> su transition", shell_su_transition);
+            } else {
+                snapshot.notes.push_back("shell -> su transition skipped because ro.build.type is not user.");
+            }
+            append_access_note(snapshot, "adbd -> adbroot binder", adbd_adbroot_binder_call);
+            append_access_note(snapshot, "untrusted_app -> magisk binder", magisk_binder_call);
+            append_access_note(snapshot, "untrusted_app -> ksu_file read", ksu_file_read);
+            append_access_note(snapshot, "untrusted_app -> lsposed_file read", lsposed_file_read);
+            append_access_note(snapshot, "untrusted_app -> xposed_data read", xposed_data_file_read);
+            append_access_note(snapshot, "zygote -> adb_data_file search", zygote_adb_data_search);
+
+            if (!snapshot.stable) {
+                snapshot.failure_reason = "Dirty policy oracle repeated inconsistently.";
+            } else if (!snapshot.controls_passed) {
+                snapshot.failure_reason = "Dirty policy oracle self-test failed.";
+            }
+            return snapshot;
         }
 
         void append_repeat_note(
@@ -612,8 +529,15 @@ namespace duckdetector::selinux {
 
             int fd = open(kSelinuxContextPath, O_RDWR | O_CLOEXEC);
             if (fd < 0) {
-                result.valid = false;
-                result.note = std::string("Unavailable: ") + context + " errno=" + strerror(errno);
+                const int error = errno;
+                if (error == EINVAL) {
+                    result.valid = false;
+                    result.note = std::string("Invalid context: ") + context +
+                                  " errno=" + std::to_string(error);
+                } else {
+                    result.note = std::string("Unavailable: ") + context +
+                                  " errno=" + std::to_string(error);
+                }
                 return result;
             }
 
@@ -626,21 +550,39 @@ namespace duckdetector::selinux {
                 return result;
             }
 
-            result.valid = false;
-            result.note = std::string("Unavailable: ") + context + " errno=" + strerror(error);
+            if (error == EINVAL) {
+                result.valid = false;
+                result.note = std::string("Invalid context: ") + context +
+                              " errno=" + std::to_string(error);
+            } else {
+                result.note = std::string("Unavailable: ") + context +
+                              " errno=" + std::to_string(error);
+            }
             return result;
         }
 
     }  // namespace
 
-    ContextValidityProbeSnapshot collect_context_validity_snapshot(JNIEnv *env) {
+    ContextValidityProbeSnapshot collect_context_validity_snapshot() {
         ContextValidityProbeSnapshot snapshot;
         snapshot.query_method = kQueryMethod;
+        const LoadedSelinuxSymbols symbols = load_selinux_symbols();
+        if (symbols.is_selinux_enabled != nullptr) {
+            snapshot.selinux_enabled = symbols.is_selinux_enabled() == 1;
+        }
+        if (symbols.security_getenforce != nullptr) {
+            const int enforce = symbols.security_getenforce();
+            if (enforce == 0 || enforce == 1) {
+                snapshot.selinux_enforced = enforce == 1;
+            }
+        }
 
         const std::string carrier_context = read_process_context();
-        snapshot.dirty_policy = safe_collect_dirty_policy_snapshot(env, carrier_context);
         if (carrier_context.empty()) {
             snapshot.failure_reason = "Current process SELinux context unreadable.";
+            if (symbols.owns_handle && symbols.handle != nullptr) {
+                dlclose(symbols.handle);
+            }
             return snapshot;
         }
 
@@ -650,9 +592,87 @@ namespace duckdetector::selinux {
         append_note(snapshot, std::string("Carrier context: ") + carrier_context);
         append_note(snapshot, std::string("Expected carrier type: ") + kExpectedCarrierType);
 
-        if (!snapshot.carrier_matches_expected) {
+        if (const auto current_context = call_context_getter(symbols, symbols.getcon);
+            current_context.has_value()) {
+            snapshot.pid_context_matches_current = (*current_context == carrier_context);
+        }
+        if (const auto pid_context = call_pid_context_getter(symbols, getpid());
+            pid_context.has_value()) {
+            snapshot.pid_context_matches_current = (*pid_context == carrier_context);
+        }
+        if (const auto proc_self_context = call_file_context_getter(symbols, "/proc/self");
+            proc_self_context.has_value()) {
+            snapshot.proc_self_context_matches_current = (*proc_self_context == carrier_context);
+        }
+        if (symbols.check_access != nullptr) {
+            const int check = symbols.check_access(
+                    kExpectedCarrierPrefix,
+                    kIsolatedAppContext,
+                    kProcessClass,
+                    kDyntransitionPermission,
+                    nullptr
+            );
+            snapshot.dyntransition_check_passed = check == 0;
+        }
+        snapshot.dirty_policy = collect_dirty_policy_snapshot(
+                symbols,
+                carrier_context,
+                snapshot.carrier_matches_expected,
+                snapshot.dyntransition_check_passed
+        );
+
+        if (!snapshot.carrier_matches_expected ||
+            carrier_context.rfind(kExpectedCarrierPrefix, 0) != 0) {
             snapshot.failure_reason = "Carrier context is not app_zygote.";
             append_note(snapshot, "The oracle is only meaningful from an app_zygote carrier.");
+            if (symbols.owns_handle && symbols.handle != nullptr) {
+                dlclose(symbols.handle);
+            }
+            return snapshot;
+        }
+        if (snapshot.selinux_enabled.has_value() && !*snapshot.selinux_enabled) {
+            snapshot.failure_reason = "SELinux is disabled.";
+            append_note(snapshot, "The carrier reported SELinux disabled.");
+            if (symbols.owns_handle && symbols.handle != nullptr) {
+                dlclose(symbols.handle);
+            }
+            return snapshot;
+        }
+        if (snapshot.selinux_enforced.has_value() && !*snapshot.selinux_enforced) {
+            snapshot.failure_reason = "SELinux is permissive.";
+            append_note(snapshot, "The carrier reported permissive SELinux.");
+            if (symbols.owns_handle && symbols.handle != nullptr) {
+                dlclose(symbols.handle);
+            }
+            return snapshot;
+        }
+        if (snapshot.pid_context_matches_current.has_value() &&
+            !*snapshot.pid_context_matches_current) {
+            snapshot.failure_reason = "PID context mismatch.";
+            append_note(snapshot, "The carrier pid context did not match /proc/self/attr/current.");
+            if (symbols.owns_handle && symbols.handle != nullptr) {
+                dlclose(symbols.handle);
+            }
+            return snapshot;
+        }
+        if (snapshot.proc_self_context_matches_current.has_value() &&
+            !*snapshot.proc_self_context_matches_current) {
+            snapshot.failure_reason = "/proc/self context mismatch.";
+            append_note(snapshot,
+                        "The carrier /proc/self file context did not match /proc/self/attr/current.");
+            if (symbols.owns_handle && symbols.handle != nullptr) {
+                dlclose(symbols.handle);
+            }
+            return snapshot;
+        }
+        if (snapshot.dyntransition_check_passed.has_value() &&
+            !*snapshot.dyntransition_check_passed) {
+            snapshot.failure_reason = "app_zygote dyntransition self-check failed.";
+            append_note(snapshot,
+                        "The carrier could not confirm app_zygote -> isolated_app dyntransition.");
+            if (symbols.owns_handle && symbols.handle != nullptr) {
+                dlclose(symbols.handle);
+            }
             return snapshot;
         }
 
@@ -707,6 +727,9 @@ namespace duckdetector::selinux {
             snapshot.failure_reason = "Context validity oracle self-test failed.";
             append_note(snapshot,
                         "KSU-specific context queries were skipped to avoid interpreting an untrusted oracle.");
+            if (symbols.owns_handle && symbols.handle != nullptr) {
+                dlclose(symbols.handle);
+            }
             return snapshot;
         }
 
@@ -714,56 +737,59 @@ namespace duckdetector::selinux {
         const ContextCheckResult domain_second = check_context_validity(kKsuContext);
         const ContextCheckResult file_first = check_context_validity(kKsuFileContext);
         const ContextCheckResult file_second = check_context_validity(kKsuFileContext);
-        const ContextCheckResult magisk_file_first = check_context_validity(magiskFileContext);
-        const ContextCheckResult magisk_file_second = check_context_validity(magiskFileContext);
 
         const bool domain_stable = stable_result(domain_first, domain_second);
         const bool file_stable = stable_result(file_first, file_second);
-        const bool magisk_file_stable = stable_result(magisk_file_first, magisk_file_second);
-        snapshot.ksu_results_stable = domain_stable && file_stable && magisk_file_stable;
+        snapshot.ksu_results_stable = domain_stable && file_stable;
 
-        append_repeat_note(snapshot, "u:r:ksu:s0 test repeat 1", domain_first);
-        append_repeat_note(snapshot, "u:r:ksu:s0 test repeat 2", domain_second);
-        append_repeat_note(snapshot, "u:object_r:ksu_file:s0 test repeat 1", file_first);
-        append_repeat_note(snapshot, "u:object_r:ksu_file:s0 repeat 2", file_second);
-        append_repeat_note(snapshot, "u:object_r:magisk_file:s0 repeat 1", magisk_file_first);
-        append_repeat_note(snapshot, "u:object_r:magisk_file:s0 repeat 2", magisk_file_second);
+        append_repeat_note(snapshot, "Domain repeat 1", domain_first);
+        append_repeat_note(snapshot, "Domain repeat 2", domain_second);
+        append_repeat_note(snapshot, "File repeat 1", file_first);
+        append_repeat_note(snapshot, "File repeat 2", file_second);
 
         if (!snapshot.ksu_results_stable) {
             snapshot.failure_reason = "Context validity oracle repeatability failed.";
             append_note(snapshot,
-                        "The root-specific context verdict changed across repeated writes, so it was not trusted.");
+                        "The KSU-specific context verdict changed across repeated writes, so it was not trusted.");
+            if (symbols.owns_handle && symbols.handle != nullptr) {
+                dlclose(symbols.handle);
+            }
             return snapshot;
         }
 
-        const ContextCheckResult& ksu_domain_result = domain_first;
-        const ContextCheckResult& ksu_file_result = file_first;
-        const ContextCheckResult& magisk_file_result = magisk_file_first;
+        const ContextCheckResult domain_result = domain_first;
+        const ContextCheckResult file_result = file_first;
 
-        snapshot.ksu_domain_valid = ksu_domain_result.valid;
-        snapshot.ksu_file_valid = ksu_file_result.valid;
-        snapshot.magisk_file_valid = magisk_file_result.valid;
-        append_note(snapshot, ksu_domain_result.note);
-        append_note(snapshot, ksu_file_result.note);
-        append_note(snapshot, magisk_file_result.note);
+        snapshot.ksu_domain_valid = domain_result.valid;
+        snapshot.ksu_file_valid = file_result.valid;
+        append_note(snapshot, domain_result.note);
+        append_note(snapshot, file_result.note);
 
-        if (ksu_domain_result.valid.has_value() || ksu_file_result.valid.has_value() || magisk_file_result.valid.has_value()) {
-
-            if (ksu_domain_result.valid.value()) {
-                append_note(snapshot, "u:r:ksu:s0 was found by live policy.");
+        if (domain_result.valid.has_value() && file_result.valid.has_value()) {
+            snapshot.bit_pair.push_back(*domain_result.valid ? '1' : '0');
+            snapshot.bit_pair.push_back(*file_result.valid ? '1' : '0');
+            if (*domain_result.valid && *file_result.valid) {
+                append_note(snapshot, "Both KSU-specific contexts were accepted by live policy.");
+            } else if (!*domain_result.valid && !*file_result.valid) {
+                append_note(snapshot, "Neither KSU-specific context was accepted by live policy.");
+            } else {
+                append_note(snapshot,
+                            "Split verdict: one KSU-specific context was accepted while the other was not.");
             }
-
-            if (ksu_file_result.valid.value()) {
-                append_note(snapshot, "u:object_r:ksu_file:s0 was found by live policy.");
-            }
-
-            if (magisk_file_result.valid.value()) {
-                append_note(snapshot, "u:object_r:magisk_file:s0 was found by live policy.");
+            if (symbols.owns_handle && symbols.handle != nullptr) {
+                dlclose(symbols.handle);
             }
             return snapshot;
         }
 
         snapshot.failure_reason = "Context validity probe could not complete both checks.";
+        if (!domain_result.valid.has_value() || !file_result.valid.has_value()) {
+            append_note(snapshot,
+                        "At least one KSU context write was unavailable from the current carrier.");
+        }
+        if (symbols.owns_handle && symbols.handle != nullptr) {
+            dlclose(symbols.handle);
+        }
         return snapshot;
     }
 

--- a/app/src/main/cpp/selinux/context_validity_probe.h
+++ b/app/src/main/cpp/selinux/context_validity_probe.h
@@ -32,9 +32,14 @@ namespace duckdetector::selinux {
         std::optional<bool> access_control_allowed;
         std::optional<bool> negative_control_rejected;
         std::optional<bool> system_server_execmem_allowed;
+        std::optional<bool> fsck_sys_admin_allowed;
+        std::optional<bool> shell_su_transition_allowed;
+        std::optional<bool> adbd_adbroot_binder_call_allowed;
         std::optional<bool> magisk_binder_call_allowed;
-        std::optional<bool> ksu_binder_call_allowed;
+        std::optional<bool> ksu_file_read_allowed;
         std::optional<bool> lsposed_file_read_allowed;
+        std::optional<bool> xposed_data_file_read_allowed;
+        std::optional<bool> zygote_adb_data_search_allowed;
         bool controls_passed = false;
         bool stable = false;
         std::string query_method;
@@ -47,6 +52,11 @@ namespace duckdetector::selinux {
         bool probe_attempted = false;
         std::string carrier_context;
         bool carrier_matches_expected = false;
+        std::optional<bool> selinux_enabled;
+        std::optional<bool> selinux_enforced;
+        std::optional<bool> pid_context_matches_current;
+        std::optional<bool> proc_self_context_matches_current;
+        std::optional<bool> dyntransition_check_passed;
         std::optional<bool> carrier_control_valid;
         std::optional<bool> negative_control_rejected;
         std::optional<bool> file_control_valid;
@@ -56,13 +66,13 @@ namespace duckdetector::selinux {
         std::string query_method;
         std::optional<bool> ksu_domain_valid;
         std::optional<bool> ksu_file_valid;
-        std::optional<bool> magisk_file_valid;
+        std::string bit_pair;
         DirtyPolicyProbeSnapshot dirty_policy;
         std::string failure_reason;
         std::vector<std::string> notes;
     };
 
-    ContextValidityProbeSnapshot collect_context_validity_snapshot(JNIEnv *env);
+    ContextValidityProbeSnapshot collect_context_validity_snapshot();
 
 }  // namespace duckdetector::selinux
 

--- a/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/probes/LSPosedDirtyPolicyProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/probes/LSPosedDirtyPolicyProbe.kt
@@ -34,7 +34,7 @@ data class LSPosedDirtyPolicyProbeResult(
     val negativeControlRejected: Boolean?,
     val systemServerExecmemAllowed: Boolean?,
     val magiskBinderCallAllowed: Boolean?,
-    val ksuBinderCallAllowed: Boolean?,
+    val ksuFileReadAllowed: Boolean?,
     val lsposedFileReadAllowed: Boolean?,
     val failureReason: String?,
     val notes: List<String>,
@@ -75,7 +75,7 @@ data class LSPosedDirtyPolicyProbeResult(
             append(" | negative control rejected=").append(yesNoLabel(negativeControlRejected))
             append(" | system_server execmem=").append(ruleLabel(systemServerExecmemAllowed))
             append(" | Magisk binder=").append(ruleLabel(magiskBinderCallAllowed))
-            append(" | KernelSU binder=").append(ruleLabel(ksuBinderCallAllowed))
+            append(" | KernelSU file read=").append(ruleLabel(ksuFileReadAllowed))
             append(" | LSPosed file read=").append(ruleLabel(lsposedFileReadAllowed))
             failureReason?.takeIf { it.isNotBlank() }?.let {
                 appendLine()
@@ -108,7 +108,11 @@ class LSPosedDirtyPolicyProbe {
     fun run(snapshot: SelinuxContextValiditySnapshot): LSPosedDirtyPolicyProbeResult {
         val available = snapshot.dirtyPolicyAvailable &&
             snapshot.dirtyPolicyProbeAttempted &&
-            snapshot.dirtyPolicyCarrierMatchesExpected
+            snapshot.dirtyPolicyCarrierMatchesExpected &&
+            snapshot.dirtyPolicyControlsPassed &&
+            snapshot.dirtyPolicyStable &&
+            snapshot.dirtyPolicyAccessControlAllowed == true &&
+            snapshot.dirtyPolicyNegativeControlRejected == true
 
         return LSPosedDirtyPolicyProbeResult(
             available = available,
@@ -124,7 +128,7 @@ class LSPosedDirtyPolicyProbe {
             negativeControlRejected = snapshot.dirtyPolicyNegativeControlRejected,
             systemServerExecmemAllowed = snapshot.dirtyPolicySystemServerExecmemAllowed,
             magiskBinderCallAllowed = snapshot.dirtyPolicyMagiskBinderCallAllowed,
-            ksuBinderCallAllowed = snapshot.dirtyPolicyKsuBinderCallAllowed,
+            ksuFileReadAllowed = snapshot.dirtyPolicyKsuFileReadAllowed,
             lsposedFileReadAllowed = snapshot.dirtyPolicyLsposedFileReadAllowed,
             failureReason = snapshot.dirtyPolicyFailureReason,
             notes = snapshot.dirtyPolicyNotes,
@@ -158,14 +162,14 @@ class LSPosedDirtyPolicyProbe {
                     ),
                 )
             }
-            if (snapshot.dirtyPolicyKsuBinderCallAllowed == true) {
+            if (snapshot.dirtyPolicyKsuFileReadAllowed == true) {
                 add(
                     policySignal(
-                        id = "policy_ksu_binder_call",
-                        label = "KernelSU binder",
+                        id = "policy_ksu_file_read",
+                        label = "KernelSU file read",
                         value = "Allowed",
                         severity = LSPosedSignalSeverity.WARNING,
-                        detail = "The app_zygote SELinux access oracle reported untrusted_app -> ksu:binder call as allowed. This is supporting dirty-policy evidence, not an LSPosed-specific rule.",
+                        detail = "The app_zygote SELinux access oracle reported untrusted_app -> ksu_file:file read as allowed. This is supporting dirty-policy evidence, not an LSPosed-specific rule.",
                     ),
                 )
             }

--- a/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/native/SelinuxContextValidityBridge.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/native/SelinuxContextValidityBridge.kt
@@ -13,147 +13,128 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.eltavine.duckdetector.features.selinux.data.native
+
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxProcAttrCurrentPayloadCodec
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxProcAttrCurrentResult
 
 open class SelinuxContextValidityBridge {
 
     open fun collectSnapshot(): SelinuxContextValiditySnapshot {
-        val rawData = preloadedRawData
-            ?: return parseFailureSnapshot("No preloaded data available. Check AppZygotePreload status.")
-
-        return runCatching {
-            parse(rawData)
-        }.getOrElse {
-            parseFailureSnapshot("Parse error: ${it.message}")
+        val preloaded = consumePreloadedRawData()
+        if (preloaded != null) {
+            return parse(preloaded)
         }
+        if (!nativeLoaded) {
+            return SelinuxContextValiditySnapshot(
+                failureReason = "duckdetector native library unavailable.",
+            )
+        }
+        return runCatching {
+            parse(nativeCollectContextValiditySnapshotInternal())
+        }.getOrDefault(SelinuxContextValiditySnapshot())
     }
 
     internal fun parse(raw: String): SelinuxContextValiditySnapshot {
         if (raw.isBlank()) {
-            return parseFailureSnapshot("SELinux context validity payload was empty.")
+            return SelinuxContextValiditySnapshot()
         }
 
         var snapshot = SelinuxContextValiditySnapshot()
         val notes = mutableListOf<String>()
         val dirtyPolicyNotes = mutableListOf<String>()
-        var recognizedEntryCount = 0
+        val procAttrCurrentResults = mutableListOf<SelinuxProcAttrCurrentResult>()
 
         raw.lineSequence()
             .map { it.trim() }
             .filter { it.isNotEmpty() }
             .forEach { line ->
                 when {
+                    line.startsWith("DIRTY_POLICY_NOTE=") -> dirtyPolicyNotes += line.removePrefix("DIRTY_POLICY_NOTE=")
+                        .decodeValue()
+
                     line.startsWith("NOTE=") -> notes += line.removePrefix("NOTE=")
                         .decodeValue()
 
-                    line.startsWith("DIRTY_POLICY_NOTE=") -> dirtyPolicyNotes += line.removePrefix(
-                        "DIRTY_POLICY_NOTE="
-                    ).decodeValue()
+                    line.startsWith("PROC_ATTR_CURRENT_RESULT=") ->
+                        SelinuxProcAttrCurrentPayloadCodec.decode(
+                            line.removePrefix("PROC_ATTR_CURRENT_RESULT=").decodeValue(),
+                        )?.let(procAttrCurrentResults::add)
 
                     line.contains('=') -> {
                         val key = line.substringBefore('=')
                         val value = line.substringAfter('=')
-                        val (updatedSnapshot, recognized) = snapshot.applyEntry(key, value)
-                        if (recognized) {
-                            recognizedEntryCount += 1
-                            snapshot = updatedSnapshot
-                        }
+                        snapshot = snapshot.applyEntry(key, value)
                     }
                 }
             }
 
-        if (recognizedEntryCount == 0) {
-            return parseFailureSnapshot("SELinux context validity payload was unrecognized.")
-        }
-
-        if (
-            snapshot.available &&
-            (snapshot.carrierContext.isNullOrBlank() || snapshot.queryMethod.isBlank() ||
-                (snapshot.carrierMatchesExpected && !snapshot.probeAttempted))
-        ) {
-            return parseFailureSnapshot("SELinux context validity payload was incomplete.")
-        }
-
-        if (
-            snapshot.dirtyPolicyAvailable &&
-            (snapshot.dirtyPolicyQueryMethod.isBlank() ||
-                (snapshot.dirtyPolicyCarrierMatchesExpected && !snapshot.dirtyPolicyProbeAttempted))
-        ) {
-            return parseFailureSnapshot("SELinux context validity payload was incomplete.")
-        }
-
         return snapshot.copy(
-            notes = notes,
             dirtyPolicyNotes = dirtyPolicyNotes,
-        )
-    }
-
-    private fun parseFailureSnapshot(reason: String): SelinuxContextValiditySnapshot {
-        return SelinuxContextValiditySnapshot(
-            failureReason = reason,
-            dirtyPolicyFailureReason = reason,
-            dirtyPolicyQueryMethod = "android.os.SELinux.checkSELinuxAccess",
-            notes = listOf("SELinux context validity parser rejected the preloaded payload."),
-            dirtyPolicyNotes = listOf("SELinux context validity parser rejected the preloaded payload."),
+            procAttrCurrentResults = procAttrCurrentResults,
+            notes = notes,
         )
     }
 
     private fun SelinuxContextValiditySnapshot.applyEntry(
         key: String,
         value: String,
-    ): Pair<SelinuxContextValiditySnapshot, Boolean> {
+    ): SelinuxContextValiditySnapshot {
         return when (key) {
-            "AVAILABLE" -> copy(available = value.asBool()) to true
-            "PROBE_ATTEMPTED" -> copy(probeAttempted = value.asBool()) to true
-            "CARRIER_CONTEXT" -> copy(carrierContext = value.decodeValue()) to true
-            "CARRIER_MATCHES_EXPECTED" -> copy(carrierMatchesExpected = value.asBool()) to true
-            "CARRIER_CONTROL_VALID" -> copy(carrierControlValid = value.asNullableBool()) to true
-            "NEGATIVE_CONTROL_REJECTED" -> copy(negativeControlRejected = value.asNullableBool()) to true
-            "FILE_CONTROL_VALID" -> copy(fileControlValid = value.asNullableBool()) to true
-            "FILE_NEGATIVE_CONTROL_REJECTED" -> copy(fileNegativeControlRejected = value.asNullableBool()) to true
-            "ORACLE_CONTROLS_PASSED" -> copy(oracleControlsPassed = value.asBool()) to true
-            "KSU_RESULTS_STABLE" -> copy(ksuResultsStable = value.asBool()) to true
-            "QUERY_METHOD" -> copy(queryMethod = value.decodeValue()) to true
-            "KSU_DOMAIN_VALID" -> copy(ksuDomainValid = value.asNullableBool()) to true
-            "KSU_FILE_VALID" -> copy(ksuFileValid = value.asNullableBool()) to true
-            "MAGISK_FILE_VALID" -> copy(magiskFileValid = value.asNullableBool()) to true
-            "DIRTY_POLICY_AVAILABLE" -> copy(dirtyPolicyAvailable = value.asBool()) to true
-            "DIRTY_POLICY_PROBE_ATTEMPTED" -> copy(dirtyPolicyProbeAttempted = value.asBool()) to true
-            "DIRTY_POLICY_CARRIER_CONTEXT" -> copy(dirtyPolicyCarrierContext = value.decodeValue()) to true
-            "DIRTY_POLICY_CARRIER_MATCHES_EXPECTED" ->
-                copy(dirtyPolicyCarrierMatchesExpected = value.asBool()) to true
-
-            "DIRTY_POLICY_CONTROLS_PASSED" -> copy(dirtyPolicyControlsPassed = value.asBool()) to true
-            "DIRTY_POLICY_STABLE" -> copy(dirtyPolicyStable = value.asBool()) to true
-            "DIRTY_POLICY_QUERY_METHOD" -> copy(dirtyPolicyQueryMethod = value.decodeValue()) to true
-            "DIRTY_POLICY_ACCESS_CONTROL_ALLOWED" ->
-                copy(dirtyPolicyAccessControlAllowed = value.asNullableBool()) to true
-
-            "DIRTY_POLICY_NEGATIVE_CONTROL_REJECTED" ->
-                copy(dirtyPolicyNegativeControlRejected = value.asNullableBool()) to true
-
-            "DIRTY_POLICY_SYSTEM_SERVER_EXECMEM_ALLOWED" ->
-                copy(dirtyPolicySystemServerExecmemAllowed = value.asNullableBool()) to true
-
-            "DIRTY_POLICY_MAGISK_BINDER_CALL_ALLOWED" ->
-                copy(dirtyPolicyMagiskBinderCallAllowed = value.asNullableBool()) to true
-
-            "DIRTY_POLICY_KSU_BINDER_CALL_ALLOWED" ->
-                copy(dirtyPolicyKsuBinderCallAllowed = value.asNullableBool()) to true
-
-            "DIRTY_POLICY_LSPOSED_FILE_READ_ALLOWED" ->
-                copy(dirtyPolicyLsposedFileReadAllowed = value.asNullableBool()) to true
-
-            "DIRTY_POLICY_FAILURE_REASON" -> copy(dirtyPolicyFailureReason = value.decodeValue()) to true
-            "FAILURE_REASON" -> copy(failureReason = value.decodeValue()) to true
-            else -> this to false
+            "AVAILABLE" -> copy(available = value.asBool())
+            "PROBE_ATTEMPTED" -> copy(probeAttempted = value.asBool())
+            "CARRIER_CONTEXT" -> copy(carrierContext = value.decodeValue())
+            "CARRIER_MATCHES_EXPECTED" -> copy(carrierMatchesExpected = value.asBool())
+            "SELINUX_ENABLED" -> copy(selinuxEnabled = value.asNullableBool())
+            "SELINUX_ENFORCED" -> copy(selinuxEnforced = value.asNullableBool())
+            "PID_CONTEXT_MATCHES_CURRENT" -> copy(pidContextMatchesCurrent = value.asNullableBool())
+            "PROC_SELF_CONTEXT_MATCHES_CURRENT" -> copy(procSelfContextMatchesCurrent = value.asNullableBool())
+            "DYNTRANSITION_CHECK_PASSED" -> copy(dyntransitionCheckPassed = value.asNullableBool())
+            "CARRIER_CONTROL_VALID" -> copy(carrierControlValid = value.asNullableBool())
+            "NEGATIVE_CONTROL_REJECTED" -> copy(negativeControlRejected = value.asNullableBool())
+            "FILE_CONTROL_VALID" -> copy(fileControlValid = value.asNullableBool())
+            "FILE_NEGATIVE_CONTROL_REJECTED" -> copy(fileNegativeControlRejected = value.asNullableBool())
+            "ORACLE_CONTROLS_PASSED" -> copy(oracleControlsPassed = value.asBool())
+            "KSU_RESULTS_STABLE" -> copy(ksuResultsStable = value.asBool())
+            "QUERY_METHOD" -> copy(queryMethod = value.decodeValue())
+            "KSU_DOMAIN_VALID" -> copy(ksuDomainValid = value.asNullableBool())
+            "KSU_FILE_VALID" -> copy(ksuFileValid = value.asNullableBool())
+            "BIT_PAIR" -> copy(bitPair = value.decodeValue())
+            "DIRTY_POLICY_AVAILABLE" -> copy(dirtyPolicyAvailable = value.asBool())
+            "DIRTY_POLICY_PROBE_ATTEMPTED" -> copy(dirtyPolicyProbeAttempted = value.asBool())
+            "DIRTY_POLICY_CARRIER_CONTEXT" -> copy(dirtyPolicyCarrierContext = value.decodeValue())
+            "DIRTY_POLICY_CARRIER_MATCHES_EXPECTED" -> copy(dirtyPolicyCarrierMatchesExpected = value.asBool())
+            "DIRTY_POLICY_CONTROLS_PASSED" -> copy(dirtyPolicyControlsPassed = value.asBool())
+            "DIRTY_POLICY_STABLE" -> copy(dirtyPolicyStable = value.asBool())
+            "DIRTY_POLICY_QUERY_METHOD" -> copy(dirtyPolicyQueryMethod = value.decodeValue())
+            "DIRTY_POLICY_ACCESS_CONTROL_ALLOWED" -> copy(dirtyPolicyAccessControlAllowed = value.asNullableBool())
+            "DIRTY_POLICY_NEGATIVE_CONTROL_REJECTED" -> copy(dirtyPolicyNegativeControlRejected = value.asNullableBool())
+            "DIRTY_POLICY_SYSTEM_SERVER_EXECMEM_ALLOWED" -> copy(dirtyPolicySystemServerExecmemAllowed = value.asNullableBool())
+            "DIRTY_POLICY_FSCK_SYS_ADMIN_ALLOWED" -> copy(dirtyPolicyFsckSysAdminAllowed = value.asNullableBool())
+            "DIRTY_POLICY_SHELL_SU_TRANSITION_ALLOWED" -> copy(dirtyPolicyShellSuTransitionAllowed = value.asNullableBool())
+            "DIRTY_POLICY_ADBD_ADBROOT_BINDER_CALL_ALLOWED" -> copy(dirtyPolicyAdbdAdbrootBinderCallAllowed = value.asNullableBool())
+            "DIRTY_POLICY_MAGISK_BINDER_CALL_ALLOWED" -> copy(dirtyPolicyMagiskBinderCallAllowed = value.asNullableBool())
+            "DIRTY_POLICY_KSU_FILE_READ_ALLOWED" -> copy(dirtyPolicyKsuFileReadAllowed = value.asNullableBool())
+            "DIRTY_POLICY_LSPOSED_FILE_READ_ALLOWED" -> copy(dirtyPolicyLsposedFileReadAllowed = value.asNullableBool())
+            "DIRTY_POLICY_XPOSED_DATA_FILE_READ_ALLOWED" -> copy(dirtyPolicyXposedDataFileReadAllowed = value.asNullableBool())
+            "DIRTY_POLICY_ZYGOTE_ADB_DATA_SEARCH_ALLOWED" -> copy(dirtyPolicyZygoteAdbDataSearchAllowed = value.asNullableBool())
+            "DIRTY_POLICY_FAILURE_REASON" -> copy(dirtyPolicyFailureReason = value.decodeValue())
+            "PROC_ATTR_CURRENT_PROBE_ATTEMPTED" -> copy(procAttrCurrentProbeAttempted = value.asBool())
+            "PROC_ATTR_CURRENT_FAILURE_REASON" -> copy(procAttrCurrentFailureReason = value.decodeValue())
+            "FAILURE_REASON" -> copy(failureReason = value.decodeValue())
+            else -> this
         }
     }
 
-    private fun String.asBool(): Boolean = this == "1" || equals("true", ignoreCase = true)
+    private fun String.asBool(): Boolean {
+        return this == "1" || equals("true", ignoreCase = true)
+    }
 
     private fun String.asNullableBool(): Boolean? {
-        if (isBlank() || equals("unknown", ignoreCase = true)) return null
+        if (isBlank() || equals("unknown", ignoreCase = true)) {
+            return null
+        }
         return asBool()
     }
 
@@ -164,10 +145,29 @@ open class SelinuxContextValidityBridge {
                 val current = this@decodeValue[index]
                 if (current == '\\' && index + 1 < this@decodeValue.length) {
                     when (this@decodeValue[index + 1]) {
-                        'n' -> { append('\n'); index += 2; continue }
-                        'r' -> { append('\r'); index += 2; continue }
-                        't' -> { append('\t'); index += 2; continue }
-                        '\\' -> { append('\\'); index += 2; continue }
+                        'n' -> {
+                            append('\n')
+                            index += 2
+                            continue
+                        }
+
+                        'r' -> {
+                            append('\r')
+                            index += 2
+                            continue
+                        }
+
+                        't' -> {
+                            append('\t')
+                            index += 2
+                            continue
+                        }
+
+                        '\\' -> {
+                            append('\\')
+                            index += 2
+                            continue
+                        }
                     }
                 }
                 append(current)
@@ -176,20 +176,32 @@ open class SelinuxContextValidityBridge {
         }
     }
 
+    private external fun nativeCollectContextValiditySnapshotInternal(): String
+
     companion object {
         @Volatile
         private var preloadedRawData: String? = null
 
-        @JvmStatic
-        fun setPreloadedRawData(data: String) {
-            preloadedRawData = data
-        }
-
-        val isNativeLibraryLoaded: Boolean by lazy {
-            runCatching { System.loadLibrary("duckdetector") }.isSuccess
-        }
+        private val nativeLoaded = runCatching { System.loadLibrary("duckdetector") }.isSuccess
 
         @JvmStatic
-        external fun nativeCollectContextValiditySnapshot(): String
+        val isNativeLibraryLoaded: Boolean
+            get() = nativeLoaded
+
+        @JvmStatic
+        fun nativeCollectContextValiditySnapshot(): String {
+            return SelinuxContextValidityBridge().nativeCollectContextValiditySnapshotInternal()
+        }
+
+        @JvmStatic
+        fun setPreloadedRawData(raw: String) {
+            preloadedRawData = raw
+        }
+
+        private fun consumePreloadedRawData(): String? {
+            val raw = preloadedRawData
+            preloadedRawData = null
+            return raw
+        }
     }
 }

--- a/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/native/SelinuxContextValidityPayloadCodec.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/native/SelinuxContextValidityPayloadCodec.kt
@@ -16,6 +16,8 @@
 
 package com.eltavine.duckdetector.features.selinux.data.native
 
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxProcAttrCurrentPayloadCodec
+
 internal object SelinuxContextValidityPayloadCodec {
 
     fun encode(snapshot: SelinuxContextValiditySnapshot): String {
@@ -29,6 +31,22 @@ internal object SelinuxContextValidityPayloadCodec {
             append("CARRIER_MATCHES_EXPECTED=")
                 .append(if (snapshot.carrierMatchesExpected) '1' else '0')
                 .append('\n')
+            snapshot.selinuxEnabled?.let {
+                append("SELINUX_ENABLED=").append(if (it) '1' else '0').append('\n')
+            }
+            snapshot.selinuxEnforced?.let {
+                append("SELINUX_ENFORCED=").append(if (it) '1' else '0').append('\n')
+            }
+            snapshot.pidContextMatchesCurrent?.let {
+                append("PID_CONTEXT_MATCHES_CURRENT=").append(if (it) '1' else '0').append('\n')
+            }
+            snapshot.procSelfContextMatchesCurrent?.let {
+                append("PROC_SELF_CONTEXT_MATCHES_CURRENT=").append(if (it) '1' else '0')
+                    .append('\n')
+            }
+            snapshot.dyntransitionCheckPassed?.let {
+                append("DYNTRANSITION_CHECK_PASSED=").append(if (it) '1' else '0').append('\n')
+            }
             snapshot.carrierControlValid?.let {
                 append("CARRIER_CONTROL_VALID=").append(if (it) '1' else '0').append('\n')
             }
@@ -56,8 +74,8 @@ internal object SelinuxContextValidityPayloadCodec {
             snapshot.ksuFileValid?.let {
                 append("KSU_FILE_VALID=").append(if (it) '1' else '0').append('\n')
             }
-            snapshot.magiskFileValid?.let {
-                append("MAGISK_FILE_VALID=").append(if (it) '1' else '0').append('\n')
+            snapshot.bitPair?.takeIf { it.isNotEmpty() }?.let {
+                append("BIT_PAIR=").append(escapeValue(it)).append('\n')
             }
             append("DIRTY_POLICY_AVAILABLE=")
                 .append(if (snapshot.dirtyPolicyAvailable) '1' else '0')
@@ -95,13 +113,28 @@ internal object SelinuxContextValidityPayloadCodec {
                     .append(if (it) '1' else '0')
                     .append('\n')
             }
+            snapshot.dirtyPolicyFsckSysAdminAllowed?.let {
+                append("DIRTY_POLICY_FSCK_SYS_ADMIN_ALLOWED=")
+                    .append(if (it) '1' else '0')
+                    .append('\n')
+            }
+            snapshot.dirtyPolicyShellSuTransitionAllowed?.let {
+                append("DIRTY_POLICY_SHELL_SU_TRANSITION_ALLOWED=")
+                    .append(if (it) '1' else '0')
+                    .append('\n')
+            }
+            snapshot.dirtyPolicyAdbdAdbrootBinderCallAllowed?.let {
+                append("DIRTY_POLICY_ADBD_ADBROOT_BINDER_CALL_ALLOWED=")
+                    .append(if (it) '1' else '0')
+                    .append('\n')
+            }
             snapshot.dirtyPolicyMagiskBinderCallAllowed?.let {
                 append("DIRTY_POLICY_MAGISK_BINDER_CALL_ALLOWED=")
                     .append(if (it) '1' else '0')
                     .append('\n')
             }
-            snapshot.dirtyPolicyKsuBinderCallAllowed?.let {
-                append("DIRTY_POLICY_KSU_BINDER_CALL_ALLOWED=")
+            snapshot.dirtyPolicyKsuFileReadAllowed?.let {
+                append("DIRTY_POLICY_KSU_FILE_READ_ALLOWED=")
                     .append(if (it) '1' else '0')
                     .append('\n')
             }
@@ -110,11 +143,34 @@ internal object SelinuxContextValidityPayloadCodec {
                     .append(if (it) '1' else '0')
                     .append('\n')
             }
+            snapshot.dirtyPolicyXposedDataFileReadAllowed?.let {
+                append("DIRTY_POLICY_XPOSED_DATA_FILE_READ_ALLOWED=")
+                    .append(if (it) '1' else '0')
+                    .append('\n')
+            }
+            snapshot.dirtyPolicyZygoteAdbDataSearchAllowed?.let {
+                append("DIRTY_POLICY_ZYGOTE_ADB_DATA_SEARCH_ALLOWED=")
+                    .append(if (it) '1' else '0')
+                    .append('\n')
+            }
             snapshot.dirtyPolicyFailureReason?.takeIf { it.isNotEmpty() }?.let {
                 append("DIRTY_POLICY_FAILURE_REASON=").append(escapeValue(it)).append('\n')
             }
             snapshot.dirtyPolicyNotes.forEach { note ->
                 append("DIRTY_POLICY_NOTE=").append(escapeValue(note)).append('\n')
+            }
+            append("PROC_ATTR_CURRENT_PROBE_ATTEMPTED=")
+                .append(if (snapshot.procAttrCurrentProbeAttempted) '1' else '0')
+                .append('\n')
+            snapshot.procAttrCurrentResults.forEach { result ->
+                append("PROC_ATTR_CURRENT_RESULT=")
+                    .append(escapeValue(SelinuxProcAttrCurrentPayloadCodec.encode(result)))
+                    .append('\n')
+            }
+            snapshot.procAttrCurrentFailureReason?.takeIf { it.isNotEmpty() }?.let {
+                append("PROC_ATTR_CURRENT_FAILURE_REASON=")
+                    .append(escapeValue(it))
+                    .append('\n')
             }
             snapshot.failureReason?.takeIf { it.isNotEmpty() }?.let {
                 append("FAILURE_REASON=").append(escapeValue(it)).append('\n')

--- a/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/native/SelinuxContextValiditySnapshot.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/native/SelinuxContextValiditySnapshot.kt
@@ -16,11 +16,18 @@
 
 package com.eltavine.duckdetector.features.selinux.data.native
 
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxProcAttrCurrentResult
+
 data class SelinuxContextValiditySnapshot(
     val available: Boolean = false,
     val probeAttempted: Boolean = false,
     val carrierContext: String? = null,
     val carrierMatchesExpected: Boolean = false,
+    val selinuxEnabled: Boolean? = null,
+    val selinuxEnforced: Boolean? = null,
+    val pidContextMatchesCurrent: Boolean? = null,
+    val procSelfContextMatchesCurrent: Boolean? = null,
+    val dyntransitionCheckPassed: Boolean? = null,
     val carrierControlValid: Boolean? = null,
     val negativeControlRejected: Boolean? = null,
     val fileControlValid: Boolean? = null,
@@ -30,7 +37,7 @@ data class SelinuxContextValiditySnapshot(
     val queryMethod: String = "",
     val ksuDomainValid: Boolean? = null,
     val ksuFileValid: Boolean? = null,
-    val magiskFileValid: Boolean? = null,
+    val bitPair: String? = null,
     val dirtyPolicyAvailable: Boolean = false,
     val dirtyPolicyProbeAttempted: Boolean = false,
     val dirtyPolicyCarrierContext: String? = null,
@@ -41,11 +48,19 @@ data class SelinuxContextValiditySnapshot(
     val dirtyPolicyAccessControlAllowed: Boolean? = null,
     val dirtyPolicyNegativeControlRejected: Boolean? = null,
     val dirtyPolicySystemServerExecmemAllowed: Boolean? = null,
+    val dirtyPolicyFsckSysAdminAllowed: Boolean? = null,
+    val dirtyPolicyShellSuTransitionAllowed: Boolean? = null,
+    val dirtyPolicyAdbdAdbrootBinderCallAllowed: Boolean? = null,
     val dirtyPolicyMagiskBinderCallAllowed: Boolean? = null,
-    val dirtyPolicyKsuBinderCallAllowed: Boolean? = null,
+    val dirtyPolicyKsuFileReadAllowed: Boolean? = null,
     val dirtyPolicyLsposedFileReadAllowed: Boolean? = null,
+    val dirtyPolicyXposedDataFileReadAllowed: Boolean? = null,
+    val dirtyPolicyZygoteAdbDataSearchAllowed: Boolean? = null,
     val dirtyPolicyFailureReason: String? = null,
     val dirtyPolicyNotes: List<String> = emptyList(),
+    val procAttrCurrentProbeAttempted: Boolean = false,
+    val procAttrCurrentResults: List<SelinuxProcAttrCurrentResult> = emptyList(),
+    val procAttrCurrentFailureReason: String? = null,
     val failureReason: String? = null,
     val notes: List<String> = emptyList(),
 )

--- a/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/probes/SelinuxContextValidityProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/probes/SelinuxContextValidityProbe.kt
@@ -20,12 +20,11 @@ import com.eltavine.duckdetector.features.selinux.data.native.SelinuxContextVali
 import com.eltavine.duckdetector.features.selinux.data.native.SelinuxContextValiditySnapshot
 
 enum class SelinuxContextValidityState {
-    UNAVAILABLE,
     CLEAN,
-    ROOT_PRESENT,
-    BLOCKED_ORACLE,
-    UNTRUSTED_ORACLE,
-    UNSTABLE_RESULTS,
+    KSU_PRESENT,
+    AMBIGUOUS,
+    INCONSISTENT,
+    UNAVAILABLE,
 }
 
 data class SelinuxContextValidityProbeResult(
@@ -34,6 +33,11 @@ data class SelinuxContextValidityProbeResult(
     val probeAttempted: Boolean,
     val carrierContext: String?,
     val carrierMatchesExpected: Boolean,
+    val selinuxEnabled: Boolean?,
+    val selinuxEnforced: Boolean?,
+    val pidContextMatchesCurrent: Boolean?,
+    val procSelfContextMatchesCurrent: Boolean?,
+    val dyntransitionCheckPassed: Boolean?,
     val carrierControlValid: Boolean?,
     val negativeControlRejected: Boolean?,
     val fileControlValid: Boolean?,
@@ -43,7 +47,30 @@ data class SelinuxContextValidityProbeResult(
     val queryMethod: String,
     val ksuDomainValid: Boolean?,
     val ksuFileValid: Boolean?,
-    val magiskFileValid: Boolean?,
+    val bitPair: String?,
+    val dirtyPolicyAvailable: Boolean,
+    val dirtyPolicyProbeAttempted: Boolean,
+    val dirtyPolicyCarrierContext: String?,
+    val dirtyPolicyCarrierMatchesExpected: Boolean,
+    val dirtyPolicyControlsPassed: Boolean,
+    val dirtyPolicyStable: Boolean,
+    val dirtyPolicyQueryMethod: String,
+    val dirtyPolicyAccessControlAllowed: Boolean?,
+    val dirtyPolicyNegativeControlRejected: Boolean?,
+    val dirtyPolicySystemServerExecmemAllowed: Boolean?,
+    val dirtyPolicyFsckSysAdminAllowed: Boolean?,
+    val dirtyPolicyShellSuTransitionAllowed: Boolean?,
+    val dirtyPolicyAdbdAdbrootBinderCallAllowed: Boolean?,
+    val dirtyPolicyMagiskBinderCallAllowed: Boolean?,
+    val dirtyPolicyKsuFileReadAllowed: Boolean?,
+    val dirtyPolicyLsposedFileReadAllowed: Boolean?,
+    val dirtyPolicyXposedDataFileReadAllowed: Boolean?,
+    val dirtyPolicyZygoteAdbDataSearchAllowed: Boolean?,
+    val dirtyPolicyFailureReason: String?,
+    val dirtyPolicyNotes: List<String>,
+    val procAttrCurrentProbeAttempted: Boolean,
+    val procAttrCurrentResults: List<SelinuxProcAttrCurrentResult>,
+    val procAttrCurrentFailureReason: String?,
     val failureReason: String?,
     val notes: List<String>,
 )
@@ -61,42 +88,34 @@ class SelinuxContextValidityProbe(
     }
 
     internal fun SelinuxContextValiditySnapshot.toProbeResult(): SelinuxContextValidityProbeResult {
-        val trustedCarrier = available && probeAttempted && carrierMatchesExpected
-        val hasRootContext = ksuDomainValid == true || ksuFileValid == true || magiskFileValid == true
-        val oracleBlockedByPolicy = trustedCarrier &&
-            !oracleControlsPassed &&
-            hasPolicyDeniedEvidence()
         val state = when {
-            !available || !probeAttempted -> SelinuxContextValidityState.UNAVAILABLE
+            !available -> SelinuxContextValidityState.UNAVAILABLE
             !carrierMatchesExpected -> SelinuxContextValidityState.UNAVAILABLE
-            oracleBlockedByPolicy -> SelinuxContextValidityState.BLOCKED_ORACLE
-            trustedCarrier && !oracleControlsPassed -> SelinuxContextValidityState.UNTRUSTED_ORACLE
-            trustedCarrier && oracleControlsPassed && !ksuResultsStable -> SelinuxContextValidityState.UNSTABLE_RESULTS
-            trustedCarrier && hasRootContext -> SelinuxContextValidityState.ROOT_PRESENT
-            else -> SelinuxContextValidityState.CLEAN
+            !probeAttempted -> SelinuxContextValidityState.UNAVAILABLE
+            !oracleControlsPassed -> SelinuxContextValidityState.INCONSISTENT
+            !ksuResultsStable -> SelinuxContextValidityState.INCONSISTENT
+            ksuDomainValid == null || ksuFileValid == null -> SelinuxContextValidityState.UNAVAILABLE
+            ksuDomainValid && ksuFileValid -> SelinuxContextValidityState.KSU_PRESENT
+            !ksuDomainValid && !ksuFileValid -> SelinuxContextValidityState.CLEAN
+            else -> SelinuxContextValidityState.AMBIGUOUS
         }
 
         val notes = buildList {
             addAll(this@toProbeResult.notes)
-            failureReason?.takeIf { it.isNotBlank() }?.let(::add)
             when (state) {
-                SelinuxContextValidityState.UNAVAILABLE ->
-                    add("The app_zygote carrier snapshot was unavailable or untrusted.")
-
                 SelinuxContextValidityState.CLEAN ->
-                    add("Root specific contexts were not found by live policy.")
+                    add("Bit pair 00 means both KSU-specific contexts were rejected by live policy.")
 
-                SelinuxContextValidityState.ROOT_PRESENT ->
-                    add("Root contexts were found by live policy.")
+                SelinuxContextValidityState.KSU_PRESENT ->
+                    add("Bit pair 11 means both KSU-specific contexts were accepted by live policy.")
 
-                SelinuxContextValidityState.BLOCKED_ORACLE ->
-                    add("app_zygote SELinux context queries were blocked by policy.")
+                SelinuxContextValidityState.AMBIGUOUS ->
+                    add("Bit pair 01/10 means the KSU-specific contexts split across live policy checks.")
 
-                SelinuxContextValidityState.UNTRUSTED_ORACLE ->
-                    add("Context validity oracle failed its self-test.")
+                SelinuxContextValidityState.INCONSISTENT ->
+                    add("Oracle self-test failed, so the KSU-specific context verdict is not trusted.")
 
-                SelinuxContextValidityState.UNSTABLE_RESULTS ->
-                    add("Context validity oracle repeated inconsistently.")
+                SelinuxContextValidityState.UNAVAILABLE -> Unit
             }
         }.distinct()
 
@@ -106,6 +125,11 @@ class SelinuxContextValidityProbe(
             probeAttempted = probeAttempted,
             carrierContext = carrierContext,
             carrierMatchesExpected = carrierMatchesExpected,
+            selinuxEnabled = selinuxEnabled,
+            selinuxEnforced = selinuxEnforced,
+            pidContextMatchesCurrent = pidContextMatchesCurrent,
+            procSelfContextMatchesCurrent = procSelfContextMatchesCurrent,
+            dyntransitionCheckPassed = dyntransitionCheckPassed,
             carrierControlValid = carrierControlValid,
             negativeControlRejected = negativeControlRejected,
             fileControlValid = fileControlValid,
@@ -115,7 +139,30 @@ class SelinuxContextValidityProbe(
             queryMethod = queryMethod,
             ksuDomainValid = ksuDomainValid,
             ksuFileValid = ksuFileValid,
-            magiskFileValid = magiskFileValid,
+            bitPair = bitPair,
+            dirtyPolicyAvailable = dirtyPolicyAvailable,
+            dirtyPolicyProbeAttempted = dirtyPolicyProbeAttempted,
+            dirtyPolicyCarrierContext = dirtyPolicyCarrierContext,
+            dirtyPolicyCarrierMatchesExpected = dirtyPolicyCarrierMatchesExpected,
+            dirtyPolicyControlsPassed = dirtyPolicyControlsPassed,
+            dirtyPolicyStable = dirtyPolicyStable,
+            dirtyPolicyQueryMethod = dirtyPolicyQueryMethod,
+            dirtyPolicyAccessControlAllowed = dirtyPolicyAccessControlAllowed,
+            dirtyPolicyNegativeControlRejected = dirtyPolicyNegativeControlRejected,
+            dirtyPolicySystemServerExecmemAllowed = dirtyPolicySystemServerExecmemAllowed,
+            dirtyPolicyFsckSysAdminAllowed = dirtyPolicyFsckSysAdminAllowed,
+            dirtyPolicyShellSuTransitionAllowed = dirtyPolicyShellSuTransitionAllowed,
+            dirtyPolicyAdbdAdbrootBinderCallAllowed = dirtyPolicyAdbdAdbrootBinderCallAllowed,
+            dirtyPolicyMagiskBinderCallAllowed = dirtyPolicyMagiskBinderCallAllowed,
+            dirtyPolicyKsuFileReadAllowed = dirtyPolicyKsuFileReadAllowed,
+            dirtyPolicyLsposedFileReadAllowed = dirtyPolicyLsposedFileReadAllowed,
+            dirtyPolicyXposedDataFileReadAllowed = dirtyPolicyXposedDataFileReadAllowed,
+            dirtyPolicyZygoteAdbDataSearchAllowed = dirtyPolicyZygoteAdbDataSearchAllowed,
+            dirtyPolicyFailureReason = dirtyPolicyFailureReason,
+            dirtyPolicyNotes = dirtyPolicyNotes,
+            procAttrCurrentProbeAttempted = procAttrCurrentProbeAttempted,
+            procAttrCurrentResults = procAttrCurrentResults,
+            procAttrCurrentFailureReason = procAttrCurrentFailureReason,
             failureReason = failureReason,
             notes = notes,
         )
@@ -123,19 +170,10 @@ class SelinuxContextValidityProbe(
 
     companion object {
         const val METHOD_LABEL = "Context validity oracle"
-        const val STATUS_ORACLE_UNAVAILABLE = "Context oracle unavailable"
-        const val STATUS_ROOT_CONTEXT_FOUND = "Root Selinux Context found"
-        const val STATUS_ORACLE_BLOCKED = "Context oracle blocked"
-        const val STATUS_ORACLE_SELF_TEST_FAILED = "Context oracle self-test failed"
-        const val STATUS_ORACLE_UNSTABLE = "Context oracle unstable"
-    }
-
-    private fun SelinuxContextValiditySnapshot.hasPolicyDeniedEvidence(): Boolean {
-        return listOfNotNull(failureReason)
-            .plus(notes)
-            .any { note ->
-                note.contains("Permission denied", ignoreCase = true) ||
-                    note.contains("EACCES", ignoreCase = true)
-            }
+        const val BITPAIR_CLEAN = "00"
+        const val BITPAIR_KSU_PRESENT = "11"
+        const val BITPAIR_AMBIGUOUS = "01/10"
+        const val BITPAIR_SELF_TEST_FAILED = "Self-test failed"
+        const val BITPAIR_UNSUPPORTED = "Unsupported"
     }
 }

--- a/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/probes/SelinuxProcAttrCurrentPayloadCodec.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/probes/SelinuxProcAttrCurrentPayloadCodec.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.selinux.data.probes
+
+object SelinuxProcAttrCurrentPayloadCodec {
+
+    fun encode(result: SelinuxProcAttrCurrentResult): String {
+        return listOf(
+            result.label,
+            result.targetContext,
+            result.outcomeClass,
+            result.rawMessage,
+        ).joinToString(FIELD_SEPARATOR)
+    }
+
+    fun decode(payload: String): SelinuxProcAttrCurrentResult? {
+        val parts = payload.split(FIELD_SEPARATOR, limit = 4)
+        if (parts.size != 4) {
+            return null
+        }
+        return SelinuxProcAttrCurrentResult(
+            label = parts[0],
+            targetContext = parts[1],
+            outcomeClass = parts[2],
+            rawMessage = parts[3],
+        )
+    }
+
+    private const val FIELD_SEPARATOR = "\t"
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/probes/SelinuxProcAttrCurrentProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/probes/SelinuxProcAttrCurrentProbe.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.selinux.data.probes
+
+import android.system.ErrnoException
+import android.system.Os
+import android.system.OsConstants
+import java.io.FileOutputStream
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+
+data class SelinuxProcAttrCurrentResult(
+    val label: String,
+    val targetContext: String,
+    val outcomeClass: String,
+    val rawMessage: String,
+) {
+    fun detected(): Boolean {
+        return outcomeClass == OUTCOME_SUCCESS ||
+            outcomeClass == OUTCOME_DETECTED_NON_EINVAL ||
+            outcomeClass == OUTCOME_DETECTED_SECURITY_EXCEPTION
+    }
+
+    companion object {
+        const val OUTCOME_SUCCESS = "SUCCESS"
+        const val OUTCOME_NORMAL_EINVAL = "NORMAL_EINVAL"
+        const val OUTCOME_DETECTED_NON_EINVAL = "DETECTED_NON_EINVAL"
+        const val OUTCOME_DETECTED_SECURITY_EXCEPTION = "DETECTED_SECURITY_EXCEPTION"
+    }
+}
+
+class SelinuxProcAttrCurrentProbe {
+
+    fun inspect(): List<SelinuxProcAttrCurrentResult> {
+        return TARGETS.map { target ->
+            runProbe(target.label, target.context)
+        }
+    }
+
+    private fun runProbe(
+        label: String,
+        targetContext: String,
+    ): SelinuxProcAttrCurrentResult {
+        return try {
+            val payload = targetContext.toByteArray(StandardCharsets.UTF_8)
+            FileOutputStream(PROC_ATTR_CURRENT_PATH).use { out ->
+                Os.write(out.fd, payload, 0, payload.size)
+            }
+            SelinuxProcAttrCurrentResult(
+                label = label,
+                targetContext = targetContext,
+                outcomeClass = SelinuxProcAttrCurrentResult.OUTCOME_SUCCESS,
+                rawMessage = "write succeeded",
+            )
+        } catch (error: SecurityException) {
+            SelinuxProcAttrCurrentResult(
+                label = label,
+                targetContext = targetContext,
+                outcomeClass = SelinuxProcAttrCurrentResult.OUTCOME_DETECTED_SECURITY_EXCEPTION,
+                rawMessage = "${error::class.java.simpleName}: ${error.message}",
+            )
+        } catch (error: IOException) {
+            classifyIOException(label, targetContext, error)
+        } catch (error: ErrnoException) {
+            classifyErrnoException(label, targetContext, error)
+        }
+    }
+
+    private fun classifyIOException(
+        label: String,
+        targetContext: String,
+        error: IOException,
+    ): SelinuxProcAttrCurrentResult {
+        val detail = "${error::class.java.simpleName}: ${error.message}"
+        val outcome = if (
+            error.message
+                ?.lowercase(Locale.ROOT)
+                ?.contains("invalid argument") == true
+        ) {
+            SelinuxProcAttrCurrentResult.OUTCOME_NORMAL_EINVAL
+        } else {
+            SelinuxProcAttrCurrentResult.OUTCOME_DETECTED_NON_EINVAL
+        }
+        return SelinuxProcAttrCurrentResult(
+            label = label,
+            targetContext = targetContext,
+            outcomeClass = outcome,
+            rawMessage = detail,
+        )
+    }
+
+    private fun classifyErrnoException(
+        label: String,
+        targetContext: String,
+        error: ErrnoException,
+    ): SelinuxProcAttrCurrentResult {
+        val detail = "${error::class.java.simpleName}: errno=${error.errno}, ${error.message}"
+        val outcome = if (error.errno == OsConstants.EINVAL) {
+            SelinuxProcAttrCurrentResult.OUTCOME_NORMAL_EINVAL
+        } else {
+            SelinuxProcAttrCurrentResult.OUTCOME_DETECTED_NON_EINVAL
+        }
+        return SelinuxProcAttrCurrentResult(
+            label = label,
+            targetContext = targetContext,
+            outcomeClass = outcome,
+            rawMessage = detail,
+        )
+    }
+
+    private data class ProbeTarget(
+        val label: String,
+        val context: String,
+    )
+
+    companion object {
+        const val METHOD_LABEL = "app_zygote attr/current write"
+        const val STATUS_CLEAN = "Normal EINVAL"
+        const val STATUS_UNSUPPORTED = "Unsupported"
+        private const val PROC_ATTR_CURRENT_PATH = "/proc/self/attr/current"
+
+        private val TARGETS = listOf(
+            ProbeTarget("KernelSU", "u:r:ksu:s0"),
+            ProbeTarget("KernelSU file", "u:r:ksu_file:s0"),
+            ProbeTarget("Magisk", "u:r:magisk:s0"),
+            ProbeTarget("Magisk file", "u:r:magisk_file:s0"),
+            ProbeTarget("LSPosed file", "u:r:lsposed_file:s0"),
+            ProbeTarget("Xposed data", "u:r:xposed_data:s0"),
+        )
+    }
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/repository/SelinuxRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/repository/SelinuxRepository.kt
@@ -21,6 +21,8 @@ import android.os.Build
 import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxContextValidityProbe
 import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxContextValidityProbeResult
 import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxContextValidityState
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxProcAttrCurrentProbe
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxProcAttrCurrentResult
 import com.eltavine.duckdetector.features.selinux.data.service.SelinuxContextValidityCarrierManager
 import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxAuditRuntimeProbe
 import com.eltavine.duckdetector.features.selinux.domain.SelinuxAuditEvidence
@@ -86,18 +88,30 @@ class SelinuxRepository(
         val procAttrResult = checkViaProcAttr()
         methods += procAttrResult
 
-        val contextValidityResult = contextValidityCarrierManager.collect().let { carrierResult ->
+        val carrierResult = contextValidityCarrierManager.collect()
+        val contextValidityResult = carrierResult.let {
             if (
-                carrierResult.available &&
-                carrierResult.carrierMatchesExpected &&
-                carrierResult.probeAttempted
+                it.available &&
+                it.carrierMatchesExpected &&
+                it.probeAttempted
             ) {
-                carrierResult
+                it
             } else {
                 contextValidityProbe.inspect()
             }
         }
-        methods += buildContextValidityMethod(contextValidityResult)
+        val contextValiditySource = if (
+            carrierResult.available &&
+            carrierResult.carrierMatchesExpected &&
+            carrierResult.probeAttempted
+        ) {
+            EvidenceSource.DEDICATED_CARRIER
+        } else {
+            EvidenceSource.LOCAL_FALLBACK
+        }
+        methods += buildContextValidityMethod(contextValidityResult, contextValiditySource)
+        methods += buildProcAttrCurrentMethod(carrierResult, EvidenceSource.DEDICATED_CARRIER)
+        methods += buildDirtyPolicyMethods(carrierResult, EvidenceSource.DEDICATED_CARRIER)
 
         val statusResolution = determineStatusWithParadoxLogic(methods)
         val processContext = readProcessContext()
@@ -284,23 +298,21 @@ class SelinuxRepository(
 
     private fun buildContextValidityMethod(
         result: SelinuxContextValidityProbeResult,
+        source: EvidenceSource,
     ): SelinuxCheckResult {
         val status = when (result.state) {
             SelinuxContextValidityState.UNAVAILABLE ->
-                SelinuxContextValidityProbe.STATUS_ORACLE_UNAVAILABLE
+                SelinuxContextValidityProbe.BITPAIR_UNSUPPORTED
 
             SelinuxContextValidityState.CLEAN -> ""
-            SelinuxContextValidityState.ROOT_PRESENT ->
-                SelinuxContextValidityProbe.STATUS_ROOT_CONTEXT_FOUND
+            SelinuxContextValidityState.KSU_PRESENT ->
+                SelinuxContextValidityProbe.BITPAIR_KSU_PRESENT
 
-            SelinuxContextValidityState.BLOCKED_ORACLE ->
-                SelinuxContextValidityProbe.STATUS_ORACLE_BLOCKED
+            SelinuxContextValidityState.AMBIGUOUS ->
+                SelinuxContextValidityProbe.BITPAIR_AMBIGUOUS
 
-            SelinuxContextValidityState.UNTRUSTED_ORACLE ->
-                SelinuxContextValidityProbe.STATUS_ORACLE_SELF_TEST_FAILED
-
-            SelinuxContextValidityState.UNSTABLE_RESULTS ->
-                SelinuxContextValidityProbe.STATUS_ORACLE_UNSTABLE
+            SelinuxContextValidityState.INCONSISTENT ->
+                SelinuxContextValidityProbe.BITPAIR_SELF_TEST_FAILED
         }
 
         val detail = buildList {
@@ -328,6 +340,7 @@ class SelinuxRepository(
             }}\n")
             add("Oracle trusted=${if (result.oracleControlsPassed) "yes" else "no"}\n")
             add("Repeatability=${if (result.ksuResultsStable) "stable" else "unstable"}\n")
+            add("Evidence source=${source.label}\n")
             add(
                 "Query=${
                     when (result.state) {
@@ -341,19 +354,16 @@ class SelinuxRepository(
                     add("The app_zygote carrier snapshot was unavailable or untrusted.\n")
 
                 SelinuxContextValidityState.CLEAN ->
-                    add("Root contexts were not found by live policy.\n")
+                    add("KSU-specific contexts were not found by live policy.\n")
 
-                SelinuxContextValidityState.ROOT_PRESENT ->
-                    add("Root contexts were found by live policy.\n")
+                SelinuxContextValidityState.KSU_PRESENT ->
+                    add("Both KSU-specific contexts were found by live policy.\n")
 
-                SelinuxContextValidityState.BLOCKED_ORACLE ->
-                    add("app_zygote SELinux context queries were blocked by policy and root context checks were not trusted.\n")
+                SelinuxContextValidityState.AMBIGUOUS ->
+                    add("The two KSU-specific contexts split across live policy checks.\n")
 
-                SelinuxContextValidityState.UNTRUSTED_ORACLE ->
-                    add("Context validity oracle failed its self-test and root context checks were not trusted.\n")
-
-                SelinuxContextValidityState.UNSTABLE_RESULTS ->
-                    add("Context validity oracle repeated inconsistently and root context checks were not trusted.\n")
+                SelinuxContextValidityState.INCONSISTENT ->
+                    add("Context validity oracle self-test or repeatability failed, so the KSU verdict was not trusted.\n")
             }
             result.notes.forEach { note ->
                 add(note)
@@ -366,13 +376,192 @@ class SelinuxRepository(
             isSecure = when (result.state) {
                 SelinuxContextValidityState.UNAVAILABLE -> null
                 SelinuxContextValidityState.CLEAN -> true
-                SelinuxContextValidityState.ROOT_PRESENT -> false
-                SelinuxContextValidityState.BLOCKED_ORACLE -> null
-                SelinuxContextValidityState.UNTRUSTED_ORACLE -> null
-                SelinuxContextValidityState.UNSTABLE_RESULTS -> null
+                SelinuxContextValidityState.KSU_PRESENT -> false
+                SelinuxContextValidityState.AMBIGUOUS -> null
+                SelinuxContextValidityState.INCONSISTENT -> null
             },
             permissionDenied = false,
             details = detail,
+        )
+    }
+
+    private fun buildProcAttrCurrentMethod(
+        result: SelinuxContextValidityProbeResult,
+        source: EvidenceSource,
+    ): SelinuxCheckResult {
+        val outcomes = result.procAttrCurrentResults
+        if (!result.procAttrCurrentProbeAttempted) {
+            return SelinuxCheckResult(
+                method = SelinuxProcAttrCurrentProbe.METHOD_LABEL,
+                status = SelinuxProcAttrCurrentProbe.STATUS_UNSUPPORTED,
+                isSecure = null,
+                permissionDenied = false,
+                details = listOfNotNull(
+                    "Evidence source=${source.label}",
+                    result.procAttrCurrentFailureReason ?: "Dedicated app_zygote attr/current write probe skipped.",
+                ).joinToString(" | "),
+            )
+        }
+        if (outcomes.isEmpty()) {
+            return SelinuxCheckResult(
+                method = SelinuxProcAttrCurrentProbe.METHOD_LABEL,
+                status = SelinuxProcAttrCurrentProbe.STATUS_UNSUPPORTED,
+                isSecure = null,
+                permissionDenied = false,
+                details = listOfNotNull(
+                    "Evidence source=${source.label}",
+                    result.procAttrCurrentFailureReason ?: "Dedicated app_zygote attr/current write probe returned no results.",
+                ).joinToString(" | "),
+            )
+        }
+
+        val detected = outcomes.filter(SelinuxProcAttrCurrentResult::detected)
+        val clean = outcomes.all {
+            it.outcomeClass == SelinuxProcAttrCurrentResult.OUTCOME_NORMAL_EINVAL
+        }
+        val status = when {
+            detected.isNotEmpty() -> "Detected: ${detected.joinToString { it.label }}"
+            clean -> SelinuxProcAttrCurrentProbe.STATUS_CLEAN
+            else -> SelinuxProcAttrCurrentProbe.STATUS_UNSUPPORTED
+        }
+        val detail = listOf(
+            "Evidence source=${source.label}",
+            outcomes.joinToString(" | ") { outcome ->
+                "${outcome.label}=${outcome.outcomeClass} target=${outcome.targetContext} raw=${outcome.rawMessage}"
+            },
+        ).joinToString(" | ")
+
+        return SelinuxCheckResult(
+            method = SelinuxProcAttrCurrentProbe.METHOD_LABEL,
+            status = status,
+            isSecure = when {
+                detected.isNotEmpty() -> false
+                clean -> true
+                else -> null
+            },
+            permissionDenied = false,
+            details = detail,
+        )
+    }
+
+    internal fun buildDirtyPolicyMethods(
+        result: SelinuxContextValidityProbeResult,
+    ): List<SelinuxCheckResult> = buildDirtyPolicyMethods(result, EvidenceSource.DEDICATED_CARRIER)
+
+    private fun buildDirtyPolicyMethods(
+        result: SelinuxContextValidityProbeResult,
+        source: EvidenceSource,
+    ): List<SelinuxCheckResult> {
+        val oracleTrusted = isDirtyPolicyOracleTrusted(result)
+        return listOf(
+            dirtyPolicyRuleMethod(
+                label = "Dirty sepolicy rule: system_server execmem",
+                allowed = result.dirtyPolicySystemServerExecmemAllowed.takeIf { oracleTrusted },
+                detail = "Observed edge: system_server -> system_server:process execmem. This should stay denied on stock policy because executable system_server memory is supporting dirty-policy evidence.",
+                failureReason = result.dirtyPolicyFailureReason,
+                source = source,
+            ),
+            dirtyPolicyRuleMethod(
+                label = "Dirty sepolicy rule: fsck_untrusted sys_admin",
+                allowed = result.dirtyPolicyFsckSysAdminAllowed.takeIf { oracleTrusted },
+                detail = "Observed edge: fsck_untrusted -> fsck_untrusted:capability sys_admin. This should stay denied on stock policy because it represents a DirtySepolicy neverallow-style violation.",
+                failureReason = result.dirtyPolicyFailureReason,
+                source = source,
+            ),
+            dirtyPolicyRuleMethod(
+                label = "Dirty sepolicy rule: shell -> su transition",
+                allowed = result.dirtyPolicyShellSuTransitionAllowed.takeIf { oracleTrusted },
+                detail = "Observed edge: shell -> su:process transition. This is only evaluated for confirmed user builds because stock user builds should not expose an AOSP su transition path.",
+                failureReason = result.dirtyPolicyFailureReason,
+                source = source,
+            ),
+            dirtyPolicyRuleMethod(
+                label = "Dirty sepolicy rule: adbd -> adbroot binder",
+                allowed = result.dirtyPolicyAdbdAdbrootBinderCallAllowed.takeIf { oracleTrusted },
+                detail = "Observed edge: adbd -> adbroot:binder call. This should stay denied on stock policy because it is supporting adb-root dirty-policy evidence.",
+                failureReason = result.dirtyPolicyFailureReason,
+                source = source,
+            ),
+            dirtyPolicyRuleMethod(
+                label = "Dirty sepolicy rule: untrusted_app -> magisk binder",
+                allowed = result.dirtyPolicyMagiskBinderCallAllowed.takeIf { oracleTrusted },
+                detail = "Observed edge: untrusted_app -> magisk:binder call. This should stay denied on stock policy because ordinary apps should not talk to a Magisk domain over binder.",
+                failureReason = result.dirtyPolicyFailureReason,
+                source = source,
+            ),
+            dirtyPolicyRuleMethod(
+                label = "Dirty sepolicy rule: untrusted_app -> ksu_file read",
+                allowed = result.dirtyPolicyKsuFileReadAllowed.takeIf { oracleTrusted },
+                detail = "Observed edge: untrusted_app -> ksu_file:file read. This should stay denied on stock policy because ordinary apps should not read KernelSU-labeled files.",
+                failureReason = result.dirtyPolicyFailureReason,
+                source = source,
+            ),
+            dirtyPolicyRuleMethod(
+                label = "Dirty sepolicy rule: untrusted_app -> lsposed_file read",
+                allowed = result.dirtyPolicyLsposedFileReadAllowed.takeIf { oracleTrusted },
+                detail = "Observed edge: untrusted_app -> lsposed_file:file read. This should stay denied on stock policy because ordinary apps should not read LSPosed-labeled files.",
+                failureReason = result.dirtyPolicyFailureReason,
+                source = source,
+            ),
+            dirtyPolicyRuleMethod(
+                label = "Dirty sepolicy rule: untrusted_app -> xposed_data read",
+                allowed = result.dirtyPolicyXposedDataFileReadAllowed.takeIf { oracleTrusted },
+                detail = "Observed edge: untrusted_app -> xposed_data:file read. This should stay denied on stock policy because ordinary apps should not read Xposed data directly.",
+                failureReason = result.dirtyPolicyFailureReason,
+                source = source,
+            ),
+            dirtyPolicyRuleMethod(
+                label = "Dirty sepolicy rule: zygote -> adb_data_file search",
+                allowed = result.dirtyPolicyZygoteAdbDataSearchAllowed.takeIf { oracleTrusted },
+                detail = "Observed edge: zygote -> adb_data_file:dir search. This should stay denied on stock policy because zygote should not traverse adb data directories.",
+                failureReason = result.dirtyPolicyFailureReason,
+                source = source,
+            ),
+        )
+    }
+
+    internal fun isDirtyPolicyOracleTrusted(
+        result: SelinuxContextValidityProbeResult,
+    ): Boolean {
+        return result.dirtyPolicyAvailable &&
+            result.dirtyPolicyProbeAttempted &&
+            result.dirtyPolicyCarrierMatchesExpected &&
+            result.dirtyPolicyControlsPassed &&
+            result.dirtyPolicyStable &&
+            result.dirtyPolicyAccessControlAllowed == true &&
+            result.dirtyPolicyNegativeControlRejected == true
+    }
+
+    private fun dirtyPolicyRuleMethod(
+        label: String,
+        allowed: Boolean?,
+        detail: String,
+        failureReason: String?,
+        source: EvidenceSource,
+    ): SelinuxCheckResult {
+        val status = when (allowed) {
+            true -> "Allowed"
+            false -> "Denied"
+            null -> "Unavailable"
+        }
+        return SelinuxCheckResult(
+            method = label,
+            status = status,
+            isSecure = when (allowed) {
+                true -> false
+                false -> true
+                null -> null
+            },
+            permissionDenied = false,
+            details = listOfNotNull(
+                "Evidence source=${source.label}",
+                when (allowed) {
+                    true -> "$detail The access oracle reported this edge as allowed."
+                    false -> "$detail The access oracle reported this edge as denied."
+                    null -> "$detail The access oracle could not produce a verdict for this edge."
+                },
+                failureReason?.takeIf { allowed == null }?.let { "Reason: $it" },
+            ).joinToString(" | "),
         )
     }
 
@@ -819,6 +1008,13 @@ class SelinuxRepository(
         val label: String,
         val paradoxDetected: Boolean,
     )
+
+    private enum class EvidenceSource(
+        val label: String,
+    ) {
+        DEDICATED_CARRIER("dedicated app_zygote carrier"),
+        LOCAL_FALLBACK("local native fallback"),
+    }
 
     private data class AuditResidueRule(
         val path: String,

--- a/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/service/SelinuxContextValidityCarrierService.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/service/SelinuxContextValidityCarrierService.kt
@@ -21,13 +21,16 @@ import android.content.Intent
 import android.os.Binder
 import android.os.IBinder
 import android.os.Parcel
+import android.system.Os
 import com.eltavine.duckdetector.features.selinux.data.native.SelinuxContextValidityBridge
 import com.eltavine.duckdetector.features.selinux.data.native.SelinuxContextValidityPayloadCodec
 import com.eltavine.duckdetector.features.selinux.data.native.SelinuxContextValiditySnapshot
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxProcAttrCurrentProbe
 
 class SelinuxContextValidityCarrierService : Service() {
 
     private val nativeBridge = SelinuxContextValidityBridge()
+    private val procAttrCurrentProbe = SelinuxProcAttrCurrentProbe()
 
     private val binder = object : Binder() {
         override fun onTransact(
@@ -58,7 +61,15 @@ class SelinuxContextValidityCarrierService : Service() {
 
     private fun buildSnapshotPayload(): String {
         return runCatching {
-            SelinuxContextValidityPayloadCodec.encode(nativeBridge.collectSnapshot())
+            val baseSnapshot = nativeBridge.collectSnapshot()
+            val procAttrGate = evaluateProcAttrCurrentGate(baseSnapshot)
+            SelinuxContextValidityPayloadCodec.encode(
+                baseSnapshot.copy(
+                    procAttrCurrentProbeAttempted = procAttrGate.attempted,
+                    procAttrCurrentResults = procAttrGate.results,
+                    procAttrCurrentFailureReason = procAttrGate.failureReason,
+                ),
+            )
         }.getOrElse { throwable ->
             SelinuxContextValidityPayloadCodec.encode(
                 SelinuxContextValiditySnapshot(
@@ -66,6 +77,71 @@ class SelinuxContextValidityCarrierService : Service() {
                     notes = listOf("SELinux carrier probe crashed before collecting a snapshot."),
                 ),
             )
+        }
+    }
+
+    private fun evaluateProcAttrCurrentGate(
+        snapshot: SelinuxContextValiditySnapshot,
+    ): ProcAttrCurrentGateResult {
+        val failureReason = procAttrCurrentGateFailureReason(
+            snapshot = snapshot,
+            appUid = applicationInfo?.uid,
+            uid = Os.getuid(),
+        )
+        if (failureReason != null) {
+            return ProcAttrCurrentGateResult(
+                failureReason = failureReason,
+            )
+        }
+        return ProcAttrCurrentGateResult(
+            attempted = true,
+            results = procAttrCurrentProbe.inspect(),
+        )
+    }
+
+    private data class ProcAttrCurrentGateResult(
+        val attempted: Boolean = false,
+        val results: List<com.eltavine.duckdetector.features.selinux.data.probes.SelinuxProcAttrCurrentResult> = emptyList(),
+        val failureReason: String? = null,
+    )
+
+    companion object {
+        internal fun procAttrCurrentGateFailureReason(
+            snapshot: SelinuxContextValiditySnapshot,
+            appUid: Int?,
+            uid: Int,
+        ): String? {
+            if (appUid == null) {
+                return "Application UID unavailable for app_zygote attr/current probe."
+            }
+            if (uid != appUid) {
+                return "UID mismatch: $uid != app uid $appUid"
+            }
+            if (!snapshot.available) {
+                return snapshot.failureReason ?: "Carrier SELinux context was unreadable."
+            }
+            if (snapshot.selinuxEnabled == false) {
+                return "SELinux is disabled in the carrier context."
+            }
+            if (snapshot.selinuxEnforced == false) {
+                return "SELinux is permissive in the carrier context."
+            }
+            if (!snapshot.carrierMatchesExpected) {
+                return "Carrier self-check did not land in app_zygote context."
+            }
+            if (snapshot.carrierContext?.startsWith("u:r:app_zygote:s0") == false) {
+                return "Carrier self-check did not match the expected app_zygote context prefix."
+            }
+            if (snapshot.pidContextMatchesCurrent == false) {
+                return "Carrier pid context did not match the current process context."
+            }
+            if (snapshot.procSelfContextMatchesCurrent == false) {
+                return "Carrier /proc/self context did not match the current process context."
+            }
+            if (snapshot.dyntransitionCheckPassed == false) {
+                return "Carrier dyntransition self-check failed."
+            }
+            return null
         }
     }
 }

--- a/app/src/main/java/com/eltavine/duckdetector/features/selinux/presentation/SelinuxCardModelMapper.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/selinux/presentation/SelinuxCardModelMapper.kt
@@ -27,6 +27,7 @@ import com.eltavine.duckdetector.features.selinux.domain.SelinuxPolicyWeakness
 import com.eltavine.duckdetector.features.selinux.domain.SelinuxReport
 import com.eltavine.duckdetector.features.selinux.domain.SelinuxStage
 import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxContextValidityProbe
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxProcAttrCurrentProbe
 import com.eltavine.duckdetector.features.selinux.ui.model.SelinuxCardModel
 import com.eltavine.duckdetector.features.selinux.ui.model.SelinuxDetailRowModel
 import com.eltavine.duckdetector.features.selinux.ui.model.SelinuxHeaderFactModel
@@ -56,10 +57,10 @@ class SelinuxCardModelMapper {
 
     private fun buildSubtitle(report: SelinuxReport): String {
         return when (report.stage) {
-            SelinuxStage.LOADING -> "sysfs + getenforce + proc attr + context oracle + policy + audit"
+            SelinuxStage.LOADING -> "sysfs + getenforce + proc attr + app_zygote attr write + context oracle + policy + audit"
             SelinuxStage.FAILED -> "local status probe failed"
             SelinuxStage.READY -> buildString {
-                append("5 local checks")
+                append("6 local checks")
                 if (report.policyAnalysis != null) {
                     append(" + policy")
                 }
@@ -72,21 +73,31 @@ class SelinuxCardModelMapper {
 
     private fun buildVerdict(report: SelinuxReport): String {
         val contextValidity = contextValidityResult(report)
+        val procAttrCurrent = procAttrCurrentResult(report)
+        val dirtyPolicyHit = firstTrustedDirtyPolicyHit(report)
+        val repeatabilityFailed =
+            contextValidity?.details?.contains("repeatability failed", ignoreCase = true) == true
         return when (report.stage) {
             SelinuxStage.LOADING -> "Scanning SELinux state"
             SelinuxStage.FAILED -> "SELinux scan failed"
             SelinuxStage.READY -> when (report.mode) {
                 SelinuxMode.ENFORCING -> when {
                     report.auditIntegrity?.state == SelinuxAuditIntegrityState.TAMPERED -> "Enforcing with audit rewrite"
-                    contextValidity?.isRootContextSignal() == true ->
-                        "Enforcing with Root context materialized"
+                    contextValidity?.status == SelinuxContextValidityProbe.BITPAIR_KSU_PRESENT ->
+                        "Enforcing with KSU context materialized"
+                    procAttrCurrent?.isSecure == false -> "Enforcing with app_zygote attr-write anomaly"
+                    dirtyPolicyHit != null -> "Enforcing with dirty sepolicy rule"
 
-                    contextValidity?.isOracleUnavailable() == true ->
-                        "Enforcing with unavailable context oracle"
+                    contextValidity?.status == SelinuxContextValidityProbe.BITPAIR_SELF_TEST_FAILED ->
+                        if (repeatabilityFailed) {
+                            "Enforcing with unstable context oracle"
+                        } else {
+                            "Enforcing with untrusted context oracle"
+                        }
 
-                    contextValidity?.isOracleBlocked() == true -> "Enforcing with app_zygote SELinux query blocked"
-                    contextValidity?.isOracleSelfTestFailure() == true -> "Enforcing with untrusted context oracle"
-                    contextValidity?.isOracleUnstable() == true -> "Enforcing with unstable context oracle"
+                    contextValidity?.status == SelinuxContextValidityProbe.BITPAIR_AMBIGUOUS ->
+                        "Enforcing with context split"
+
                     report.auditIntegrity?.state == SelinuxAuditIntegrityState.EXPOSED -> "Enforcing with audit exposure"
                     report.policyAnalysis?.weakness == SelinuxPolicyWeakness.SEVERE -> "Enforcing with weak policy"
                     report.auditIntegrity?.state == SelinuxAuditIntegrityState.RESIDUE -> "Enforcing with audit risk"
@@ -104,9 +115,13 @@ class SelinuxCardModelMapper {
 
     private fun buildSummary(report: SelinuxReport): String {
         val contextValidity = contextValidityResult(report)
+        val procAttrCurrent = procAttrCurrentResult(report)
+        val dirtyPolicyHit = firstTrustedDirtyPolicyHit(report)
+        val repeatabilityFailed =
+            contextValidity?.details?.contains("repeatability failed", ignoreCase = true) == true
         return when (report.stage) {
             SelinuxStage.LOADING ->
-                "Checking sysfs, getenforce, and /proc/self/attr/current before deriving final mode with paradox logic."
+                "Checking sysfs, getenforce, /proc/self/attr/current, and app_zygote attr writes before deriving final mode with paradox logic."
 
             SelinuxStage.FAILED ->
                 report.errorMessage
@@ -131,6 +146,16 @@ class SelinuxCardModelMapper {
                         if (report.paradoxDetected) {
                             add("Permission-denied probes also reinforced the enforcing verdict.")
                         }
+                        if (procAttrCurrent?.isSecure == false) {
+                            add(
+                                "The dedicated app_zygote carrier hit anomalous /proc/self/attr/current write outcomes while probing privileged contexts: ${
+                                    procAttrCurrent.status.removePrefix("Detected: ")
+                                }.",
+                            )
+                        }
+                        if (dirtyPolicyHit != null) {
+                            add("A trusted DirtySepolicy-style access query reported ${dirtyPolicyHit.method.removePrefix("Dirty sepolicy rule: ")} as allowed.")
+                        }
                         when (report.auditIntegrity?.state) {
                             SelinuxAuditIntegrityState.TAMPERED ->
                                 add("Recent audit or log markers suggest logd output is being rewritten before apps inspect it.")
@@ -147,16 +172,31 @@ class SelinuxCardModelMapper {
                             SelinuxAuditIntegrityState.CLEAR, null -> Unit
                         }
                     }
-                    val contextNote = contextValiditySummaryNote(contextValidity)
-                    val unavailableNote = if (contextValidity?.isOracleUnavailable() == true) {
-                        "app_zygote carrier snapshot was unavailable."
-                    } else {
-                        null
+                    val contextNote = when (contextValidity?.status) {
+                        SelinuxContextValidityProbe.BITPAIR_KSU_PRESENT ->
+                            "The context validity oracle accepted both KSU-specific contexts from the current carrier."
+
+                        SelinuxContextValidityProbe.BITPAIR_CLEAN ->
+                            "The context validity oracle rejected both KSU-specific contexts in live policy."
+
+                        SelinuxContextValidityProbe.BITPAIR_SELF_TEST_FAILED ->
+                            if (repeatabilityFailed) {
+                                "The context validity oracle repeated inconsistently, so its KSU verdict was not trusted."
+                            } else {
+                                "The context validity oracle failed its self-test, so its KSU verdict was not trusted."
+                            }
+
+                        SelinuxContextValidityProbe.BITPAIR_AMBIGUOUS ->
+                            "The context validity oracle split across the two KSU-specific contexts."
+
+                        SelinuxContextValidityProbe.BITPAIR_UNSUPPORTED ->
+                            contextValidity.details ?: "The context validity oracle stayed unavailable."
+
+                        else -> null
                     }
                     listOf(base)
                         .plus(extra)
                         .plus(contextNote?.let { listOf(it) }.orEmpty())
-                        .plus(unavailableNote?.let { listOf(it) }.orEmpty())
                         .joinToString(" ")
                 }
 
@@ -262,6 +302,10 @@ class SelinuxCardModelMapper {
 
     private fun buildImpactItems(report: SelinuxReport): List<SelinuxImpactItemModel> {
         val contextValidity = contextValidityResult(report)
+        val procAttrCurrent = procAttrCurrentResult(report)
+        val dirtyPolicyHit = firstTrustedDirtyPolicyHit(report)
+        val repeatabilityFailed =
+            contextValidity?.details?.contains("repeatability failed", ignoreCase = true) == true
         if (report.stage != SelinuxStage.READY) {
             return when (report.stage) {
                 SelinuxStage.LOADING -> listOf(
@@ -367,33 +411,60 @@ class SelinuxCardModelMapper {
             }
         }
 
-        if (contextValidity?.isRootContextSignal() == true) {
-            items += SelinuxImpactItemModel(
-                "The app_zygote carrier validated root contexts in live policy.",
+        when (contextValidity?.status) {
+            SelinuxContextValidityProbe.BITPAIR_KSU_PRESENT -> items += SelinuxImpactItemModel(
+                "The app_zygote carrier validated both KSU-specific contexts in live policy.",
                 DetectorStatus.danger(),
             )
-        } else if (contextValidity?.isOracleUnavailable() == true) {
-            items += SelinuxImpactItemModel(
-                "The app_zygote context oracle was unavailable, so live policy checks could not be trusted.",
+
+            SelinuxContextValidityProbe.BITPAIR_CLEAN -> items += SelinuxImpactItemModel(
+                "The app_zygote carrier rejected both KSU-specific contexts.",
+                DetectorStatus.allClear(),
+            )
+
+            SelinuxContextValidityProbe.BITPAIR_SELF_TEST_FAILED -> items += SelinuxImpactItemModel(
+                if (repeatabilityFailed) {
+                    "The context validity oracle repeated inconsistently, so its KSU verdict was not trusted."
+                } else {
+                    "The context validity oracle failed its self-test, so its KSU verdict was not trusted."
+                },
+                DetectorStatus.warning(),
+            )
+
+            SelinuxContextValidityProbe.BITPAIR_AMBIGUOUS -> items += SelinuxImpactItemModel(
+                "The context validity oracle split across the two KSU-specific contexts.",
+                DetectorStatus.warning(),
+            )
+
+            SelinuxContextValidityProbe.BITPAIR_UNSUPPORTED -> items += SelinuxImpactItemModel(
+                contextValidity.details ?: "The context validity oracle stayed unavailable.",
                 DetectorStatus.info(InfoKind.SUPPORT),
             )
-        } else if (contextValidity?.isOracleBlocked() == true) {
-            items += SelinuxImpactItemModel(
-                "app_zygote SELinux context queries were blocked by policy, which is unexpected for the stock app_zygote domain.",
-                DetectorStatus.warning(),
+
+            else -> Unit
+        }
+        when {
+            procAttrCurrent?.isSecure == false -> items += SelinuxImpactItemModel(
+                "The dedicated app_zygote carrier observed anomalous /proc/self/attr/current writes for ${procAttrCurrent.status.removePrefix("Detected: ")}.",
+                DetectorStatus.danger(),
             )
-        } else if (contextValidity?.isOracleSelfTestFailure() == true) {
-            items += SelinuxImpactItemModel(
-                "The app_zygote context oracle failed its self-test, so root-context results were not trusted.",
-                DetectorStatus.warning(),
+
+            procAttrCurrent?.isSecure == true -> items += SelinuxImpactItemModel(
+                "The dedicated app_zygote carrier rejected the tested privileged contexts with normal EINVAL results.",
+                DetectorStatus.allClear(),
             )
-        } else if (contextValidity?.isOracleUnstable() == true) {
-            items += SelinuxImpactItemModel(
-                "The app_zygote context oracle repeated inconsistently, so root-context results were not trusted.",
-                DetectorStatus.warning(),
+
+            procAttrCurrent != null -> items += SelinuxImpactItemModel(
+                procAttrCurrent.details ?: "The dedicated app_zygote attr/current write probe stayed unavailable.",
+                DetectorStatus.info(InfoKind.SUPPORT),
             )
         }
-
+        if (dirtyPolicyHit != null) {
+            items += SelinuxImpactItemModel(
+                "A trusted DirtySepolicy-style access rule was allowed: ${dirtyPolicyHit.method.removePrefix("Dirty sepolicy rule: ")}.",
+                DetectorStatus.danger(),
+            )
+        }
         return items
     }
 
@@ -657,6 +728,7 @@ class SelinuxCardModelMapper {
             "Enforcing mode blocks disallowed actions instead of only logging them.",
             "Production Android devices are expected to run enforcing SELinux.",
             "app_zygote can query SELinux context validity through selinux_check_context, which ultimately writes to /sys/fs/selinux/context.",
+            "A dedicated app_zygote carrier can also probe privileged context materialization by writing candidate labels to /proc/self/attr/current and classifying non-EINVAL outcomes.",
             "Audit or log surfaces can be rewritten in user space, so missing suspicious tcontext values is not always proof.",
             "Readable AVC denial lines should be treated as audit-surface leakage, not as direct proof of a root process.",
             "comm, exe, path, and name fields inside AVC logs are supporting hints, not standalone proof of a live su daemon.",
@@ -685,12 +757,18 @@ class SelinuxCardModelMapper {
 
     private fun methodStatus(result: SelinuxCheckResult): DetectorStatus {
         if (result.method == SelinuxContextValidityProbe.METHOD_LABEL) {
+            return when (result.status) {
+                SelinuxContextValidityProbe.BITPAIR_KSU_PRESENT -> DetectorStatus.danger()
+                SelinuxContextValidityProbe.BITPAIR_CLEAN -> DetectorStatus.allClear()
+                SelinuxContextValidityProbe.BITPAIR_AMBIGUOUS -> DetectorStatus.warning()
+                SelinuxContextValidityProbe.BITPAIR_SELF_TEST_FAILED -> DetectorStatus.warning()
+                else -> DetectorStatus.info(InfoKind.SUPPORT)
+            }
+        }
+        if (result.method == SelinuxProcAttrCurrentProbe.METHOD_LABEL) {
             return when {
-                result.isRootContextSignal() -> DetectorStatus.danger()
-                result.isOracleBlocked() ||
-                        result.isOracleSelfTestFailure() ||
-                        result.isOracleUnstable() -> DetectorStatus.warning()
-
+                result.isSecure == false -> DetectorStatus.danger()
+                result.isSecure == true -> DetectorStatus.allClear()
                 else -> DetectorStatus.info(InfoKind.SUPPORT)
             }
         }
@@ -753,22 +831,25 @@ class SelinuxCardModelMapper {
         return report.methods.firstOrNull { it.method == SelinuxContextValidityProbe.METHOD_LABEL }
     }
 
+    private fun procAttrCurrentResult(report: SelinuxReport): SelinuxCheckResult? {
+        return report.methods.firstOrNull { it.method == SelinuxProcAttrCurrentProbe.METHOD_LABEL }
+    }
+
     private fun SelinuxReport.toDetectorStatus(): DetectorStatus {
         val contextValidity = contextValidityResult(this)
+        val procAttrCurrent = procAttrCurrentResult(this)
+        val dirtyPolicyHit = firstTrustedDirtyPolicyHit(this)
         return when (stage) {
             SelinuxStage.LOADING -> DetectorStatus.info(InfoKind.SUPPORT)
             SelinuxStage.FAILED -> DetectorStatus.info(InfoKind.ERROR)
             SelinuxStage.READY -> when (mode) {
                 SelinuxMode.ENFORCING -> when {
                     auditIntegrity?.state == SelinuxAuditIntegrityState.TAMPERED -> DetectorStatus.danger()
-                    contextValidity?.isRootContextSignal() == true -> DetectorStatus.danger()
-                    contextValidity?.isOracleBlocked() == true ||
-                            contextValidity?.isOracleSelfTestFailure() == true ||
-                            contextValidity?.isOracleUnstable() == true -> DetectorStatus.warning()
-
-                    contextValidity?.isOracleUnavailable() == true ->
-                        DetectorStatus.info(InfoKind.SUPPORT)
-
+                    contextValidity?.status == SelinuxContextValidityProbe.BITPAIR_KSU_PRESENT -> DetectorStatus.danger()
+                    procAttrCurrent?.isSecure == false -> DetectorStatus.danger()
+                    dirtyPolicyHit != null -> DetectorStatus.warning()
+                    contextValidity?.status == SelinuxContextValidityProbe.BITPAIR_SELF_TEST_FAILED -> DetectorStatus.warning()
+                    contextValidity?.status == SelinuxContextValidityProbe.BITPAIR_AMBIGUOUS -> DetectorStatus.warning()
                     policyAnalysis?.weakness == SelinuxPolicyWeakness.SEVERE ||
                             policyAnalysis?.weakness == SelinuxPolicyWeakness.MODERATE ||
                             auditIntegrity?.state == SelinuxAuditIntegrityState.EXPOSED ||
@@ -783,45 +864,11 @@ class SelinuxCardModelMapper {
         }
     }
 
-    private fun contextValiditySummaryNote(result: SelinuxCheckResult?): String? {
-        return when {
-            result == null -> null
-            result.isRootContextSignal() -> result.status
-            result.isOracleBlocked() ->
-                "app_zygote SELinux context queries were blocked by policy."
-
-            result.isOracleSelfTestFailure() ->
-                "Context validity oracle failed its self-test, so root context checks were not trusted."
-
-            result.isOracleUnstable() ->
-                "Context validity oracle repeated inconsistently, so root context checks were not trusted."
-
-            else -> null
+    private fun firstTrustedDirtyPolicyHit(report: SelinuxReport): SelinuxCheckResult? {
+        return report.methods.firstOrNull {
+            it.method.startsWith("Dirty sepolicy rule: ") &&
+                it.status == "Allowed" &&
+                it.isSecure == false
         }
-    }
-
-    private fun SelinuxCheckResult.isRootContextSignal(): Boolean {
-        return method == SelinuxContextValidityProbe.METHOD_LABEL &&
-                status == SelinuxContextValidityProbe.STATUS_ROOT_CONTEXT_FOUND
-    }
-
-    private fun SelinuxCheckResult.isOracleBlocked(): Boolean {
-        return method == SelinuxContextValidityProbe.METHOD_LABEL &&
-                status == SelinuxContextValidityProbe.STATUS_ORACLE_BLOCKED
-    }
-
-    private fun SelinuxCheckResult.isOracleSelfTestFailure(): Boolean {
-        return method == SelinuxContextValidityProbe.METHOD_LABEL &&
-                status == SelinuxContextValidityProbe.STATUS_ORACLE_SELF_TEST_FAILED
-    }
-
-    private fun SelinuxCheckResult.isOracleUnstable(): Boolean {
-        return method == SelinuxContextValidityProbe.METHOD_LABEL &&
-                status == SelinuxContextValidityProbe.STATUS_ORACLE_UNSTABLE
-    }
-
-    private fun SelinuxCheckResult.isOracleUnavailable(): Boolean {
-        return method == SelinuxContextValidityProbe.METHOD_LABEL &&
-                status == SelinuxContextValidityProbe.STATUS_ORACLE_UNAVAILABLE
     }
 }

--- a/app/src/test/java/com/eltavine/duckdetector/features/lsposed/data/probes/LSPosedDirtyPolicyProbeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/lsposed/data/probes/LSPosedDirtyPolicyProbeTest.kt
@@ -73,6 +73,7 @@ class LSPosedDirtyPolicyProbeTest {
                 dirtyPolicyAccessControlAllowed = true,
                 dirtyPolicyNegativeControlRejected = true,
                 dirtyPolicyMagiskBinderCallAllowed = true,
+                dirtyPolicyKsuFileReadAllowed = false,
                 dirtyPolicyLsposedFileReadAllowed = false,
             ),
         )
@@ -108,11 +109,11 @@ class LSPosedDirtyPolicyProbeTest {
             ),
         )
 
-        assertTrue(result.available)
-        assertEquals("LSPosed rule present", result.summary)
-        assertEquals(LSPosedMethodOutcome.DETECTED, result.outcome)
-        assertEquals(1, result.hitCount)
-        assertTrue(result.signals.any { it.label == "LSPosed file read" })
+        assertFalse(result.available)
+        assertEquals("Unavailable", result.summary)
+        assertEquals(LSPosedMethodOutcome.SUPPORT, result.outcome)
+        assertEquals(0, result.hitCount)
+        assertTrue(result.signals.isEmpty())
         assertTrue(result.detail.contains("controls=failed"))
     }
 

--- a/app/src/test/java/com/eltavine/duckdetector/features/selinux/data/native/SelinuxContextValidityBridgeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/selinux/data/native/SelinuxContextValidityBridgeTest.kt
@@ -16,8 +16,8 @@
 
 package com.eltavine.duckdetector.features.selinux.data.native
 
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxProcAttrCurrentResult
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -26,13 +26,18 @@ class SelinuxContextValidityBridgeTest {
     private val bridge = SelinuxContextValidityBridge()
 
     @Test
-    fun `parse decodes context validity and dirty policy snapshot`() {
+    fun `parse decodes context validity snapshot`() {
         val snapshot = bridge.parse(
             """
                 AVAILABLE=1
                 PROBE_ATTEMPTED=1
                 CARRIER_CONTEXT=u:r:app_zygote:s0:c1,c2
                 CARRIER_MATCHES_EXPECTED=1
+                SELINUX_ENABLED=1
+                SELINUX_ENFORCED=1
+                PID_CONTEXT_MATCHES_CURRENT=1
+                PROC_SELF_CONTEXT_MATCHES_CURRENT=1
+                DYNTRANSITION_CHECK_PASSED=1
                 CARRIER_CONTROL_VALID=1
                 NEGATIVE_CONTROL_REJECTED=1
                 FILE_CONTROL_VALID=1
@@ -42,7 +47,7 @@ class SelinuxContextValidityBridgeTest {
                 QUERY_METHOD=raw selinuxfs write
                 KSU_DOMAIN_VALID=1
                 KSU_FILE_VALID=0
-                MAGISK_FILE_VALID=0
+                BIT_PAIR=01/10
                 DIRTY_POLICY_AVAILABLE=1
                 DIRTY_POLICY_PROBE_ATTEMPTED=1
                 DIRTY_POLICY_CARRIER_CONTEXT=u:r:app_zygote:s0:c1,c2
@@ -52,13 +57,22 @@ class SelinuxContextValidityBridgeTest {
                 DIRTY_POLICY_QUERY_METHOD=android.os.SELinux.checkSELinuxAccess
                 DIRTY_POLICY_ACCESS_CONTROL_ALLOWED=1
                 DIRTY_POLICY_NEGATIVE_CONTROL_REJECTED=1
-                DIRTY_POLICY_SYSTEM_SERVER_EXECMEM_ALLOWED=0
-                DIRTY_POLICY_MAGISK_BINDER_CALL_ALLOWED=0
-                DIRTY_POLICY_KSU_BINDER_CALL_ALLOWED=0
+                DIRTY_POLICY_SYSTEM_SERVER_EXECMEM_ALLOWED=1
+                DIRTY_POLICY_FSCK_SYS_ADMIN_ALLOWED=0
+                DIRTY_POLICY_SHELL_SU_TRANSITION_ALLOWED=0
+                DIRTY_POLICY_ADBD_ADBROOT_BINDER_CALL_ALLOWED=1
+                DIRTY_POLICY_MAGISK_BINDER_CALL_ALLOWED=1
+                DIRTY_POLICY_KSU_FILE_READ_ALLOWED=0
                 DIRTY_POLICY_LSPOSED_FILE_READ_ALLOWED=1
-                DIRTY_POLICY_FAILURE_REASON=Dirty\npolicy unavailable
-                DIRTY_POLICY_NOTE=Carrier\ncontext: u:r:app_zygote:s0
-                DIRTY_POLICY_NOTE=LSPosed\tpolicy\nread
+                DIRTY_POLICY_XPOSED_DATA_FILE_READ_ALLOWED=0
+                DIRTY_POLICY_ZYGOTE_ADB_DATA_SEARCH_ALLOWED=1
+                DIRTY_POLICY_FAILURE_REASON=Dirty policy oracle self-test failed.
+                DIRTY_POLICY_NOTE=system_server execmem=allowed
+                PROC_ATTR_CURRENT_PROBE_ATTEMPTED=1
+                PROC_ATTR_CURRENT_RESULT=KernelSU\tu:r:ksu:s0\tNORMAL_EINVAL\tErrnoException: errno=22, Invalid argument
+                PROC_ATTR_CURRENT_RESULT=Magisk\tu:r:magisk:s0\tDETECTED_NON_EINVAL\tErrnoException: errno=13, Permission denied
+                PROC_ATTR_CURRENT_FAILURE_REASON=Carrier self-check did not establish a trusted app_zygote context.
+                FAILURE_REASON=Carrier\ncontext unavailable
                 NOTE=Carrier\ncontext: u:r:app_zygote:s0
                 NOTE=Query\tmethod\nraw selinuxfs write
             """.trimIndent(),
@@ -68,6 +82,11 @@ class SelinuxContextValidityBridgeTest {
         assertTrue(snapshot.probeAttempted)
         assertEquals("u:r:app_zygote:s0:c1,c2", snapshot.carrierContext)
         assertTrue(snapshot.carrierMatchesExpected)
+        assertTrue(snapshot.selinuxEnabled == true)
+        assertTrue(snapshot.selinuxEnforced == true)
+        assertTrue(snapshot.pidContextMatchesCurrent == true)
+        assertTrue(snapshot.procSelfContextMatchesCurrent == true)
+        assertTrue(snapshot.dyntransitionCheckPassed == true)
         assertTrue(snapshot.carrierControlValid == true)
         assertTrue(snapshot.negativeControlRejected == true)
         assertTrue(snapshot.fileControlValid == true)
@@ -77,7 +96,7 @@ class SelinuxContextValidityBridgeTest {
         assertEquals("raw selinuxfs write", snapshot.queryMethod)
         assertEquals(true, snapshot.ksuDomainValid)
         assertEquals(false, snapshot.ksuFileValid)
-        assertEquals(false, snapshot.magiskFileValid)
+        assertEquals("01/10", snapshot.bitPair)
         assertTrue(snapshot.dirtyPolicyAvailable)
         assertTrue(snapshot.dirtyPolicyProbeAttempted)
         assertEquals("u:r:app_zygote:s0:c1,c2", snapshot.dirtyPolicyCarrierContext)
@@ -85,20 +104,42 @@ class SelinuxContextValidityBridgeTest {
         assertTrue(snapshot.dirtyPolicyControlsPassed)
         assertTrue(snapshot.dirtyPolicyStable)
         assertEquals("android.os.SELinux.checkSELinuxAccess", snapshot.dirtyPolicyQueryMethod)
-        assertTrue(snapshot.dirtyPolicyAccessControlAllowed == true)
-        assertTrue(snapshot.dirtyPolicyNegativeControlRejected == true)
-        assertTrue(snapshot.dirtyPolicySystemServerExecmemAllowed == false)
-        assertTrue(snapshot.dirtyPolicyMagiskBinderCallAllowed == false)
-        assertTrue(snapshot.dirtyPolicyKsuBinderCallAllowed == false)
-        assertTrue(snapshot.dirtyPolicyLsposedFileReadAllowed == true)
-        assertEquals("Dirty\npolicy unavailable", snapshot.dirtyPolicyFailureReason)
+        assertEquals(true, snapshot.dirtyPolicyAccessControlAllowed)
+        assertEquals(true, snapshot.dirtyPolicyNegativeControlRejected)
+        assertEquals(true, snapshot.dirtyPolicySystemServerExecmemAllowed)
+        assertEquals(false, snapshot.dirtyPolicyFsckSysAdminAllowed)
+        assertEquals(false, snapshot.dirtyPolicyShellSuTransitionAllowed)
+        assertEquals(true, snapshot.dirtyPolicyAdbdAdbrootBinderCallAllowed)
+        assertEquals(true, snapshot.dirtyPolicyMagiskBinderCallAllowed)
+        assertEquals(false, snapshot.dirtyPolicyKsuFileReadAllowed)
+        assertEquals(true, snapshot.dirtyPolicyLsposedFileReadAllowed)
+        assertEquals(false, snapshot.dirtyPolicyXposedDataFileReadAllowed)
+        assertEquals(true, snapshot.dirtyPolicyZygoteAdbDataSearchAllowed)
+        assertEquals("Dirty policy oracle self-test failed.", snapshot.dirtyPolicyFailureReason)
+        assertEquals(listOf("system_server execmem=allowed"), snapshot.dirtyPolicyNotes)
+        assertEquals(true, snapshot.procAttrCurrentProbeAttempted)
         assertEquals(
             listOf(
-                "Carrier\ncontext: u:r:app_zygote:s0",
-                "LSPosed\tpolicy\nread",
+                SelinuxProcAttrCurrentResult(
+                    label = "KernelSU",
+                    targetContext = "u:r:ksu:s0",
+                    outcomeClass = SelinuxProcAttrCurrentResult.OUTCOME_NORMAL_EINVAL,
+                    rawMessage = "ErrnoException: errno=22, Invalid argument",
+                ),
+                SelinuxProcAttrCurrentResult(
+                    label = "Magisk",
+                    targetContext = "u:r:magisk:s0",
+                    outcomeClass = SelinuxProcAttrCurrentResult.OUTCOME_DETECTED_NON_EINVAL,
+                    rawMessage = "ErrnoException: errno=13, Permission denied",
+                ),
             ),
-            snapshot.dirtyPolicyNotes,
+            snapshot.procAttrCurrentResults,
         )
+        assertEquals(
+            "Carrier self-check did not establish a trusted app_zygote context.",
+            snapshot.procAttrCurrentFailureReason,
+        )
+        assertEquals("Carrier\ncontext unavailable", snapshot.failureReason)
         assertEquals(
             listOf(
                 "Carrier\ncontext: u:r:app_zygote:s0",
@@ -106,39 +147,5 @@ class SelinuxContextValidityBridgeTest {
             ),
             snapshot.notes,
         )
-    }
-
-    @Test
-    fun `parse rejects unrecognized payload`() {
-        val snapshot = bridge.parse(
-            """
-                ???
-                not a payload
-                garbage=still garbage
-            """.trimIndent(),
-        )
-
-        assertFalse(snapshot.available)
-        assertEquals("SELinux context validity payload was unrecognized.", snapshot.failureReason)
-        assertEquals("SELinux context validity payload was unrecognized.", snapshot.dirtyPolicyFailureReason)
-        assertTrue(snapshot.notes.any { it.contains("parser rejected", ignoreCase = true) })
-        assertTrue(snapshot.dirtyPolicyNotes.any { it.contains("parser rejected", ignoreCase = true) })
-    }
-
-    @Test
-    fun `parse rejects incomplete availability claims`() {
-        val snapshot = bridge.parse(
-            """
-                AVAILABLE=1
-                PROBE_ATTEMPTED=1
-                CARRIER_MATCHES_EXPECTED=1
-                ORACLE_CONTROLS_PASSED=1
-                KSU_RESULTS_STABLE=1
-            """.trimIndent(),
-        )
-
-        assertFalse(snapshot.available)
-        assertEquals("SELinux context validity payload was incomplete.", snapshot.failureReason)
-        assertEquals("SELinux context validity payload was incomplete.", snapshot.dirtyPolicyFailureReason)
     }
 }

--- a/app/src/test/java/com/eltavine/duckdetector/features/selinux/data/native/SelinuxContextValidityPayloadCodecTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/selinux/data/native/SelinuxContextValidityPayloadCodecTest.kt
@@ -16,6 +16,7 @@
 
 package com.eltavine.duckdetector.features.selinux.data.native
 
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxProcAttrCurrentResult
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -31,6 +32,11 @@ class SelinuxContextValidityPayloadCodecTest {
             probeAttempted = true,
             carrierContext = "u:r:app_zygote:s0:c1,c2",
             carrierMatchesExpected = true,
+            selinuxEnabled = true,
+            selinuxEnforced = true,
+            pidContextMatchesCurrent = true,
+            procSelfContextMatchesCurrent = true,
+            dyntransitionCheckPassed = true,
             carrierControlValid = true,
             negativeControlRejected = true,
             fileControlValid = true,
@@ -40,7 +46,7 @@ class SelinuxContextValidityPayloadCodecTest {
             queryMethod = "raw selinuxfs write",
             ksuDomainValid = true,
             ksuFileValid = false,
-            magiskFileValid = false,
+            bitPair = "11",
             dirtyPolicyAvailable = true,
             dirtyPolicyProbeAttempted = true,
             dirtyPolicyCarrierContext = "u:r:app_zygote:s0:c1,c2",
@@ -50,15 +56,33 @@ class SelinuxContextValidityPayloadCodecTest {
             dirtyPolicyQueryMethod = "android.os.SELinux.checkSELinuxAccess",
             dirtyPolicyAccessControlAllowed = true,
             dirtyPolicyNegativeControlRejected = true,
-            dirtyPolicySystemServerExecmemAllowed = false,
-            dirtyPolicyMagiskBinderCallAllowed = false,
-            dirtyPolicyKsuBinderCallAllowed = false,
+            dirtyPolicySystemServerExecmemAllowed = true,
+            dirtyPolicyFsckSysAdminAllowed = false,
+            dirtyPolicyShellSuTransitionAllowed = false,
+            dirtyPolicyAdbdAdbrootBinderCallAllowed = true,
+            dirtyPolicyMagiskBinderCallAllowed = true,
+            dirtyPolicyKsuFileReadAllowed = false,
             dirtyPolicyLsposedFileReadAllowed = true,
-            dirtyPolicyFailureReason = "Dirty\npolicy unavailable",
-            dirtyPolicyNotes = listOf(
-                "Carrier context: u:r:app_zygote:s0",
-                "LSPosed\tpolicy\nread",
+            dirtyPolicyXposedDataFileReadAllowed = false,
+            dirtyPolicyZygoteAdbDataSearchAllowed = true,
+            dirtyPolicyFailureReason = "Dirty policy oracle self-test failed.",
+            dirtyPolicyNotes = listOf("system_server execmem=allowed"),
+            procAttrCurrentProbeAttempted = true,
+            procAttrCurrentResults = listOf(
+                SelinuxProcAttrCurrentResult(
+                    label = "KernelSU",
+                    targetContext = "u:r:ksu:s0",
+                    outcomeClass = SelinuxProcAttrCurrentResult.OUTCOME_NORMAL_EINVAL,
+                    rawMessage = "ErrnoException: errno=22, Invalid argument",
+                ),
+                SelinuxProcAttrCurrentResult(
+                    label = "Magisk",
+                    targetContext = "u:r:magisk:s0",
+                    outcomeClass = SelinuxProcAttrCurrentResult.OUTCOME_DETECTED_NON_EINVAL,
+                    rawMessage = "ErrnoException: errno=13, Permission denied",
+                ),
             ),
+            procAttrCurrentFailureReason = "Carrier self-check did not establish a trusted app_zygote context.",
             failureReason = "Carrier\ncontext unavailable",
             notes = listOf(
                 "Carrier context: u:r:app_zygote:s0",
@@ -72,6 +96,11 @@ class SelinuxContextValidityPayloadCodecTest {
         assertTrue(parsed.probeAttempted)
         assertEquals(snapshot.carrierContext, parsed.carrierContext)
         assertTrue(parsed.carrierMatchesExpected)
+        assertTrue(parsed.selinuxEnabled == true)
+        assertTrue(parsed.selinuxEnforced == true)
+        assertTrue(parsed.pidContextMatchesCurrent == true)
+        assertTrue(parsed.procSelfContextMatchesCurrent == true)
+        assertTrue(parsed.dyntransitionCheckPassed == true)
         assertTrue(parsed.carrierControlValid == true)
         assertTrue(parsed.negativeControlRejected == true)
         assertTrue(parsed.fileControlValid == true)
@@ -81,7 +110,7 @@ class SelinuxContextValidityPayloadCodecTest {
         assertEquals(snapshot.queryMethod, parsed.queryMethod)
         assertTrue(parsed.ksuDomainValid == true)
         assertTrue(parsed.ksuFileValid == false)
-        assertTrue(parsed.magiskFileValid == false)
+        assertEquals(snapshot.bitPair, parsed.bitPair)
         assertTrue(parsed.dirtyPolicyAvailable)
         assertTrue(parsed.dirtyPolicyProbeAttempted)
         assertEquals(snapshot.dirtyPolicyCarrierContext, parsed.dirtyPolicyCarrierContext)
@@ -89,14 +118,22 @@ class SelinuxContextValidityPayloadCodecTest {
         assertTrue(parsed.dirtyPolicyControlsPassed)
         assertTrue(parsed.dirtyPolicyStable)
         assertEquals(snapshot.dirtyPolicyQueryMethod, parsed.dirtyPolicyQueryMethod)
-        assertTrue(parsed.dirtyPolicyAccessControlAllowed == true)
-        assertTrue(parsed.dirtyPolicyNegativeControlRejected == true)
-        assertTrue(parsed.dirtyPolicySystemServerExecmemAllowed == false)
-        assertTrue(parsed.dirtyPolicyMagiskBinderCallAllowed == false)
-        assertTrue(parsed.dirtyPolicyKsuBinderCallAllowed == false)
-        assertTrue(parsed.dirtyPolicyLsposedFileReadAllowed == true)
+        assertEquals(snapshot.dirtyPolicyAccessControlAllowed, parsed.dirtyPolicyAccessControlAllowed)
+        assertEquals(snapshot.dirtyPolicyNegativeControlRejected, parsed.dirtyPolicyNegativeControlRejected)
+        assertEquals(snapshot.dirtyPolicySystemServerExecmemAllowed, parsed.dirtyPolicySystemServerExecmemAllowed)
+        assertEquals(snapshot.dirtyPolicyFsckSysAdminAllowed, parsed.dirtyPolicyFsckSysAdminAllowed)
+        assertEquals(snapshot.dirtyPolicyShellSuTransitionAllowed, parsed.dirtyPolicyShellSuTransitionAllowed)
+        assertEquals(snapshot.dirtyPolicyAdbdAdbrootBinderCallAllowed, parsed.dirtyPolicyAdbdAdbrootBinderCallAllowed)
+        assertEquals(snapshot.dirtyPolicyMagiskBinderCallAllowed, parsed.dirtyPolicyMagiskBinderCallAllowed)
+        assertEquals(snapshot.dirtyPolicyKsuFileReadAllowed, parsed.dirtyPolicyKsuFileReadAllowed)
+        assertEquals(snapshot.dirtyPolicyLsposedFileReadAllowed, parsed.dirtyPolicyLsposedFileReadAllowed)
+        assertEquals(snapshot.dirtyPolicyXposedDataFileReadAllowed, parsed.dirtyPolicyXposedDataFileReadAllowed)
+        assertEquals(snapshot.dirtyPolicyZygoteAdbDataSearchAllowed, parsed.dirtyPolicyZygoteAdbDataSearchAllowed)
         assertEquals(snapshot.dirtyPolicyFailureReason, parsed.dirtyPolicyFailureReason)
         assertEquals(snapshot.dirtyPolicyNotes, parsed.dirtyPolicyNotes)
+        assertTrue(parsed.procAttrCurrentProbeAttempted)
+        assertEquals(snapshot.procAttrCurrentResults, parsed.procAttrCurrentResults)
+        assertEquals(snapshot.procAttrCurrentFailureReason, parsed.procAttrCurrentFailureReason)
         assertEquals(snapshot.failureReason, parsed.failureReason)
         assertEquals(snapshot.notes, parsed.notes)
     }

--- a/app/src/test/java/com/eltavine/duckdetector/features/selinux/data/probes/SelinuxContextValidityProbeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/selinux/data/probes/SelinuxContextValidityProbeTest.kt
@@ -16,91 +16,184 @@
 
 package com.eltavine.duckdetector.features.selinux.data.probes
 
+import com.eltavine.duckdetector.features.selinux.data.native.SelinuxContextValidityBridge
 import com.eltavine.duckdetector.features.selinux.data.native.SelinuxContextValiditySnapshot
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class SelinuxContextValidityProbeTest {
 
-    private val probe = SelinuxContextValidityProbe()
-
     @Test
-    fun `unavailable carrier snapshot is not treated as clean`() {
-        val result = probe.interpret(
-            SelinuxContextValiditySnapshot(
-                failureReason = "SELinux context validity payload was unrecognized.",
-            ),
-        )
-
-        assertEquals(SelinuxContextValidityState.UNAVAILABLE, result.state)
-    }
-
-    @Test
-    fun `trusted stable root context maps to root present`() {
-        val result = probe.interpret(
-            trustedSnapshot(
-                ksuDomainValid = true,
-            ),
-        )
-
-        assertEquals(SelinuxContextValidityState.ROOT_PRESENT, result.state)
-    }
-
-    @Test
-    fun `self test failure is not treated as clean or root present`() {
-        val result = probe.interpret(
-            trustedSnapshot(
-                oracleControlsPassed = false,
-                ksuDomainValid = true,
-            ),
-        )
-
-        assertEquals(SelinuxContextValidityState.UNTRUSTED_ORACLE, result.state)
-    }
-
-    @Test
-    fun `permission denied self test maps to blocked oracle`() {
-        val result = probe.interpret(
-            trustedSnapshot(
-                oracleControlsPassed = false,
-                ksuDomainValid = true,
-            ).copy(
-                notes = listOf(
-                    "Unavailable: u:r:app_zygote:s0 errno=Permission denied",
+    fun `clean snapshot maps to strong clean state`() {
+        val result = SelinuxContextValidityProbe(
+            nativeBridge = FakeSelinuxContextValidityBridge(
+                SelinuxContextValiditySnapshot(
+                    available = true,
+                    probeAttempted = true,
+                    carrierContext = "u:r:app_zygote:s0:c1,c2",
+                    carrierMatchesExpected = true,
+                    selinuxEnabled = true,
+                    selinuxEnforced = true,
+                    pidContextMatchesCurrent = true,
+                    procSelfContextMatchesCurrent = true,
+                    dyntransitionCheckPassed = true,
+                    carrierControlValid = true,
+                    negativeControlRejected = true,
+                    fileControlValid = true,
+                    fileNegativeControlRejected = true,
+                    oracleControlsPassed = true,
+                    ksuResultsStable = true,
+                    queryMethod = "raw selinuxfs write",
+                    ksuDomainValid = false,
+                    ksuFileValid = false,
+                    bitPair = SelinuxContextValidityProbe.BITPAIR_CLEAN,
+                    procAttrCurrentProbeAttempted = true,
+                    procAttrCurrentResults = listOf(
+                        SelinuxProcAttrCurrentResult(
+                            label = "KernelSU",
+                            targetContext = "u:r:ksu:s0",
+                            outcomeClass = SelinuxProcAttrCurrentResult.OUTCOME_NORMAL_EINVAL,
+                            rawMessage = "ErrnoException: errno=22, Invalid argument",
+                        ),
+                    ),
+                    notes = listOf("Carrier context: u:r:app_zygote:s0:c1,c2"),
                 ),
             ),
-        )
+        ).inspect()
 
-        assertEquals(SelinuxContextValidityState.BLOCKED_ORACLE, result.state)
+        assertEquals(SelinuxContextValidityState.CLEAN, result.state)
+        assertEquals(SelinuxContextValidityProbe.BITPAIR_CLEAN, result.bitPair)
+        assertEquals(true, result.selinuxEnabled)
+        assertEquals(true, result.selinuxEnforced)
+        assertEquals(true, result.procAttrCurrentProbeAttempted)
+        assertEquals(1, result.procAttrCurrentResults.size)
+        assertTrue(result.notes.any { it.contains("Bit pair 00") })
     }
 
     @Test
-    fun `unstable root result is not treated as clean or root present`() {
-        val result = probe.interpret(
-            trustedSnapshot(
-                ksuResultsStable = false,
-                ksuDomainValid = true,
+    fun `ksu snapshot maps to strong ksu state`() {
+        val result = SelinuxContextValidityProbe(
+            nativeBridge = FakeSelinuxContextValidityBridge(
+                SelinuxContextValiditySnapshot(
+                    available = true,
+                    probeAttempted = true,
+                    carrierContext = "u:r:app_zygote:s0:c1,c2",
+                    carrierMatchesExpected = true,
+                    carrierControlValid = true,
+                    negativeControlRejected = true,
+                    fileControlValid = true,
+                    fileNegativeControlRejected = true,
+                    oracleControlsPassed = true,
+                    ksuResultsStable = true,
+                    queryMethod = "raw selinuxfs write",
+                    ksuDomainValid = true,
+                    ksuFileValid = true,
+                    bitPair = SelinuxContextValidityProbe.BITPAIR_KSU_PRESENT,
+                    notes = listOf("Carrier context: u:r:app_zygote:s0:c1,c2"),
+                ),
             ),
-        )
+        ).inspect()
 
-        assertEquals(SelinuxContextValidityState.UNSTABLE_RESULTS, result.state)
+        assertEquals(SelinuxContextValidityState.KSU_PRESENT, result.state)
+        assertEquals(SelinuxContextValidityProbe.BITPAIR_KSU_PRESENT, result.bitPair)
+        assertTrue(result.notes.any { it.contains("Bit pair 11") })
     }
 
-    private fun trustedSnapshot(
-        oracleControlsPassed: Boolean = true,
-        ksuResultsStable: Boolean = true,
-        ksuDomainValid: Boolean? = false,
-    ): SelinuxContextValiditySnapshot {
-        return SelinuxContextValiditySnapshot(
-            available = true,
-            probeAttempted = true,
-            carrierContext = "u:r:app_zygote:s0:c1,c2",
-            carrierMatchesExpected = true,
-            oracleControlsPassed = oracleControlsPassed,
-            ksuResultsStable = ksuResultsStable,
-            ksuDomainValid = ksuDomainValid,
-            ksuFileValid = false,
-            magiskFileValid = false,
-        )
+    @Test
+    fun `failed oracle controls are not interpreted as ksu or clean`() {
+        val result = SelinuxContextValidityProbe(
+            nativeBridge = FakeSelinuxContextValidityBridge(
+                SelinuxContextValiditySnapshot(
+                    available = true,
+                    probeAttempted = true,
+                    carrierContext = "u:r:app_zygote:s0:c1,c2",
+                    carrierMatchesExpected = true,
+                    carrierControlValid = true,
+                    negativeControlRejected = false,
+                    fileControlValid = true,
+                    fileNegativeControlRejected = false,
+                    oracleControlsPassed = false,
+                    ksuResultsStable = false,
+                    queryMethod = "raw selinuxfs write",
+                    failureReason = "Context validity oracle self-test failed.",
+                    notes = listOf("Negative control accepted"),
+                ),
+            ),
+        ).inspect()
+
+        assertEquals(SelinuxContextValidityState.INCONSISTENT, result.state)
+        assertTrue(result.notes.any { it.contains("not trusted") })
+    }
+
+    @Test
+    fun `repeatability failure is not interpreted as clean or ksu`() {
+        val result = SelinuxContextValidityProbe(
+            nativeBridge = FakeSelinuxContextValidityBridge(
+                SelinuxContextValiditySnapshot(
+                    available = true,
+                    probeAttempted = true,
+                    carrierContext = "u:r:app_zygote:s0:c1,c2",
+                    carrierMatchesExpected = true,
+                    carrierControlValid = true,
+                    negativeControlRejected = true,
+                    fileControlValid = true,
+                    fileNegativeControlRejected = true,
+                    oracleControlsPassed = true,
+                    ksuResultsStable = false,
+                    queryMethod = "raw selinuxfs write",
+                    failureReason = "Context validity oracle repeatability failed.",
+                    notes = listOf("The KSU-specific context verdict changed across repeated writes, so it was not trusted."),
+                ),
+            ),
+        ).inspect()
+
+        assertEquals(SelinuxContextValidityState.INCONSISTENT, result.state)
+        assertTrue(result.failureReason?.contains("repeatability failed") == true)
+        assertTrue(result.notes.any { it.contains("not trusted") })
+    }
+
+    @Test
+    fun `non app zygote carrier stays unavailable`() {
+        val result = SelinuxContextValidityProbe(
+            nativeBridge = FakeSelinuxContextValidityBridge(
+                SelinuxContextValiditySnapshot(
+                    available = true,
+                    probeAttempted = false,
+                    carrierContext = "u:r:untrusted_app:s0:c1,c2",
+                    carrierMatchesExpected = false,
+                    failureReason = "Carrier context is not app_zygote.",
+                    notes = listOf("The oracle is only meaningful from an app_zygote carrier."),
+                ),
+            ),
+        ).inspect()
+
+        assertEquals(SelinuxContextValidityState.UNAVAILABLE, result.state)
+        assertTrue(result.failureReason?.contains("app_zygote") == true)
+    }
+
+    @Test
+    fun `app zygote like prefix does not pass carrier gate`() {
+        val result = SelinuxContextValidityProbe(
+            nativeBridge = FakeSelinuxContextValidityBridge(
+                SelinuxContextValiditySnapshot(
+                    available = true,
+                    probeAttempted = false,
+                    carrierContext = "u:r:app_zygote_helper:s0",
+                    carrierMatchesExpected = false,
+                    failureReason = "Carrier context is not app_zygote.",
+                    notes = listOf("The oracle is only meaningful from an app_zygote carrier."),
+                ),
+            ),
+        ).inspect()
+
+        assertEquals(SelinuxContextValidityState.UNAVAILABLE, result.state)
+        assertTrue(result.failureReason?.contains("app_zygote") == true)
+    }
+
+    private class FakeSelinuxContextValidityBridge(
+        private val snapshot: SelinuxContextValiditySnapshot,
+    ) : SelinuxContextValidityBridge() {
+        override fun collectSnapshot(): SelinuxContextValiditySnapshot = snapshot
     }
 }

--- a/app/src/test/java/com/eltavine/duckdetector/features/selinux/data/probes/SelinuxProcAttrCurrentPayloadCodecTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/selinux/data/probes/SelinuxProcAttrCurrentPayloadCodecTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.selinux.data.probes
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class SelinuxProcAttrCurrentPayloadCodecTest {
+
+    @Test
+    fun `round trips proc attr current result`() {
+        val result = SelinuxProcAttrCurrentResult(
+            label = "Magisk",
+            targetContext = "u:r:magisk:s0",
+            outcomeClass = SelinuxProcAttrCurrentResult.OUTCOME_DETECTED_NON_EINVAL,
+            rawMessage = "ErrnoException: errno=13, Permission denied",
+        )
+
+        val decoded = SelinuxProcAttrCurrentPayloadCodec.decode(
+            SelinuxProcAttrCurrentPayloadCodec.encode(result),
+        )
+
+        assertNotNull(decoded)
+        assertEquals(result, decoded)
+    }
+}

--- a/app/src/test/java/com/eltavine/duckdetector/features/selinux/data/repository/SelinuxRepositoryDirtyPolicyMethodsTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/selinux/data/repository/SelinuxRepositoryDirtyPolicyMethodsTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.selinux.data.repository
+
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxContextValidityProbeResult
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxContextValidityState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SelinuxRepositoryDirtyPolicyMethodsTest {
+
+    private val repository = SelinuxRepository()
+
+    @Test
+    fun `dirty policy methods expose explicit rule rows`() {
+        val methods = repository.buildDirtyPolicyMethods(
+            SelinuxContextValidityProbeResult(
+                state = SelinuxContextValidityState.CLEAN,
+                available = true,
+                probeAttempted = true,
+                carrierContext = "u:r:app_zygote:s0:c1,c2",
+                carrierMatchesExpected = true,
+                selinuxEnabled = true,
+                selinuxEnforced = true,
+                pidContextMatchesCurrent = true,
+                procSelfContextMatchesCurrent = true,
+                dyntransitionCheckPassed = true,
+                carrierControlValid = true,
+                negativeControlRejected = true,
+                fileControlValid = true,
+                fileNegativeControlRejected = true,
+                oracleControlsPassed = true,
+                ksuResultsStable = true,
+                queryMethod = "raw selinuxfs write",
+                ksuDomainValid = false,
+                ksuFileValid = false,
+                bitPair = "00",
+                dirtyPolicyAvailable = true,
+                dirtyPolicyProbeAttempted = true,
+                dirtyPolicyCarrierContext = "u:r:app_zygote:s0:c1,c2",
+                dirtyPolicyCarrierMatchesExpected = true,
+                dirtyPolicyControlsPassed = true,
+                dirtyPolicyStable = true,
+                dirtyPolicyQueryMethod = "android.os.SELinux.checkSELinuxAccess",
+                dirtyPolicyAccessControlAllowed = true,
+                dirtyPolicyNegativeControlRejected = true,
+                dirtyPolicySystemServerExecmemAllowed = true,
+                dirtyPolicyFsckSysAdminAllowed = false,
+                dirtyPolicyShellSuTransitionAllowed = null,
+                dirtyPolicyAdbdAdbrootBinderCallAllowed = true,
+                dirtyPolicyMagiskBinderCallAllowed = false,
+                dirtyPolicyKsuFileReadAllowed = false,
+                dirtyPolicyLsposedFileReadAllowed = true,
+                dirtyPolicyXposedDataFileReadAllowed = false,
+                dirtyPolicyZygoteAdbDataSearchAllowed = true,
+                dirtyPolicyFailureReason = "shell -> su transition skipped on non-user build.",
+                dirtyPolicyNotes = emptyList(),
+                procAttrCurrentProbeAttempted = false,
+                procAttrCurrentResults = emptyList(),
+                procAttrCurrentFailureReason = null,
+                failureReason = null,
+                notes = emptyList(),
+            ),
+        )
+
+        assertEquals(9, methods.size)
+        assertTrue(methods.any { it.method == "Dirty sepolicy rule: system_server execmem" && it.status == "Allowed" && it.isSecure == false })
+        assertTrue(methods.any { it.method == "Dirty sepolicy rule: fsck_untrusted sys_admin" && it.status == "Denied" && it.isSecure == true })
+        assertTrue(methods.any { it.method == "Dirty sepolicy rule: shell -> su transition" && it.status == "Unavailable" && it.isSecure == null })
+        assertTrue(methods.any { it.method == "Dirty sepolicy rule: adbd -> adbroot binder" && it.status == "Allowed" && it.isSecure == false })
+        assertTrue(methods.any { it.method == "Dirty sepolicy rule: untrusted_app -> magisk binder" && it.status == "Denied" && it.isSecure == true })
+        assertTrue(methods.any { it.method == "Dirty sepolicy rule: untrusted_app -> ksu_file read" && it.status == "Denied" && it.isSecure == true })
+        assertTrue(methods.any { it.method == "Dirty sepolicy rule: untrusted_app -> lsposed_file read" && it.status == "Allowed" && it.isSecure == false })
+        assertTrue(methods.any { it.method == "Dirty sepolicy rule: untrusted_app -> xposed_data read" && it.status == "Denied" && it.isSecure == true })
+        assertTrue(methods.any { it.method == "Dirty sepolicy rule: zygote -> adb_data_file search" && it.status == "Allowed" && it.isSecure == false })
+        assertTrue(methods.any { it.method == "Dirty sepolicy rule: system_server execmem" && it.details.orEmpty().contains("Evidence source=dedicated app_zygote carrier") && it.details.orEmpty().contains("Observed edge:") })
+        assertTrue(methods.any { it.method == "Dirty sepolicy rule: shell -> su transition" && it.details.orEmpty().contains("Reason:") })
+    }
+
+    @Test
+    fun `untrusted dirty policy oracle downgrades all rule rows to unavailable`() {
+        val methods = repository.buildDirtyPolicyMethods(
+            SelinuxContextValidityProbeResult(
+                state = SelinuxContextValidityState.CLEAN,
+                available = true,
+                probeAttempted = true,
+                carrierContext = "u:r:app_zygote:s0:c1,c2",
+                carrierMatchesExpected = true,
+                selinuxEnabled = true,
+                selinuxEnforced = true,
+                pidContextMatchesCurrent = true,
+                procSelfContextMatchesCurrent = true,
+                dyntransitionCheckPassed = true,
+                carrierControlValid = true,
+                negativeControlRejected = true,
+                fileControlValid = true,
+                fileNegativeControlRejected = true,
+                oracleControlsPassed = true,
+                ksuResultsStable = true,
+                queryMethod = "raw selinuxfs write",
+                ksuDomainValid = false,
+                ksuFileValid = false,
+                bitPair = "00",
+                dirtyPolicyAvailable = true,
+                dirtyPolicyProbeAttempted = true,
+                dirtyPolicyCarrierContext = "u:r:app_zygote:s0:c1,c2",
+                dirtyPolicyCarrierMatchesExpected = true,
+                dirtyPolicyControlsPassed = false,
+                dirtyPolicyStable = false,
+                dirtyPolicyQueryMethod = "android.os.SELinux.checkSELinuxAccess",
+                dirtyPolicyAccessControlAllowed = false,
+                dirtyPolicyNegativeControlRejected = false,
+                dirtyPolicySystemServerExecmemAllowed = true,
+                dirtyPolicyFsckSysAdminAllowed = true,
+                dirtyPolicyShellSuTransitionAllowed = true,
+                dirtyPolicyAdbdAdbrootBinderCallAllowed = true,
+                dirtyPolicyMagiskBinderCallAllowed = true,
+                dirtyPolicyKsuFileReadAllowed = true,
+                dirtyPolicyLsposedFileReadAllowed = true,
+                dirtyPolicyXposedDataFileReadAllowed = true,
+                dirtyPolicyZygoteAdbDataSearchAllowed = true,
+                dirtyPolicyFailureReason = "Dirty policy oracle self-test failed.",
+                dirtyPolicyNotes = emptyList(),
+                procAttrCurrentProbeAttempted = false,
+                procAttrCurrentResults = emptyList(),
+                procAttrCurrentFailureReason = null,
+                failureReason = null,
+                notes = emptyList(),
+            ),
+        )
+
+        assertEquals(9, methods.size)
+        assertTrue(methods.all { it.status == "Unavailable" && it.isSecure == null })
+    }
+}

--- a/app/src/test/java/com/eltavine/duckdetector/features/selinux/data/service/SelinuxContextValidityCarrierServiceTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/selinux/data/service/SelinuxContextValidityCarrierServiceTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.selinux.data.service
+
+import com.eltavine.duckdetector.features.selinux.data.native.SelinuxContextValiditySnapshot
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SelinuxContextValidityCarrierServiceTest {
+
+    @Test
+    fun `proc attr current gate does not depend on context oracle controls`() {
+        val failureReason = SelinuxContextValidityCarrierService.procAttrCurrentGateFailureReason(
+            snapshot = baseSnapshot(
+                probeAttempted = true,
+                oracleControlsPassed = false,
+                ksuResultsStable = false,
+                failureReason = "Context validity oracle self-test failed.",
+            ),
+            appUid = 10000,
+            uid = 10000,
+        )
+
+        assertNull(failureReason)
+    }
+
+    @Test
+    fun `proc attr current gate still rejects failed carrier dyntransition self check`() {
+        val failureReason = SelinuxContextValidityCarrierService.procAttrCurrentGateFailureReason(
+            snapshot = baseSnapshot(
+                dyntransitionCheckPassed = false,
+            ),
+            appUid = 10000,
+            uid = 10000,
+        )
+
+        assertEquals("Carrier dyntransition self-check failed.", failureReason)
+    }
+
+    private fun baseSnapshot(
+        probeAttempted: Boolean = false,
+        oracleControlsPassed: Boolean = true,
+        ksuResultsStable: Boolean = true,
+        dyntransitionCheckPassed: Boolean? = true,
+        failureReason: String? = null,
+    ): SelinuxContextValiditySnapshot {
+        return SelinuxContextValiditySnapshot(
+            available = true,
+            probeAttempted = probeAttempted,
+            carrierContext = "u:r:app_zygote:s0:c1,c2",
+            carrierMatchesExpected = true,
+            selinuxEnabled = true,
+            selinuxEnforced = true,
+            pidContextMatchesCurrent = true,
+            procSelfContextMatchesCurrent = true,
+            dyntransitionCheckPassed = dyntransitionCheckPassed,
+            oracleControlsPassed = oracleControlsPassed,
+            ksuResultsStable = ksuResultsStable,
+            failureReason = failureReason,
+        )
+    }
+}

--- a/app/src/test/java/com/eltavine/duckdetector/features/selinux/presentation/SelinuxCardModelMapperContextValidityTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/selinux/presentation/SelinuxCardModelMapperContextValidityTest.kt
@@ -18,6 +18,7 @@ package com.eltavine.duckdetector.features.selinux.presentation
 
 import com.eltavine.duckdetector.core.ui.model.DetectorStatus
 import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxContextValidityProbe
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxProcAttrCurrentProbe
 import com.eltavine.duckdetector.features.selinux.domain.SelinuxCheckResult
 import com.eltavine.duckdetector.features.selinux.domain.SelinuxMode
 import com.eltavine.duckdetector.features.selinux.domain.SelinuxReport
@@ -59,20 +60,21 @@ class SelinuxCardModelMapperContextValidityTest {
             baseReport(
                 SelinuxCheckResult(
                     method = SelinuxContextValidityProbe.METHOD_LABEL,
-                    status = SelinuxContextValidityProbe.STATUS_ROOT_CONTEXT_FOUND,
+                    status = SelinuxContextValidityProbe.BITPAIR_KSU_PRESENT,
                     isSecure = false,
                     permissionDenied = false,
-                    details = "Root contexts were found by live policy.",
+                    details = "Both KSU-specific contexts were found by live policy.",
                 ),
             ),
         )
 
         assertEquals(DetectorStatus.danger(), model.status)
-        assertEquals("Enforcing with Root context materialized", model.verdict)
-        assertTrue(model.summary.contains(SelinuxContextValidityProbe.STATUS_ROOT_CONTEXT_FOUND))
+        assertEquals("Enforcing with KSU context materialized", model.verdict)
+        assertTrue(model.summary.contains("accepted both KSU-specific contexts"))
         assertTrue(
             model.impactItems.any {
-                it.text.contains("validated root contexts")
+                it.text.contains("validated both KSU-specific contexts") ||
+                    it.text.contains("accepted both KSU-specific contexts")
             },
         )
     }
@@ -83,7 +85,7 @@ class SelinuxCardModelMapperContextValidityTest {
             baseReport(
                 SelinuxCheckResult(
                     method = SelinuxContextValidityProbe.METHOD_LABEL,
-                    status = SelinuxContextValidityProbe.STATUS_ORACLE_SELF_TEST_FAILED,
+                    status = SelinuxContextValidityProbe.BITPAIR_SELF_TEST_FAILED,
                     isSecure = null,
                     permissionDenied = false,
                     details = "Context validity oracle failed its self-test.",
@@ -107,7 +109,7 @@ class SelinuxCardModelMapperContextValidityTest {
             baseReport(
                 SelinuxCheckResult(
                     method = SelinuxContextValidityProbe.METHOD_LABEL,
-                    status = SelinuxContextValidityProbe.STATUS_ORACLE_BLOCKED,
+                    status = SelinuxContextValidityProbe.BITPAIR_UNSUPPORTED,
                     isSecure = null,
                     permissionDenied = false,
                     details = "Unavailable: u:r:app_zygote:s0 errno=Permission denied",
@@ -115,12 +117,12 @@ class SelinuxCardModelMapperContextValidityTest {
             ),
         )
 
-        assertEquals(DetectorStatus.warning(), model.status)
-        assertEquals("Enforcing with app_zygote SELinux query blocked", model.verdict)
-        assertTrue(model.summary.contains("app_zygote SELinux context queries were blocked"))
+        assertEquals(DetectorStatus.allClear(), model.status)
+        assertEquals("Enforcing", model.verdict)
+        assertTrue(model.summary.contains("Unavailable: u:r:app_zygote:s0 errno=Permission denied"))
         assertTrue(
             model.impactItems.any {
-                it.text.contains("unexpected for the stock app_zygote domain")
+                it.text.contains("Unavailable: u:r:app_zygote:s0 errno=Permission denied")
             },
         )
     }
@@ -131,20 +133,26 @@ class SelinuxCardModelMapperContextValidityTest {
             baseReport(
                 SelinuxCheckResult(
                     method = SelinuxContextValidityProbe.METHOD_LABEL,
-                    status = SelinuxContextValidityProbe.STATUS_ORACLE_UNAVAILABLE,
+                    status = SelinuxContextValidityProbe.BITPAIR_UNSUPPORTED,
                     isSecure = null,
                     permissionDenied = false,
-                    details = "No preloaded data available. Check AppZygotePreload status.",
+                    details = "Evidence source=local native fallback | No preloaded data available. Check AppZygotePreload status.",
                 ),
             ),
         )
 
-        assertEquals(DetectorStatus.info(com.eltavine.duckdetector.core.ui.model.InfoKind.SUPPORT), model.status)
-        assertEquals("Enforcing with unavailable context oracle", model.verdict)
-        assertTrue(model.summary.contains("app_zygote carrier snapshot was unavailable"))
+        assertEquals(DetectorStatus.allClear(), model.status)
+        assertEquals("Enforcing", model.verdict)
+        assertTrue(model.summary.contains("No preloaded data available"))
         assertTrue(
             model.impactItems.any {
-                it.text.contains("context oracle was unavailable")
+                it.text.contains("No preloaded data available")
+            },
+        )
+        assertTrue(
+            model.methodRows.any {
+                it.label == SelinuxContextValidityProbe.METHOD_LABEL &&
+                    it.detail?.contains("Evidence source=local native fallback") == true
             },
         )
     }
@@ -155,7 +163,7 @@ class SelinuxCardModelMapperContextValidityTest {
             baseReport(
                 SelinuxCheckResult(
                     method = SelinuxContextValidityProbe.METHOD_LABEL,
-                    status = SelinuxContextValidityProbe.STATUS_ORACLE_UNSTABLE,
+                    status = SelinuxContextValidityProbe.BITPAIR_SELF_TEST_FAILED,
                     isSecure = null,
                     permissionDenied = false,
                     details = "Context validity oracle repeatability failed.",
@@ -173,14 +181,45 @@ class SelinuxCardModelMapperContextValidityTest {
         )
     }
 
-    private fun baseReport(contextResult: SelinuxCheckResult): SelinuxReport {
+    @Test
+    fun `app zygote attr write anomaly maps to danger copy`() {
+        val model = mapper.map(
+            baseReport(
+                SelinuxCheckResult(
+                    method = SelinuxContextValidityProbe.METHOD_LABEL,
+                    status = SelinuxContextValidityProbe.BITPAIR_CLEAN,
+                    isSecure = true,
+                    permissionDenied = false,
+                    details = "Pair 00",
+                ),
+                SelinuxCheckResult(
+                    method = SelinuxProcAttrCurrentProbe.METHOD_LABEL,
+                    status = "Detected: Magisk, LSPosed file",
+                    isSecure = false,
+                    permissionDenied = false,
+                    details = "Magisk=DETECTED_NON_EINVAL | LSPosed file=SUCCESS",
+                ),
+            ),
+        )
+
+        assertEquals(DetectorStatus.danger(), model.status)
+        assertEquals("Enforcing with app_zygote attr-write anomaly", model.verdict)
+        assertTrue(model.summary.contains("Magisk, LSPosed file"))
+        assertTrue(
+            model.impactItems.any {
+                it.text.contains("anomalous /proc/self/attr/current writes")
+            },
+        )
+    }
+
+    private fun baseReport(vararg methods: SelinuxCheckResult): SelinuxReport {
         return SelinuxReport(
             stage = SelinuxStage.READY,
             mode = SelinuxMode.ENFORCING,
             resolvedStatusLabel = "Enforcing",
             filesystemMounted = true,
             paradoxDetected = false,
-            methods = listOf(contextResult),
+            methods = methods.toList(),
             processContext = "u:r:untrusted_app:s0:c1,c2",
             contextType = "untrusted_app",
             policyAnalysis = null,

--- a/app/src/test/java/com/eltavine/duckdetector/features/selinux/presentation/SelinuxCardModelMapperDirtyPolicyRulesTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/selinux/presentation/SelinuxCardModelMapperDirtyPolicyRulesTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.selinux.presentation
+
+import com.eltavine.duckdetector.core.ui.model.DetectorStatus
+import com.eltavine.duckdetector.features.selinux.domain.SelinuxCheckResult
+import com.eltavine.duckdetector.features.selinux.domain.SelinuxMode
+import com.eltavine.duckdetector.features.selinux.domain.SelinuxReport
+import com.eltavine.duckdetector.features.selinux.domain.SelinuxStage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SelinuxCardModelMapperDirtyPolicyRulesTest {
+
+    private val mapper = SelinuxCardModelMapper()
+
+    @Test
+    fun `dirty sepolicy rule rows stay visible with per-rule statuses`() {
+        val model = mapper.map(
+            baseReport(
+                SelinuxCheckResult(
+                    method = "Dirty sepolicy rule: system_server execmem",
+                    status = "Allowed",
+                    isSecure = false,
+                    permissionDenied = false,
+                    details = "Observed edge: system_server -> system_server:process execmem. This should stay denied on stock policy because executable system_server memory is supporting dirty-policy evidence. The access oracle reported this edge as allowed.",
+                ),
+                SelinuxCheckResult(
+                    method = "Dirty sepolicy rule: untrusted_app -> ksu_file read",
+                    status = "Denied",
+                    isSecure = true,
+                    permissionDenied = false,
+                    details = "Observed edge: untrusted_app -> ksu_file:file read. This should stay denied on stock policy because ordinary apps should not read KernelSU-labeled files. The access oracle reported this edge as denied.",
+                ),
+                SelinuxCheckResult(
+                    method = "Dirty sepolicy rule: shell -> su transition",
+                    status = "Unavailable",
+                    isSecure = null,
+                    permissionDenied = false,
+                    details = "Observed edge: shell -> su:process transition. This is only evaluated for confirmed user builds because stock user builds should not expose an AOSP su transition path. The access oracle could not produce a verdict for this edge. | Reason: Dirty policy oracle self-test failed.",
+                ),
+            ),
+        )
+
+        assertTrue(
+            model.methodRows.any {
+                it.label == "Dirty sepolicy rule: system_server execmem" &&
+                    it.value == "Allowed" &&
+                    it.status == DetectorStatus.danger()
+            },
+        )
+        assertTrue(
+            model.methodRows.any {
+                it.label == "Dirty sepolicy rule: untrusted_app -> ksu_file read" &&
+                    it.value == "Denied" &&
+                    it.status == DetectorStatus.allClear()
+            },
+        )
+        assertTrue(
+            model.methodRows.any {
+                it.label == "Dirty sepolicy rule: shell -> su transition" &&
+                    it.value == "Unavailable" &&
+                    it.status == DetectorStatus.info(com.eltavine.duckdetector.core.ui.model.InfoKind.SUPPORT)
+            },
+        )
+        assertTrue(
+            model.methodRows.any {
+                val detail = it.detail
+                it.label == "Dirty sepolicy rule: system_server execmem" &&
+                    detail != null &&
+                    detail.contains("Observed edge:") &&
+                    detail.contains("reported this edge as allowed")
+            },
+        )
+    }
+
+    @Test
+    fun `trusted dirty sepolicy hit raises overall selinux warning`() {
+        val model = mapper.map(
+            baseReport(
+                SelinuxCheckResult(
+                    method = "Dirty sepolicy rule: system_server execmem",
+                    status = "Allowed",
+                    isSecure = false,
+                    permissionDenied = false,
+                    details = "Observed edge: system_server -> system_server:process execmem. This should stay denied on stock policy because executable system_server memory is supporting dirty-policy evidence. The access oracle reported this edge as allowed.",
+                ),
+            ),
+        )
+
+        assertEquals(DetectorStatus.warning(), model.status)
+        assertEquals("Enforcing with dirty sepolicy rule", model.verdict)
+        assertTrue(model.summary.contains("DirtySepolicy-style access query reported system_server execmem as allowed"))
+        assertTrue(model.impactItems.any { it.text.contains("trusted DirtySepolicy-style access rule was allowed") })
+    }
+
+    private fun baseReport(vararg methods: SelinuxCheckResult): SelinuxReport {
+        return SelinuxReport(
+            stage = SelinuxStage.READY,
+            mode = SelinuxMode.ENFORCING,
+            resolvedStatusLabel = "Enforcing",
+            filesystemMounted = true,
+            paradoxDetected = false,
+            methods = methods.toList(),
+            processContext = "u:r:untrusted_app:s0:c1,c2",
+            contextType = "untrusted_app",
+            policyAnalysis = null,
+            auditIntegrity = null,
+            androidVersion = "16",
+            apiLevel = 36,
+        )
+    }
+}


### PR DESCRIPTION
- Dynamically resolve `libselinux.so` symbols to query SELinux enforcement states and validate access vectors (`selinux_check_access`) directly via JNI.
- Introduce `SelinuxProcAttrCurrentProbe` to inspect context transitions by writing candidate labels to `/proc/self/attr/current`.
- Expand DirtySepolicy access rule validations to cover explicit edge cases like `fsck_untrusted sys_admin`, `shell -> su` transitions, and `adbd -> adbroot` binder calls.
- Refactor `ContextValidityProbeSnapshot` and payload codecs to track probe repeatability, context splits (BitPair logic for KSU presence), and dyntransition self-checks.
- Update `SelinuxRepository` and UI mappers (`SelinuxCardModelMapper`) to surface granular dirty policy hits, ambiguous context verdicts, and attr-write anomalies securely.
- Implement comprehensive unit tests for payload decoding, carrier gating logic, and UI rule mappings.