### PR TITLE
自定义内核检测增强

### DIFF
--- a/app/src/main/java/com/eltavine/duckdetector/features/kernelcheck/data/repository/KernelCheckRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/kernelcheck/data/repository/KernelCheckRepository.kt
@@ -825,7 +825,7 @@ class KernelCheckRepository(
             "mirinfork",
             "brokestar",
             "sukisu",
-            "Glow-v4.7"
+            "Glow-v"
         )
 
         private val CASE_SENSITIVE_KEYWORDS = listOf("OKI")


### PR DESCRIPTION
## Summary
- Broaden Glow kernel keyword detection from `Glow-v4.7` to `Glow-v` so future Glow versions are covered.

## Testing
- Not run (keyword-only change).