### PR TITLE
feat(dashboard): show Detected time and total duration after scan

### DIFF
--- a/app/src/main/java/com/eltavine/duckdetector/features/dashboard/ui/DashboardScreen.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/dashboard/ui/DashboardScreen.kt
@@ -565,7 +565,7 @@ private fun DashboardOverviewCard(
                         WrapSafeText(
                             text = model.title,
                             modifier = Modifier.weight(1f),
-                            style = MaterialTheme.typography.labelLarge,
+                            style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }

--- a/app/src/main/java/com/eltavine/duckdetector/features/dashboard/ui/DashboardScreen.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/dashboard/ui/DashboardScreen.kt
@@ -565,7 +565,7 @@ private fun DashboardOverviewCard(
                         WrapSafeText(
                             text = model.title,
                             modifier = Modifier.weight(1f),
-                            style = MaterialTheme.typography.labelSmall,
+                            style = MaterialTheme.typography.labelMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }

--- a/app/src/main/java/com/eltavine/duckdetector/features/dashboard/ui/model/DashboardUiState.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/dashboard/ui/model/DashboardUiState.kt
@@ -35,6 +35,9 @@ import com.eltavine.duckdetector.features.systemproperties.ui.model.SystemProper
 import com.eltavine.duckdetector.features.tee.ui.model.TeeCardModel
 import com.eltavine.duckdetector.features.virtualization.ui.model.VirtualizationCardModel
 import com.eltavine.duckdetector.features.zygisk.ui.model.ZygiskCardModel
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 data class DashboardOverviewMetricModel(
@@ -189,6 +192,7 @@ data class DashboardUiState(
 fun buildDashboardOverview(
     contributions: List<DashboardDetectorContribution>,
     scanDurationMillis: Long? = null,
+    scanCompletedAtEpochMillis: Long? = null,
 ): DashboardOverviewModel {
     val total = contributions.size
     val readyCount = contributions.count { it.ready }
@@ -231,8 +235,8 @@ fun buildDashboardOverview(
     }
 
     return DashboardOverviewModel(
-        title = if (scanDurationMillis != null && pendingCount == 0) {
-            "Scan time ${formatScanDuration(scanDurationMillis)}"
+        title = if (scanDurationMillis != null && scanCompletedAtEpochMillis != null && pendingCount == 0) {
+            "Detected ${formatDetectedTimeLocal(scanCompletedAtEpochMillis)}, total ${formatScanDuration(scanDurationMillis)}"
         } else {
             "Security overview"
         },
@@ -265,6 +269,13 @@ fun buildDashboardOverview(
         ),
         showTitleIcon = scanDurationMillis != null && pendingCount == 0,
     )
+}
+
+private fun formatDetectedTimeLocal(epochMillis: Long): String {
+    val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.US)
+    return Instant.ofEpochMilli(epochMillis)
+        .atZone(ZoneId.systemDefault())
+        .format(formatter)
 }
 
 private fun formatScanDuration(

--- a/app/src/main/java/com/eltavine/duckdetector/features/dashboard/ui/model/DashboardUiState.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/dashboard/ui/model/DashboardUiState.kt
@@ -236,7 +236,7 @@ fun buildDashboardOverview(
 
     return DashboardOverviewModel(
         title = if (scanDurationMillis != null && scanCompletedAtEpochMillis != null && pendingCount == 0) {
-            "Detected ${formatDetectedTimeLocal(scanCompletedAtEpochMillis)}, total ${formatScanDuration(scanDurationMillis)}"
+            "Scanned at ${formatDetectedTimeLocal(scanCompletedAtEpochMillis)}\nTotal time ${formatScanDuration(scanDurationMillis)}"
         } else {
             "Security overview"
         },

--- a/app/src/main/java/com/eltavine/duckdetector/ui/DuckDetectorApp.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/ui/DuckDetectorApp.kt
@@ -520,6 +520,7 @@ private fun AppReadyShell(
     val isDashboardLoading = contributions.any { !it.ready }
     var dashboardScanStartedAt by remember { mutableLongStateOf(SystemClock.elapsedRealtime()) }
     var dashboardScanFinishedAt by remember { mutableStateOf<Long?>(null) }
+    var dashboardScanCompletedAtEpoch by remember { mutableLongStateOf(0L) }
 
     LaunchedEffect(isDashboardLoading) {
         if (isDashboardLoading) {
@@ -529,16 +530,19 @@ private fun AppReadyShell(
             }
         } else if (dashboardScanFinishedAt == null) {
             dashboardScanFinishedAt = SystemClock.elapsedRealtime()
+            dashboardScanCompletedAtEpoch = System.currentTimeMillis()
         }
     }
 
     val dashboardScanDurationMillis = dashboardScanFinishedAt
         ?.minus(dashboardScanStartedAt)
         ?.coerceAtLeast(0L)
+    val dashboardScanCompletedAtEpochMillis = dashboardScanFinishedAt?.let { dashboardScanCompletedAtEpoch }
 
     val dashboardState = remember(
         contributions,
         dashboardScanDurationMillis,
+        dashboardScanCompletedAtEpochMillis,
         isDashboardLoading,
         deviceInfoUiState,
         bootloaderUiState,
@@ -561,6 +565,7 @@ private fun AppReadyShell(
             overview = buildDashboardOverview(
                 contributions = contributions,
                 scanDurationMillis = dashboardScanDurationMillis,
+                scanCompletedAtEpochMillis = dashboardScanCompletedAtEpochMillis,
             ),
             topFindings = buildDashboardFindings(contributions),
             detectorCards = sortDashboardDetectorCards(

--- a/app/src/main/java/com/eltavine/duckdetector/ui/DuckDetectorApp.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/ui/DuckDetectorApp.kt
@@ -520,13 +520,14 @@ private fun AppReadyShell(
     val isDashboardLoading = contributions.any { !it.ready }
     var dashboardScanStartedAt by remember { mutableLongStateOf(SystemClock.elapsedRealtime()) }
     var dashboardScanFinishedAt by remember { mutableStateOf<Long?>(null) }
-    var dashboardScanCompletedAtEpoch by remember { mutableLongStateOf(0L) }
+    var dashboardScanCompletedAtEpoch by remember { mutableStateOf<Long?>(null) }
 
     LaunchedEffect(isDashboardLoading) {
         if (isDashboardLoading) {
             if (dashboardScanFinishedAt != null) {
                 dashboardScanStartedAt = SystemClock.elapsedRealtime()
                 dashboardScanFinishedAt = null
+                dashboardScanCompletedAtEpoch = null
             }
         } else if (dashboardScanFinishedAt == null) {
             dashboardScanFinishedAt = SystemClock.elapsedRealtime()
@@ -537,7 +538,7 @@ private fun AppReadyShell(
     val dashboardScanDurationMillis = dashboardScanFinishedAt
         ?.minus(dashboardScanStartedAt)
         ?.coerceAtLeast(0L)
-    val dashboardScanCompletedAtEpochMillis = dashboardScanFinishedAt?.let { dashboardScanCompletedAtEpoch }
+    val dashboardScanCompletedAtEpochMillis = dashboardScanCompletedAtEpoch
 
     val dashboardState = remember(
         contributions,


### PR DESCRIPTION
Replace Scan time overview title with local completion timestamp and total scan duration when all detectors finish.