### PR TITLE
feat(tee): enhance and add TEE/Keystore detections

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -80,6 +80,11 @@ limitations under the License.
             android:exported="false"
             android:isolatedProcess="true"
             android:useAppZygote="true" />
+        <service
+            android:name=".features.tee.data.verification.keystore.TeeGrantDomainGranteeService"
+            android:exported="false"
+            android:isolatedProcess="true"
+            tools:targetApi="baklava" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
@@ -30,6 +30,7 @@ import com.eltavine.duckdetector.features.tee.domain.TeeSignalLevel
 import com.eltavine.duckdetector.features.tee.domain.TeeTier
 import com.eltavine.duckdetector.features.tee.domain.TeeTrustRoot
 import com.eltavine.duckdetector.features.tee.domain.TeeVerdict
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.TIMING_SIDE_CHANNEL_THRESHOLD_RATIO
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.TimingSideChannelResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.timingSideChannelRatio
@@ -270,16 +271,29 @@ class TeeReportReducer(
                     )
                 )
             }
-            if (artifacts.grantDomainFullChainSplit.executed &&
-                artifacts.grantDomainFullChainSplit.splitDetected
-            ) {
-                add(
-                    fact(
-                        "Grant domain",
-                        "Grant-domain certificate-chain narrative split detected.",
-                        TeeSignalLevel.FAIL,
+            when (artifacts.grantDomainFullChainSplit.anomalyKind) {
+                GrantDomainAnomalyKind.ISOLATED_CHAIN_SPLIT -> {
+                    add(
+                        fact(
+                            "Grant isolated-domain",
+                            "Grant isolated-domain certificate-chain narrative split detected.",
+                            TeeSignalLevel.FAIL,
+                        )
                     )
-                )
+                }
+
+                GrantDomainAnomalyKind.ISOLATED_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN -> {
+                    add(
+                        fact(
+                            "Grant isolated-domain",
+                            "Grant isolated-domain key visibility divergence detected.",
+                            TeeSignalLevel.FAIL,
+                        )
+                    )
+                }
+
+                GrantDomainAnomalyKind.NONE,
+                GrantDomainAnomalyKind.UNAVAILABLE -> Unit
             }
             if (artifacts.keystore2Hook.javaHookDetected) {
                 add(
@@ -817,7 +831,7 @@ class TeeReportReducer(
                     )
                     add(
                         fact(
-                            "Grant domain",
+                            "Grant isolated-domain",
                             grantDomainFullChainSplitValue(artifacts),
                             grantDomainFullChainSplitLevel(artifacts)
                         )
@@ -1466,6 +1480,8 @@ class TeeReportReducer(
         return when {
             result.executed && result.splitDetected -> buildString {
                 append("Matched")
+                append(" kind=")
+                append(result.anomalyKind.name)
                 append(" owner=")
                 append(result.ownerChainLength)
                 append(" grantee=")
@@ -1476,12 +1492,21 @@ class TeeReportReducer(
             }
             result.executed && result.available -> buildString {
                 append("Clean")
+                append(" kind=")
+                append(result.anomalyKind.name)
                 append(" length=")
                 append(result.ownerChainLength)
                 result.granteeUid?.let { append(" uid=$it") }
                 result.detail.takeIf { it.isNotBlank() }?.let { append(" • $it") }
             }
-            else -> "Unavailable${result.detail.takeIf { it.isNotBlank() }?.let { " • $it" }.orEmpty()}"
+            else -> buildString {
+                append("Unavailable")
+                append(" kind=")
+                append(result.anomalyKind.name)
+                result.ownerChainLength.takeIf { it > 0 }?.let { append(" owner=$it") }
+                result.granteeUid?.let { append(" uid=$it") }
+                result.detail.takeIf { it.isNotBlank() }?.let { append(" • $it") }
+            }
         }
     }
 
@@ -1728,6 +1753,10 @@ class TeeReportReducer(
     private fun grantDomainFullChainSplitLevel(artifacts: TeeScanArtifacts): TeeSignalLevel {
         val result = artifacts.grantDomainFullChainSplit
         return when {
+            result.anomalyKind == GrantDomainAnomalyKind.ISOLATED_CHAIN_SPLIT -> TeeSignalLevel.FAIL
+            result.anomalyKind == GrantDomainAnomalyKind.ISOLATED_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN ->
+                TeeSignalLevel.FAIL
+
             result.executed && result.splitDetected -> TeeSignalLevel.FAIL
             result.executed && result.available -> TeeSignalLevel.PASS
             else -> TeeSignalLevel.INFO

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
@@ -1401,6 +1401,8 @@ class TeeReportReducer(
 
     private fun importKeyRetainedAttestationNarrativeValue(artifacts: TeeScanArtifacts): String {
         val result = artifacts.importKeyRetainedAttestationNarrative
+        // Keep the stable anomaly kind in the Checks row: the TEE card mapper uses it to propagate red-card state to the dashboard without exposing raw DER.
+        // 保留稳定 anomaly kind 在 Checks 行里：TEE card mapper 依赖它把红卡状态上传到 Dashboard，同时不暴露原始 DER。
         val status = when {
             result.anomalyKind == com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationAnomalyKind.IMPORT_UNSUPPORTED -> "Unavailable"
             !result.executed -> "Unavailable"

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
@@ -344,6 +344,17 @@ class TeeReportReducer(
                     )
                 )
             }
+            if (artifacts.importKeyRetainedAttestationNarrative.executed &&
+                artifacts.importKeyRetainedAttestationNarrative.retainedNarrativeDetected
+            ) {
+                add(
+                    fact(
+                        "ImportKey narrative",
+                        "ImportKey retained attestation narrative detected.",
+                        TeeSignalLevel.FAIL,
+                    )
+                )
+            }
             if (!artifacts.pairConsistency.keyMatchesCertificate) {
                 add(
                     fact(
@@ -786,6 +797,13 @@ class TeeReportReducer(
                         )
                     )
                     add(fact("Keybox", keyboxValue(artifacts), keyboxLevel(artifacts)))
+                    add(
+                        fact(
+                            "ImportKey narrative",
+                            importKeyRetainedAttestationNarrativeValue(artifacts),
+                            importKeyRetainedAttestationNarrativeLevel(artifacts)
+                        )
+                    )
                     add(
                         fact(
                             "Keystore2",
@@ -1381,6 +1399,18 @@ class TeeReportReducer(
         }
     }
 
+    private fun importKeyRetainedAttestationNarrativeValue(artifacts: TeeScanArtifacts): String {
+        val result = artifacts.importKeyRetainedAttestationNarrative
+        val status = when {
+            !result.executed -> "Unavailable"
+            result.retainedNarrativeDetected -> "Matched"
+            result.originImported -> "Clean"
+            else -> "Unavailable"
+        }
+        val detail = result.detail.takeIf { it.isNotBlank() } ?: return status
+        return "$status • $detail"
+    }
+
     private fun oversizedChallengeValue(artifacts: TeeScanArtifacts): String {
         return if (artifacts.oversizedChallenge.acceptedOversizedChallenge) {
             "Accepted ${artifacts.oversizedChallenge.acceptedSizesLabel()}"
@@ -1637,6 +1667,16 @@ class TeeReportReducer(
             !result.executed -> TeeSignalLevel.INFO
             result.usesKeyIdDomain && result.aliasCleared -> TeeSignalLevel.PASS
             else -> TeeSignalLevel.FAIL
+        }
+    }
+
+    private fun importKeyRetainedAttestationNarrativeLevel(artifacts: TeeScanArtifacts): TeeSignalLevel {
+        val result = artifacts.importKeyRetainedAttestationNarrative
+        return when {
+            !result.executed -> TeeSignalLevel.INFO
+            result.retainedNarrativeDetected -> TeeSignalLevel.FAIL
+            result.originImported -> TeeSignalLevel.PASS
+            else -> TeeSignalLevel.INFO
         }
     }
 

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
@@ -32,6 +32,7 @@ import com.eltavine.duckdetector.features.tee.domain.TeeTrustRoot
 import com.eltavine.duckdetector.features.tee.domain.TeeVerdict
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainAnomalyKind
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.MIN_RATIO_SAMPLE_COUNT
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.TIMING_SIDE_CHANNEL_THRESHOLD_RATIO
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.TimingSideChannelResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.timingSideChannelRatio
@@ -253,7 +254,11 @@ class TeeReportReducer(
                         timingSideChannelSkipSignature.level,
                     )
                 )
-            } else if (artifacts.timingSideChannel.measurementAvailable && artifacts.timingSideChannel.suspicious) {
+            } else if (
+                artifacts.timingSideChannel.measurementAvailable &&
+                artifacts.timingSideChannel.ratioEligible &&
+                artifacts.timingSideChannel.suspicious
+            ) {
                 add(
                     fact(
                         "Timing side-channel",
@@ -1401,7 +1406,10 @@ class TeeReportReducer(
         val timerSource = timingSideChannelTimerSourceLabel(result.timerSource, result.detail)
         val thresholdRatio = String.format(Locale.US, "%.1fx", TIMING_SIDE_CHANNEL_THRESHOLD_RATIO)
         val ratio = timingSideChannelRatio(result.avgAttestedMillis, result.avgNonAttestedMillis)
-        val ratioLabel = ratio?.let { String.format(Locale.US, "%.3fx", it) } ?: "n/a"
+        val ratioLabel = when {
+            result.measurementAvailable && !result.ratioEligible -> "skipped"
+            else -> ratio?.let { String.format(Locale.US, "%.3fx", it) } ?: "n/a"
+        }
         val affinity = when {
             result.affinity.isBlank() || result.affinity == "unknown" -> "affinity unknown"
             else -> result.affinity
@@ -1419,16 +1427,18 @@ class TeeReportReducer(
         val state = when {
             !result.probeRan -> "Skipped"
             !result.measurementAvailable -> "Measurement unavailable"
+            !result.ratioEligible -> "Ratio skipped"
             result.suspicious -> "Positive"
             else -> "Not positive"
         }
-        val filtered = Regex("""filteredBadSamples=\d+/\d+""")
-            .find(result.detail)
-            ?.value
-            ?.let { " • $it" }
-            .orEmpty()
+        val attemptedPairs = result.attemptedPairCount.takeIf { it > 0 } ?: result.sampleCount
+        val successfulPairs = result.successfulPairCount.takeIf { it > 0 } ?: result.sampleCount
+        val failedPairs = " • failedPairs=${result.failedPairCount}/$attemptedPairs"
+        val outlierFiltered = " • outlierFiltered=${result.filteredOutlierCount}/$successfulPairs"
+        val samples = " • samples=${result.sampleCount}"
+        val ratioSkip = result.ratioSkipReason?.takeIf { it.isNotBlank() }?.let { " • $it" }.orEmpty()
         val reason = result.failureReason?.takeIf { it.isNotBlank() }?.let { " • reason $it" }.orEmpty()
-        return "$timerSource • $affinity • attested $avgAttested • non-attested $avgNonAttested • diff $diff • ratio $ratioLabel$filtered • threshold > $thresholdRatio • $state$reason"
+        return "$timerSource • $affinity • attested $avgAttested • non-attested $avgNonAttested • diff $diff • ratio $ratioLabel • threshold > $thresholdRatio$failedPairs$outlierFiltered$samples$ratioSkip • $state$reason"
     }
 
     private fun timingSideChannelSummary(artifacts: TeeScanArtifacts): String {
@@ -1438,6 +1448,9 @@ class TeeReportReducer(
         val thresholdRatio = String.format(Locale.US, "%.1fx", TIMING_SIDE_CHANNEL_THRESHOLD_RATIO)
         if (!result.measurementAvailable) {
             return "$timerSource timing side-channel could not finish measurement; ${result.failureReason ?: "reason unavailable"}."
+        }
+        if (!result.ratioEligible) {
+            return "$timerSource timing side-channel skipped ratio; ${result.ratioSkipReason ?: "insufficientSamples=${result.sampleCount}/$MIN_RATIO_SAMPLE_COUNT"}."
         }
         val ratio = timingSideChannelRatio(result.avgAttestedMillis, result.avgNonAttestedMillis)
         val thresholdDirection = ratio?.let { value ->
@@ -2185,6 +2198,7 @@ class TeeReportReducer(
             skipSignature != null -> skipSignature.level
             !artifacts.timingSideChannel.probeRan -> TeeSignalLevel.INFO
             !artifacts.timingSideChannel.measurementAvailable -> TeeSignalLevel.INFO
+            !artifacts.timingSideChannel.ratioEligible -> TeeSignalLevel.INFO
             artifacts.timingSideChannel.suspicious -> TeeSignalLevel.WARN
             else -> TeeSignalLevel.INFO
         }

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
@@ -270,6 +270,17 @@ class TeeReportReducer(
                     )
                 )
             }
+            if (artifacts.grantDomainFullChainSplit.executed &&
+                artifacts.grantDomainFullChainSplit.splitDetected
+            ) {
+                add(
+                    fact(
+                        "Grant domain",
+                        "Grant-domain certificate-chain narrative split detected.",
+                        TeeSignalLevel.FAIL,
+                    )
+                )
+            }
             if (artifacts.keystore2Hook.javaHookDetected) {
                 add(
                     fact(
@@ -802,6 +813,13 @@ class TeeReportReducer(
                             "ImportKey narrative",
                             importKeyRetainedAttestationNarrativeValue(artifacts),
                             importKeyRetainedAttestationNarrativeLevel(artifacts)
+                        )
+                    )
+                    add(
+                        fact(
+                            "Grant domain",
+                            grantDomainFullChainSplitValue(artifacts),
+                            grantDomainFullChainSplitLevel(artifacts)
                         )
                     )
                     add(
@@ -1443,6 +1461,30 @@ class TeeReportReducer(
         }
     }
 
+    private fun grantDomainFullChainSplitValue(artifacts: TeeScanArtifacts): String {
+        val result = artifacts.grantDomainFullChainSplit
+        return when {
+            result.executed && result.splitDetected -> buildString {
+                append("Matched")
+                append(" owner=")
+                append(result.ownerChainLength)
+                append(" grantee=")
+                append(result.granteeChainLength)
+                result.mismatchIndex?.let { append(" mismatchIndex=$it") }
+                result.granteeUid?.let { append(" uid=$it") }
+                result.detail.takeIf { it.isNotBlank() }?.let { append(" • $it") }
+            }
+            result.executed && result.available -> buildString {
+                append("Clean")
+                append(" length=")
+                append(result.ownerChainLength)
+                result.granteeUid?.let { append(" uid=$it") }
+                result.detail.takeIf { it.isNotBlank() }?.let { append(" • $it") }
+            }
+            else -> "Unavailable${result.detail.takeIf { it.isNotBlank() }?.let { " • $it" }.orEmpty()}"
+        }
+    }
+
     private fun pureCertificateValue(artifacts: TeeScanArtifacts): String {
         return if (artifacts.pureCertificate.pureCertificateReturnsNullKey) {
             "Null key as expected"
@@ -1679,6 +1721,15 @@ class TeeReportReducer(
             !result.executed -> TeeSignalLevel.INFO
             result.retainedNarrativeDetected -> TeeSignalLevel.FAIL
             result.importSupported && result.markerImportBaselineClean -> TeeSignalLevel.PASS
+            else -> TeeSignalLevel.INFO
+        }
+    }
+
+    private fun grantDomainFullChainSplitLevel(artifacts: TeeScanArtifacts): TeeSignalLevel {
+        val result = artifacts.grantDomainFullChainSplit
+        return when {
+            result.executed && result.splitDetected -> TeeSignalLevel.FAIL
+            result.executed && result.available -> TeeSignalLevel.PASS
             else -> TeeSignalLevel.INFO
         }
     }

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
@@ -31,6 +31,7 @@ import com.eltavine.duckdetector.features.tee.domain.TeeTier
 import com.eltavine.duckdetector.features.tee.domain.TeeTrustRoot
 import com.eltavine.duckdetector.features.tee.domain.TeeVerdict
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainAnomalyKind
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.TIMING_SIDE_CHANNEL_THRESHOLD_RATIO
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.TimingSideChannelResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.timingSideChannelRatio
@@ -294,6 +295,15 @@ class TeeReportReducer(
 
                 GrantDomainAnomalyKind.NONE,
                 GrantDomainAnomalyKind.UNAVAILABLE -> Unit
+            }
+            if (artifacts.grantSelfDomainFullChainSplit.anomalyKind == GrantSelfDomainAnomalyKind.SELF_CHAIN_SPLIT) {
+                add(
+                    fact(
+                        "Grant self-domain",
+                        "Grant self-domain certificate-chain split detected.",
+                        TeeSignalLevel.FAIL,
+                    )
+                )
             }
             if (artifacts.keystore2Hook.javaHookDetected) {
                 add(
@@ -834,6 +844,13 @@ class TeeReportReducer(
                             "Grant isolated-domain",
                             grantDomainFullChainSplitValue(artifacts),
                             grantDomainFullChainSplitLevel(artifacts)
+                        )
+                    )
+                    add(
+                        fact(
+                            "Grant self-domain",
+                            grantSelfDomainFullChainSplitValue(artifacts),
+                            grantSelfDomainFullChainSplitLevel(artifacts)
                         )
                     )
                     add(
@@ -1510,6 +1527,43 @@ class TeeReportReducer(
         }
     }
 
+    private fun grantSelfDomainFullChainSplitValue(artifacts: TeeScanArtifacts): String {
+        val result = artifacts.grantSelfDomainFullChainSplit
+        return when {
+            result.executed && result.splitDetected -> buildString {
+                append("Matched")
+                append(" kind=")
+                append(result.anomalyKind.name)
+                append(" owner=")
+                append(result.ownerChainLength)
+                append(" grant=")
+                append(result.grantChainLength)
+                result.mismatchIndex?.let { append(" mismatchIndex=$it") }
+                if (result.grantIdPresent) append(" grantId=true")
+                result.detail.takeIf { it.isNotBlank() }?.let { append(" • $it") }
+            }
+
+            result.executed && result.available -> buildString {
+                append("Clean")
+                append(" kind=")
+                append(result.anomalyKind.name)
+                append(" length=")
+                append(result.ownerChainLength)
+                if (result.grantIdPresent) append(" grantId=true")
+                result.detail.takeIf { it.isNotBlank() }?.let { append(" • $it") }
+            }
+
+            else -> buildString {
+                append("Unavailable")
+                append(" kind=")
+                append(result.anomalyKind.name)
+                result.ownerChainLength.takeIf { it > 0 }?.let { append(" owner=$it") }
+                if (result.grantIdPresent) append(" grantId=true")
+                result.detail.takeIf { it.isNotBlank() }?.let { append(" • $it") }
+            }
+        }
+    }
+
     private fun pureCertificateValue(artifacts: TeeScanArtifacts): String {
         return if (artifacts.pureCertificate.pureCertificateReturnsNullKey) {
             "Null key as expected"
@@ -1758,6 +1812,15 @@ class TeeReportReducer(
                 TeeSignalLevel.FAIL
 
             result.executed && result.splitDetected -> TeeSignalLevel.FAIL
+            result.executed && result.available -> TeeSignalLevel.PASS
+            else -> TeeSignalLevel.INFO
+        }
+    }
+
+    private fun grantSelfDomainFullChainSplitLevel(artifacts: TeeScanArtifacts): TeeSignalLevel {
+        val result = artifacts.grantSelfDomainFullChainSplit
+        return when {
+            result.anomalyKind == GrantSelfDomainAnomalyKind.SELF_CHAIN_SPLIT -> TeeSignalLevel.FAIL
             result.executed && result.available -> TeeSignalLevel.PASS
             else -> TeeSignalLevel.INFO
         }

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
@@ -296,14 +296,29 @@ class TeeReportReducer(
                 GrantDomainAnomalyKind.NONE,
                 GrantDomainAnomalyKind.UNAVAILABLE -> Unit
             }
-            if (artifacts.grantSelfDomainFullChainSplit.anomalyKind == GrantSelfDomainAnomalyKind.SELF_CHAIN_SPLIT) {
-                add(
-                    fact(
-                        "Grant self-domain",
-                        "Grant self-domain certificate-chain split detected.",
-                        TeeSignalLevel.FAIL,
+            when (artifacts.grantSelfDomainFullChainSplit.anomalyKind) {
+                GrantSelfDomainAnomalyKind.SELF_CHAIN_SPLIT -> {
+                    add(
+                        fact(
+                            "Grant self-domain",
+                            "Grant self-domain certificate-chain split detected.",
+                            TeeSignalLevel.FAIL,
+                        )
                     )
-                )
+                }
+
+                GrantSelfDomainAnomalyKind.SELF_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN -> {
+                    add(
+                        fact(
+                            "Grant self-domain",
+                            "Grant self-domain key visibility divergence detected.",
+                            TeeSignalLevel.FAIL,
+                        )
+                    )
+                }
+
+                GrantSelfDomainAnomalyKind.NONE,
+                GrantSelfDomainAnomalyKind.UNAVAILABLE -> Unit
             }
             if (artifacts.keystore2Hook.javaHookDetected) {
                 add(
@@ -1820,7 +1835,10 @@ class TeeReportReducer(
     private fun grantSelfDomainFullChainSplitLevel(artifacts: TeeScanArtifacts): TeeSignalLevel {
         val result = artifacts.grantSelfDomainFullChainSplit
         return when {
-            result.anomalyKind == GrantSelfDomainAnomalyKind.SELF_CHAIN_SPLIT -> TeeSignalLevel.FAIL
+            result.anomalyKind == GrantSelfDomainAnomalyKind.SELF_CHAIN_SPLIT ||
+                result.anomalyKind == GrantSelfDomainAnomalyKind.SELF_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN -> {
+                TeeSignalLevel.FAIL
+            }
             result.executed && result.available -> TeeSignalLevel.PASS
             else -> TeeSignalLevel.INFO
         }

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
@@ -1402,9 +1402,10 @@ class TeeReportReducer(
     private fun importKeyRetainedAttestationNarrativeValue(artifacts: TeeScanArtifacts): String {
         val result = artifacts.importKeyRetainedAttestationNarrative
         val status = when {
+            result.anomalyKind == com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationAnomalyKind.IMPORT_UNSUPPORTED -> "Unavailable"
             !result.executed -> "Unavailable"
             result.retainedNarrativeDetected -> "Matched"
-            result.originImported -> "Clean"
+            result.importSupported && result.markerImportBaselineClean -> "Clean"
             else -> "Unavailable"
         }
         val detail = result.detail.takeIf { it.isNotBlank() } ?: return status
@@ -1675,7 +1676,7 @@ class TeeReportReducer(
         return when {
             !result.executed -> TeeSignalLevel.INFO
             result.retainedNarrativeDetected -> TeeSignalLevel.FAIL
-            result.originImported -> TeeSignalLevel.PASS
+            result.importSupported && result.markerImportBaselineClean -> TeeSignalLevel.PASS
             else -> TeeSignalLevel.INFO
         }
     }

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
@@ -272,6 +272,12 @@ class TeeReportReducer(
                     )
                 )
             }
+            // Grant checks are supplementary, but these two kinds are strong local evidence:
+            // Grant 检测属于补充证据；但下面两类是强本地证据：
+            // 1) chain split means owner alias and Domain.GRANT return different ordered certificate narratives.
+            // 1) chain split 表示 owner alias 与 Domain.GRANT 返回了不同的有序证书叙事。
+            // 2) key-not-found after owner chain means the alias exists in owner view but not in grant lookup.
+            // 2) owner chain 后 key-not-found 表示 alias 存在于 owner 视图，却不存在于 grant 查找路径。
             when (artifacts.grantDomainFullChainSplit.anomalyKind) {
                 GrantDomainAnomalyKind.ISOLATED_CHAIN_SPLIT -> {
                     add(
@@ -296,6 +302,8 @@ class TeeReportReducer(
                 GrantDomainAnomalyKind.NONE,
                 GrantDomainAnomalyKind.UNAVAILABLE -> Unit
             }
+            // self-domain removes the isolated-process policy variable; its key-not-found variant is treated like a visibility split.
+            // self-domain 排除了 isolated-process 策略变量；其 key-not-found 变体按可见性断裂处理。
             when (artifacts.grantSelfDomainFullChainSplit.anomalyKind) {
                 GrantSelfDomainAnomalyKind.SELF_CHAIN_SPLIT -> {
                     add(
@@ -1822,6 +1830,8 @@ class TeeReportReducer(
     private fun grantDomainFullChainSplitLevel(artifacts: TeeScanArtifacts): TeeSignalLevel {
         val result = artifacts.grantDomainFullChainSplit
         return when {
+            // These anomaly kinds are already curated by the probe, so reducer can safely upgrade them without parsing detail text.
+            // 这些 anomaly kind 已由 probe 结构化归类，reducer 不需要解析 detail 文本即可升级。
             result.anomalyKind == GrantDomainAnomalyKind.ISOLATED_CHAIN_SPLIT -> TeeSignalLevel.FAIL
             result.anomalyKind == GrantDomainAnomalyKind.ISOLATED_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN ->
                 TeeSignalLevel.FAIL
@@ -1835,6 +1845,8 @@ class TeeReportReducer(
     private fun grantSelfDomainFullChainSplitLevel(artifacts: TeeScanArtifacts): TeeSignalLevel {
         val result = artifacts.grantSelfDomainFullChainSplit
         return when {
+            // Same-UID key-not-found is not ordinary unavailability: the owner alias was proven readable before grant.
+            // 同 UID key-not-found 不是普通不可用：grant 之前 owner alias 已被证明可读。
             result.anomalyKind == GrantSelfDomainAnomalyKind.SELF_CHAIN_SPLIT ||
                 result.anomalyKind == GrantSelfDomainAnomalyKind.SELF_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN -> {
                 TeeSignalLevel.FAIL

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeScanArtifacts.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeScanArtifacts.kt
@@ -29,6 +29,7 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderC
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderHookBootstrapResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderPatchModeResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BiometricTeeIntegrationResult
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationNarrativeResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyboxImportResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2GenerateModeParcelFingerprintResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2HookResult
@@ -64,6 +65,7 @@ data class TeeScanArtifacts(
     val timingSideChannel: TimingSideChannelResult,
     val oversizedChallenge: OversizedChallengeResult,
     val keyboxImport: KeyboxImportResult,
+    val importKeyRetainedAttestationNarrative: ImportKeyRetainedAttestationNarrativeResult,
     val keystore2Hook: Keystore2HookResult,
     val generateModeParcelFingerprint: Keystore2GenerateModeParcelFingerprintResult,
     val legacyKeystorePath: LegacyKeystorePathResult,

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeScanArtifacts.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeScanArtifacts.kt
@@ -35,6 +35,7 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystor
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2HookResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyLifecycleResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.LegacyKeystorePathResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesBatchedResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesConsistencyResult
@@ -70,6 +71,7 @@ data class TeeScanArtifacts(
     val keystore2Hook: Keystore2HookResult,
     val generateModeParcelFingerprint: Keystore2GenerateModeParcelFingerprintResult,
     val grantDomainFullChainSplit: GrantDomainFullChainSplitResult,
+    val grantSelfDomainFullChainSplit: GrantSelfDomainFullChainSplitResult,
     val legacyKeystorePath: LegacyKeystorePathResult,
     val listEntriesConsistency: ListEntriesConsistencyResult,
     val listEntriesBatched: ListEntriesBatchedResult,

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeScanArtifacts.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeScanArtifacts.kt
@@ -34,6 +34,7 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyboxI
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2GenerateModeParcelFingerprintResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2HookResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyLifecycleResult
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.LegacyKeystorePathResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesBatchedResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesConsistencyResult
@@ -68,6 +69,7 @@ data class TeeScanArtifacts(
     val importKeyRetainedAttestationNarrative: ImportKeyRetainedAttestationNarrativeResult,
     val keystore2Hook: Keystore2HookResult,
     val generateModeParcelFingerprint: Keystore2GenerateModeParcelFingerprintResult,
+    val grantDomainFullChainSplit: GrantDomainFullChainSplitResult,
     val legacyKeystorePath: LegacyKeystorePathResult,
     val listEntriesConsistency: ListEntriesConsistencyResult,
     val listEntriesBatched: ListEntriesBatchedResult,

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
@@ -196,6 +196,8 @@ class TeeRepository(
         val timing = async { timingProbe.inspect(useStrongBox = useStrongBox) }
         val oversizedChallenge = async { oversizedChallengeProbe.inspect(useStrongBox = useStrongBox) }
         val keyboxImport = async { keyboxImportProbe.inspect() }
+        // Run after keybox import fixtures are available, but keep it independent so unsupported importKey paths degrade to INFO only.
+        // 放在 keybox import fixture 可用之后独立执行；importKey 不可观测时只降级为 INFO，不影响主扫描。
         val importKeyRetainedAttestationNarrative = async {
             importKeyRetainedAttestationNarrativeProbe.inspect()
         }

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
@@ -44,6 +44,7 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyPair
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyboxImportProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2GenerateModeParcelFingerprintProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2HookProbe
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.LegacyKeystorePathProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesBatchedProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesConsistencyProbe
@@ -90,6 +91,7 @@ class TeeRepository(
         ImportKeyRetainedAttestationNarrativeProbe(appContext)
     private val keystore2HookProbe = Keystore2HookProbe()
     private val generateModeParcelFingerprintProbe = Keystore2GenerateModeParcelFingerprintProbe()
+    private val grantDomainFullChainSplitProbe = GrantDomainFullChainSplitProbe(appContext)
     private val legacyKeystorePathProbe = LegacyKeystorePathProbe()
     private val listEntriesConsistencyProbe = ListEntriesConsistencyProbe()
     private val listEntriesBatchedProbe = ListEntriesBatchedProbe()
@@ -153,6 +155,7 @@ class TeeRepository(
                     importKeyRetainedAttestationNarrative = deepChecks.importKeyRetainedAttestationNarrative,
                     keystore2Hook = deepChecks.keystore2Hook,
                     generateModeParcelFingerprint = deepChecks.generateModeParcelFingerprint,
+                    grantDomainFullChainSplit = deepChecks.grantDomainFullChainSplit,
                     legacyKeystorePath = deepChecks.legacyKeystorePath,
                     listEntriesConsistency = deepChecks.listEntriesConsistency,
                     listEntriesBatched = deepChecks.listEntriesBatched,
@@ -241,6 +244,7 @@ class TeeRepository(
         val strongBoxResult = strongBox.await()
 
         val generateModeParcelFingerprint = generateModeParcelFingerprintProbe.inspect()
+        val grantDomainFullChainSplit = grantDomainFullChainSplitProbe.inspect(useStrongBox = useStrongBox)
         val legacyKeystorePath = legacyKeystorePathProbe.inspect()
         val binderHookBootstrap = binderHookBootstrapProbe.inspect()
         val binderPatchMode = binderPatchModeProbe.inspect()
@@ -257,6 +261,7 @@ class TeeRepository(
             importKeyRetainedAttestationNarrative = importKeyRetainedAttestationNarrativeResult,
             keystore2Hook = keystore2HookResult,
             generateModeParcelFingerprint = generateModeParcelFingerprint,
+            grantDomainFullChainSplit = grantDomainFullChainSplit,
             legacyKeystorePath = legacyKeystorePath,
             listEntriesConsistency = listEntriesConsistencyResult,
             listEntriesBatched = listEntriesBatchedResult,
@@ -290,6 +295,7 @@ private data class DeferredChecks(
     val importKeyRetainedAttestationNarrative: com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationNarrativeResult,
     val keystore2Hook: com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2HookResult,
     val generateModeParcelFingerprint: com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2GenerateModeParcelFingerprintResult,
+    val grantDomainFullChainSplit: com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult,
     val legacyKeystorePath: com.eltavine.duckdetector.features.tee.data.verification.keystore.LegacyKeystorePathResult,
     val listEntriesConsistency: com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesConsistencyResult,
     val listEntriesBatched: com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesBatchedResult,
@@ -356,6 +362,9 @@ private data class DeferredChecks(
             generateModeParcelFingerprint = com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2GenerateModeParcelFingerprintResult(
                 executed = false,
                 detail = "Keystore2 generate-mode parcel fingerprint probe skipped.",
+            ),
+            grantDomainFullChainSplit = com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult(
+                detail = "Grant-domain full-chain split probe skipped.",
             ),
             legacyKeystorePath = com.eltavine.duckdetector.features.tee.data.verification.keystore.LegacyKeystorePathResult(
                 executed = false,

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
@@ -36,6 +36,7 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderC
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderHookBootstrapProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderPatchModeProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BiometricTeeIntegrationProbe
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationNarrativeProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyLifecycleProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyMetadataSemanticsProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyMetadataShapeProbe
@@ -85,6 +86,8 @@ class TeeRepository(
     private val timingSideChannelProbe = TimingSideChannelProbe()
     private val oversizedChallengeProbe = OversizedChallengeProbe()
     private val keyboxImportProbe = KeyboxImportProbe(appContext)
+    private val importKeyRetainedAttestationNarrativeProbe =
+        ImportKeyRetainedAttestationNarrativeProbe(appContext)
     private val keystore2HookProbe = Keystore2HookProbe()
     private val generateModeParcelFingerprintProbe = Keystore2GenerateModeParcelFingerprintProbe()
     private val legacyKeystorePathProbe = LegacyKeystorePathProbe()
@@ -147,6 +150,7 @@ class TeeRepository(
                     timingSideChannel = deepChecks.timingSideChannel,
                     oversizedChallenge = deepChecks.oversizedChallenge,
                     keyboxImport = deepChecks.keyboxImport,
+                    importKeyRetainedAttestationNarrative = deepChecks.importKeyRetainedAttestationNarrative,
                     keystore2Hook = deepChecks.keystore2Hook,
                     generateModeParcelFingerprint = deepChecks.generateModeParcelFingerprint,
                     legacyKeystorePath = deepChecks.legacyKeystorePath,
@@ -192,6 +196,9 @@ class TeeRepository(
         val timing = async { timingProbe.inspect(useStrongBox = useStrongBox) }
         val oversizedChallenge = async { oversizedChallengeProbe.inspect(useStrongBox = useStrongBox) }
         val keyboxImport = async { keyboxImportProbe.inspect() }
+        val importKeyRetainedAttestationNarrative = async {
+            importKeyRetainedAttestationNarrativeProbe.inspect()
+        }
         val keystore2Hook = async { keystore2HookProbe.inspect() }
         val listEntriesConsistency = async { listEntriesConsistencyProbe.inspect() }
         val listEntriesBatched = async { listEntriesBatchedProbe.inspect() }
@@ -215,6 +222,7 @@ class TeeRepository(
         val timingResult = timing.await()
         val oversizedChallengeResult = oversizedChallenge.await()
         val keyboxImportResult = keyboxImport.await()
+        val importKeyRetainedAttestationNarrativeResult = importKeyRetainedAttestationNarrative.await()
         val keystore2HookResult = keystore2Hook.await()
         val listEntriesConsistencyResult = listEntriesConsistency.await()
         val listEntriesBatchedResult = listEntriesBatched.await()
@@ -244,6 +252,7 @@ class TeeRepository(
             timingSideChannel = timingSideChannel,
             oversizedChallenge = oversizedChallengeResult,
             keyboxImport = keyboxImportResult,
+            importKeyRetainedAttestationNarrative = importKeyRetainedAttestationNarrativeResult,
             keystore2Hook = keystore2HookResult,
             generateModeParcelFingerprint = generateModeParcelFingerprint,
             legacyKeystorePath = legacyKeystorePath,
@@ -276,6 +285,7 @@ private data class DeferredChecks(
     val timingSideChannel: com.eltavine.duckdetector.features.tee.data.verification.keystore.TimingSideChannelResult,
     val oversizedChallenge: com.eltavine.duckdetector.features.tee.data.verification.keystore.OversizedChallengeResult,
     val keyboxImport: com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyboxImportResult,
+    val importKeyRetainedAttestationNarrative: com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationNarrativeResult,
     val keystore2Hook: com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2HookResult,
     val generateModeParcelFingerprint: com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2GenerateModeParcelFingerprintResult,
     val legacyKeystorePath: com.eltavine.duckdetector.features.tee.data.verification.keystore.LegacyKeystorePathResult,
@@ -332,6 +342,10 @@ private data class DeferredChecks(
                 markerPreserved = true,
                 marker = com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyboxImportProbe.FIXTURE_MARKER,
                 detail = "Keybox import probe skipped.",
+            ),
+            importKeyRetainedAttestationNarrative = com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationNarrativeResult(
+                executed = false,
+                detail = "ImportKey retained attestation narrative probe skipped.",
             ),
             keystore2Hook = com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2HookResult(
                 available = false,

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
@@ -45,6 +45,7 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyboxI
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2GenerateModeParcelFingerprintProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2HookProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitProbe
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.LegacyKeystorePathProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesBatchedProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesConsistencyProbe
@@ -92,6 +93,7 @@ class TeeRepository(
     private val keystore2HookProbe = Keystore2HookProbe()
     private val generateModeParcelFingerprintProbe = Keystore2GenerateModeParcelFingerprintProbe()
     private val grantDomainFullChainSplitProbe = GrantDomainFullChainSplitProbe(appContext)
+    private val grantSelfDomainFullChainSplitProbe = GrantSelfDomainFullChainSplitProbe(appContext)
     private val legacyKeystorePathProbe = LegacyKeystorePathProbe()
     private val listEntriesConsistencyProbe = ListEntriesConsistencyProbe()
     private val listEntriesBatchedProbe = ListEntriesBatchedProbe()
@@ -156,6 +158,7 @@ class TeeRepository(
                     keystore2Hook = deepChecks.keystore2Hook,
                     generateModeParcelFingerprint = deepChecks.generateModeParcelFingerprint,
                     grantDomainFullChainSplit = deepChecks.grantDomainFullChainSplit,
+                    grantSelfDomainFullChainSplit = deepChecks.grantSelfDomainFullChainSplit,
                     legacyKeystorePath = deepChecks.legacyKeystorePath,
                     listEntriesConsistency = deepChecks.listEntriesConsistency,
                     listEntriesBatched = deepChecks.listEntriesBatched,
@@ -245,6 +248,7 @@ class TeeRepository(
 
         val generateModeParcelFingerprint = generateModeParcelFingerprintProbe.inspect()
         val grantDomainFullChainSplit = grantDomainFullChainSplitProbe.inspect(useStrongBox = useStrongBox)
+        val grantSelfDomainFullChainSplit = grantSelfDomainFullChainSplitProbe.inspect(useStrongBox = useStrongBox)
         val legacyKeystorePath = legacyKeystorePathProbe.inspect()
         val binderHookBootstrap = binderHookBootstrapProbe.inspect()
         val binderPatchMode = binderPatchModeProbe.inspect()
@@ -262,6 +266,7 @@ class TeeRepository(
             keystore2Hook = keystore2HookResult,
             generateModeParcelFingerprint = generateModeParcelFingerprint,
             grantDomainFullChainSplit = grantDomainFullChainSplit,
+            grantSelfDomainFullChainSplit = grantSelfDomainFullChainSplit,
             legacyKeystorePath = legacyKeystorePath,
             listEntriesConsistency = listEntriesConsistencyResult,
             listEntriesBatched = listEntriesBatchedResult,
@@ -296,6 +301,7 @@ private data class DeferredChecks(
     val keystore2Hook: com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2HookResult,
     val generateModeParcelFingerprint: com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2GenerateModeParcelFingerprintResult,
     val grantDomainFullChainSplit: com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult,
+    val grantSelfDomainFullChainSplit: com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitResult,
     val legacyKeystorePath: com.eltavine.duckdetector.features.tee.data.verification.keystore.LegacyKeystorePathResult,
     val listEntriesConsistency: com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesConsistencyResult,
     val listEntriesBatched: com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesBatchedResult,
@@ -365,6 +371,9 @@ private data class DeferredChecks(
             ),
             grantDomainFullChainSplit = com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult(
                 detail = "Grant-domain full-chain split probe skipped.",
+            ),
+            grantSelfDomainFullChainSplit = com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitResult(
+                detail = "Grant self-domain full-chain split probe skipped.",
             ),
             legacyKeystorePath = com.eltavine.duckdetector.features.tee.data.verification.keystore.LegacyKeystorePathResult(
                 executed = false,

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GenerateKeyReplyParcelParser.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GenerateKeyReplyParcelParser.kt
@@ -66,7 +66,8 @@ class GenerateKeyReplyParcelParser {
             val lastAuthorizationHasUnknownUnionTag = isUnknownKeyParameterValueUnionTag(lastAuthorization.unionTag)
             val matched =
                 modificationTimeMs == TARGET_MODIFICATION_TIME_MS &&
-                    lastAuthorization.secLevel == TARGET_LAST_AUTHORIZATION_SEC_LEVEL &&
+                    lastAuthorization.secLevel in TARGET_LAST_AUTHORIZATION_SEC_LEVELS &&
+                    lastAuthorization.tag == TARGET_LAST_AUTHORIZATION_TAG &&
                     lastAuthorization.unionTag == TARGET_LAST_AUTHORIZATION_UNION_TAG &&
                     lastAuthorizationHasUnknownUnionTag
             GenerateKeyReplyParcelParseResult(
@@ -304,7 +305,8 @@ class GenerateKeyReplyParcelParser {
         const val AUTHORIZATION_TAG_OFFSET = 4
         const val AUTHORIZATION_UNION_TAG_OFFSET = 8
         const val TARGET_MODIFICATION_TIME_MS = 4294967297L
-        const val TARGET_LAST_AUTHORIZATION_SEC_LEVEL = 256L
+        val TARGET_LAST_AUTHORIZATION_SEC_LEVELS = setOf(4L, 256L)
+        const val TARGET_LAST_AUTHORIZATION_TAG = 0x00000001L
         const val TARGET_LAST_AUTHORIZATION_UNION_TAG = 32L
         val KNOWN_KEY_PARAMETER_VALUE_UNION_TAGS = (0L..14L).toSet()
         val INT_LIKE_KEY_PARAMETER_VALUE_UNION_TAGS = setOf(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L)

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantDomainFullChainSplitProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantDomainFullChainSplitProbe.kt
@@ -67,6 +67,8 @@ class GrantDomainFullChainSplitProbe(
                     detail = "Owner KeyStore certificate chain was empty.",
                 )
             }
+            // isolated-domain 特意跨 UID / process 验证 Domain.GRANT；grantee 侧不可达可能只是 SELinux/app_zygote 策略噪声。
+            // isolated-domain intentionally crosses UID/process boundaries; grantee failures can reflect SELinux/app_zygote policy noise.
             val sessionResult = granteeManager.openSession()
             if (!sessionResult.available || sessionResult.session == null) {
                 return GrantDomainFullChainSplitResult(
@@ -78,6 +80,10 @@ class GrantDomainFullChainSplitProbe(
                 val grantId = runCatching {
                     keyStoreManager.grantKeyAccess(alias, session.uid)
                 }.getOrElse { throwable ->
+                    // 这里 owner 已通过 Java KeyStore 读到 alias 的真实证书链；AOSP grant path 应能解析同一 alias 再创建 Domain.GRANT。
+                    // Owner has already read a concrete chain for alias; AOSP grant path should resolve the same alias before creating Domain.GRANT.
+                    // key-not-found 因此表示 owner 视图和 keystore2 授权查找断裂，而不是普通 isolated service 兼容性失败。
+                    // key-not-found therefore means owner visibility and keystore2 grant lookup diverged, not a generic isolated-service failure.
                     val anomalyKind = if (isGrantAliasNotFound(throwable)) {
                         GrantDomainAnomalyKind.ISOLATED_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN
                     } else {
@@ -93,6 +99,8 @@ class GrantDomainFullChainSplitProbe(
                 }
                 grantCreated = true
                 val granteeResult = session.readGrantedCertificateChain(grantId)
+                // grant 创建后的 grantee 读取失败保持 INFO：isolated_app 访问 keystore2 的策略差异不是证书叙事 split 证据。
+                // After grant creation, grantee read failures stay INFO: isolated_app keystore2 access policy is not certificate narrative split evidence.
                 if (!granteeResult.available) {
                     return GrantDomainFullChainSplitResult(
                         ownerChainLength = ownerChain.certificates.size,
@@ -111,6 +119,8 @@ class GrantDomainFullChainSplitProbe(
                         detail = "Grantee granted certificate chain was empty.",
                     )
                 }
+                // 比较 ordered full-chain，而不是只看 leaf；部分 hook 可能只替换叶证书或只回放中间链。
+                // Compare the ordered full chain, not only the leaf; hooks may rewrite only the leaf or replay only intermediates.
                 val comparison = compareChains(ownerChain, granteeChain)
                 GrantDomainFullChainSplitResult(
                     executed = true,
@@ -178,6 +188,8 @@ class GrantDomainFullChainSplitProbe(
         }
 
         internal fun isGrantAliasNotFound(throwable: Throwable): Boolean {
+            // 严格限定异常类型和 AOSP 文案，避免把 OEM/暂态 grant 失败误归因为授权域断裂。
+            // Keep both exception type and AOSP-style message strict to avoid treating OEM/transient grant failures as domain divergence.
             return throwable is UnrecoverableKeyException &&
                 throwable.message?.contains("No key found by the given alias", ignoreCase = true) == true
         }

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantDomainFullChainSplitProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantDomainFullChainSplitProbe.kt
@@ -21,6 +21,7 @@ import android.os.Build
 import android.security.keystore.KeyStoreManager
 import com.eltavine.duckdetector.features.tee.data.keystore.AndroidKeyStoreTools
 import java.security.MessageDigest
+import java.security.UnrecoverableKeyException
 import java.security.cert.X509Certificate
 import java.nio.charset.StandardCharsets
 import java.util.Locale
@@ -77,9 +78,16 @@ class GrantDomainFullChainSplitProbe(
                 val grantId = runCatching {
                     keyStoreManager.grantKeyAccess(alias, session.uid)
                 }.getOrElse { throwable ->
+                    val anomalyKind = if (isGrantAliasNotFound(throwable)) {
+                        GrantDomainAnomalyKind.ISOLATED_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN
+                    } else {
+                        GrantDomainAnomalyKind.UNAVAILABLE
+                    }
                     return GrantDomainFullChainSplitResult(
+                        executed = anomalyKind == GrantDomainAnomalyKind.ISOLATED_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN,
                         ownerChainLength = ownerChain.certificates.size,
                         granteeUid = session.uid,
+                        anomalyKind = anomalyKind,
                         detail = "grantKeyAccess failed: ${describeThrowable(throwable)}",
                     )
                 }
@@ -112,6 +120,11 @@ class GrantDomainFullChainSplitProbe(
                     granteeChainLength = granteeChain.certificates.size,
                     mismatchIndex = comparison.mismatchIndex,
                     granteeUid = session.uid,
+                    anomalyKind = if (comparison.splitDetected) {
+                        GrantDomainAnomalyKind.ISOLATED_CHAIN_SPLIT
+                    } else {
+                        GrantDomainAnomalyKind.NONE
+                    },
                     detail = comparison.detail,
                 )
             }
@@ -163,6 +176,11 @@ class GrantDomainFullChainSplitProbe(
             val message = throwable.message?.takeIf { it.isNotBlank() }
             return if (message == null) type else "$type: $message"
         }
+
+        internal fun isGrantAliasNotFound(throwable: Throwable): Boolean {
+            return throwable is UnrecoverableKeyException &&
+                throwable.message?.contains("No key found by the given alias", ignoreCase = true) == true
+        }
     }
 }
 
@@ -174,8 +192,16 @@ data class GrantDomainFullChainSplitResult(
     val granteeChainLength: Int = 0,
     val mismatchIndex: Int? = null,
     val granteeUid: Int? = null,
+    val anomalyKind: GrantDomainAnomalyKind = GrantDomainAnomalyKind.UNAVAILABLE,
     val detail: String = "",
 )
+
+enum class GrantDomainAnomalyKind {
+    NONE,
+    ISOLATED_CHAIN_SPLIT,
+    ISOLATED_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN,
+    UNAVAILABLE,
+}
 
 data class GrantDomainFullChainComparison(
     val splitDetected: Boolean,

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantDomainFullChainSplitProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantDomainFullChainSplitProbe.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.verification.keystore
+
+import android.content.Context
+import android.os.Build
+import android.security.keystore.KeyStoreManager
+import com.eltavine.duckdetector.features.tee.data.keystore.AndroidKeyStoreTools
+import java.security.MessageDigest
+import java.security.cert.X509Certificate
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+
+class GrantDomainFullChainSplitProbe(
+    context: Context,
+    private val granteeManager: TeeGrantDomainGranteeManager = TeeGrantDomainGranteeManager(context),
+) {
+
+    private val appContext = context.applicationContext
+
+    suspend fun inspect(useStrongBox: Boolean): GrantDomainFullChainSplitResult {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.BAKLAVA) {
+            return GrantDomainFullChainSplitResult(
+                detail = "Grant-domain full-chain split probe requires Android 16 or newer.",
+            )
+        }
+        val keyStoreManager = runCatching {
+            appContext.getSystemService(KeyStoreManager::class.java)
+        }.getOrNull() ?: return GrantDomainFullChainSplitResult(
+            detail = "KeyStoreManager grant API was unavailable.",
+        )
+        val keyStore = AndroidKeyStoreTools.loadKeyStore()
+        val alias = "duck_grant_domain_${System.nanoTime()}"
+        var granteeUid: Int? = null
+        var grantCreated = false
+        return try {
+            val ownerCertificates = runCatching {
+                AndroidKeyStoreTools.generateAttestedEcChain(
+                    keyStore = keyStore,
+                    alias = alias,
+                    challenge = "duck_grant_domain_${System.nanoTime()}".toByteArray(StandardCharsets.UTF_8),
+                    useStrongBox = useStrongBox,
+                )
+            }.getOrElse { throwable ->
+                return GrantDomainFullChainSplitResult(
+                    detail = "Owner attested key generation failed: ${describeThrowable(throwable)}",
+                )
+            }
+            val ownerChain = GrantDomainCertificateChain.fromCertificates(ownerCertificates)
+            if (ownerChain.certificates.isEmpty()) {
+                return GrantDomainFullChainSplitResult(
+                    detail = "Owner KeyStore certificate chain was empty.",
+                )
+            }
+            val sessionResult = granteeManager.openSession()
+            if (!sessionResult.available || sessionResult.session == null) {
+                return GrantDomainFullChainSplitResult(
+                    detail = sessionResult.detail.ifBlank { "Isolated grant-domain grantee was unavailable." },
+                )
+            }
+            sessionResult.session.use { session ->
+                granteeUid = session.uid
+                val grantId = runCatching {
+                    keyStoreManager.grantKeyAccess(alias, session.uid)
+                }.getOrElse { throwable ->
+                    return GrantDomainFullChainSplitResult(
+                        ownerChainLength = ownerChain.certificates.size,
+                        granteeUid = session.uid,
+                        detail = "grantKeyAccess failed: ${describeThrowable(throwable)}",
+                    )
+                }
+                grantCreated = true
+                val granteeResult = session.readGrantedCertificateChain(grantId)
+                if (!granteeResult.available) {
+                    return GrantDomainFullChainSplitResult(
+                        ownerChainLength = ownerChain.certificates.size,
+                        granteeUid = session.uid,
+                        detail = granteeResult.detail.ifBlank {
+                            "Grantee getGrantedCertificateChainFromId() was unavailable."
+                        },
+                    )
+                }
+                val granteeChain = granteeResult.chain
+                if (granteeChain.certificates.isEmpty()) {
+                    return GrantDomainFullChainSplitResult(
+                        ownerChainLength = ownerChain.certificates.size,
+                        granteeChainLength = 0,
+                        granteeUid = session.uid,
+                        detail = "Grantee granted certificate chain was empty.",
+                    )
+                }
+                val comparison = compareChains(ownerChain, granteeChain)
+                GrantDomainFullChainSplitResult(
+                    executed = true,
+                    available = true,
+                    splitDetected = comparison.splitDetected,
+                    ownerChainLength = ownerChain.certificates.size,
+                    granteeChainLength = granteeChain.certificates.size,
+                    mismatchIndex = comparison.mismatchIndex,
+                    granteeUid = session.uid,
+                    detail = comparison.detail,
+                )
+            }
+        } catch (throwable: Throwable) {
+            GrantDomainFullChainSplitResult(
+                detail = "Grant-domain full-chain split probe failed: ${describeThrowable(throwable)}",
+            )
+        } finally {
+            granteeUid?.takeIf { grantCreated }?.let { uid ->
+                runCatching { keyStoreManager.revokeKeyAccess(alias, uid) }
+            }
+            AndroidKeyStoreTools.safeDelete(keyStore, alias)
+        }
+    }
+
+    companion object {
+        internal fun compareChains(
+            ownerChain: GrantDomainCertificateChain,
+            granteeChain: GrantDomainCertificateChain,
+        ): GrantDomainFullChainComparison {
+            val owner = ownerChain.certificates
+            val grantee = granteeChain.certificates
+            val min = minOf(owner.size, grantee.size)
+            for (index in 0 until min) {
+                if (owner[index] != grantee[index]) {
+                    val reason = if (index == 0) "leafMismatch" else "chainMismatch"
+                    return GrantDomainFullChainComparison(
+                        splitDetected = true,
+                        mismatchIndex = index,
+                        detail = "$reason index=$index owner=${owner[index].summary()} grantee=${grantee[index].summary()}",
+                    )
+                }
+            }
+            if (owner.size != grantee.size) {
+                return GrantDomainFullChainComparison(
+                    splitDetected = true,
+                    mismatchIndex = min,
+                    detail = "lengthMismatch owner=${owner.size} grantee=${grantee.size}",
+                )
+            }
+            return GrantDomainFullChainComparison(
+                splitDetected = false,
+                detail = "Owner alias and grantee Domain.GRANT ordered full-chain fingerprints matched.",
+            )
+        }
+
+        internal fun describeThrowable(throwable: Throwable): String {
+            val type = throwable.javaClass.simpleName.ifBlank { throwable.javaClass.name }
+            val message = throwable.message?.takeIf { it.isNotBlank() }
+            return if (message == null) type else "$type: $message"
+        }
+    }
+}
+
+data class GrantDomainFullChainSplitResult(
+    val executed: Boolean = false,
+    val available: Boolean = false,
+    val splitDetected: Boolean = false,
+    val ownerChainLength: Int = 0,
+    val granteeChainLength: Int = 0,
+    val mismatchIndex: Int? = null,
+    val granteeUid: Int? = null,
+    val detail: String = "",
+)
+
+data class GrantDomainFullChainComparison(
+    val splitDetected: Boolean,
+    val mismatchIndex: Int? = null,
+    val detail: String,
+)
+
+data class GrantDomainCertificateChain(
+    val certificates: List<GrantDomainCertificateFingerprint> = emptyList(),
+) {
+    companion object {
+        fun fromCertificates(certificates: List<X509Certificate>): GrantDomainCertificateChain {
+            return GrantDomainCertificateChain(
+                certificates = certificates.map { certificate ->
+                    GrantDomainCertificateFingerprint.fromDer(certificate.encoded)
+                },
+            )
+        }
+    }
+}
+
+data class GrantDomainCertificateFingerprint(
+    val derLength: Int,
+    val sha256: String,
+) {
+    fun summary(): String {
+        return "len=$derLength sha256=${sha256.take(16)}"
+    }
+
+    companion object {
+        fun fromDer(der: ByteArray): GrantDomainCertificateFingerprint {
+            val digest = MessageDigest.getInstance("SHA-256").digest(der)
+            return GrantDomainCertificateFingerprint(
+                derLength = der.size,
+                sha256 = digest.joinToString(separator = "") { byte ->
+                    "%02x".format(Locale.US, byte.toInt() and 0xff)
+                },
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantSelfDomainFullChainSplitProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantSelfDomainFullChainSplitProbe.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.verification.keystore
+
+import android.content.Context
+import android.os.Build
+import android.os.Process
+import android.security.keystore.KeyStoreManager
+import com.eltavine.duckdetector.features.tee.data.keystore.AndroidKeyStoreTools
+import java.nio.charset.StandardCharsets
+import java.security.cert.X509Certificate
+
+class GrantSelfDomainFullChainSplitProbe(
+    context: Context,
+) {
+
+    private val appContext = context.applicationContext
+
+    suspend fun inspect(useStrongBox: Boolean): GrantSelfDomainFullChainSplitResult {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.BAKLAVA) {
+            return GrantSelfDomainFullChainSplitResult(
+                detail = "Grant self-domain full-chain split probe requires Android 16 or newer.",
+            )
+        }
+        val keyStoreManager = runCatching {
+            appContext.getSystemService(KeyStoreManager::class.java)
+        }.getOrNull() ?: return GrantSelfDomainFullChainSplitResult(
+            detail = "KeyStoreManager grant API was unavailable.",
+        )
+        val keyStore = AndroidKeyStoreTools.loadKeyStore()
+        val alias = "duck_grant_self_domain_${System.nanoTime()}"
+        val selfUid = Process.myUid()
+        var grantCreated = false
+        return try {
+            val ownerCertificates = runCatching {
+                AndroidKeyStoreTools.generateAttestedEcChain(
+                    keyStore = keyStore,
+                    alias = alias,
+                    challenge = "duck_grant_self_domain_${System.nanoTime()}".toByteArray(StandardCharsets.UTF_8),
+                    useStrongBox = useStrongBox,
+                )
+            }.getOrElse { throwable ->
+                return GrantSelfDomainFullChainSplitResult(
+                    detail = "Owner attested key generation failed: ${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}",
+                )
+            }
+            val ownerChain = GrantDomainCertificateChain.fromCertificates(ownerCertificates)
+            if (ownerChain.certificates.isEmpty()) {
+                return GrantSelfDomainFullChainSplitResult(
+                    detail = "Owner KeyStore certificate chain was empty.",
+                )
+            }
+            val grantId = runCatching {
+                keyStoreManager.grantKeyAccess(alias, selfUid)
+            }.getOrElse { throwable ->
+                return GrantSelfDomainFullChainSplitResult(
+                    ownerChainLength = ownerChain.certificates.size,
+                    detail = "self grantKeyAccess failed: ${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}",
+                )
+            }
+            grantCreated = true
+            val grantCertificates = runCatching {
+                keyStoreManager.getGrantedCertificateChainFromId(grantId)
+                    .filterIsInstance<X509Certificate>()
+            }.getOrElse { throwable ->
+                return GrantSelfDomainFullChainSplitResult(
+                    ownerChainLength = ownerChain.certificates.size,
+                    grantIdPresent = true,
+                    detail = "self getGrantedCertificateChainFromId failed: ${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}",
+                )
+            }
+            val grantChain = GrantDomainCertificateChain.fromCertificates(grantCertificates)
+            if (grantChain.certificates.isEmpty()) {
+                return GrantSelfDomainFullChainSplitResult(
+                    ownerChainLength = ownerChain.certificates.size,
+                    grantChainLength = 0,
+                    grantIdPresent = true,
+                    detail = "Self Domain.GRANT certificate chain was empty.",
+                )
+            }
+            // 同 UID 自授权验证普通 app 域能访问 Domain.GRANT；该路径避开 isolated_app 的 keystore2 SELinux 限制。
+            // Self-grant verifies ordinary-app Domain.GRANT visibility while avoiding isolated_app keystore2 SELinux limits.
+            val comparison = compareChains(ownerChain, grantChain)
+            GrantSelfDomainFullChainSplitResult(
+                executed = true,
+                available = true,
+                splitDetected = comparison.splitDetected,
+                ownerChainLength = ownerChain.certificates.size,
+                grantChainLength = grantChain.certificates.size,
+                mismatchIndex = comparison.mismatchIndex,
+                grantIdPresent = true,
+                anomalyKind = if (comparison.splitDetected) {
+                    GrantSelfDomainAnomalyKind.SELF_CHAIN_SPLIT
+                } else {
+                    GrantSelfDomainAnomalyKind.NONE
+                },
+                detail = comparison.detail,
+            )
+        } catch (throwable: Throwable) {
+            GrantSelfDomainFullChainSplitResult(
+                detail = "Grant self-domain full-chain split probe failed: ${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}",
+            )
+        } finally {
+            if (grantCreated) {
+                runCatching { keyStoreManager.revokeKeyAccess(alias, selfUid) }
+            }
+            AndroidKeyStoreTools.safeDelete(keyStore, alias)
+        }
+    }
+
+    companion object {
+        internal fun compareChains(
+            ownerChain: GrantDomainCertificateChain,
+            grantChain: GrantDomainCertificateChain,
+        ): GrantDomainFullChainComparison {
+            return GrantDomainFullChainSplitProbe.compareChains(ownerChain, grantChain)
+        }
+    }
+}
+
+data class GrantSelfDomainFullChainSplitResult(
+    val executed: Boolean = false,
+    val available: Boolean = false,
+    val splitDetected: Boolean = false,
+    val ownerChainLength: Int = 0,
+    val grantChainLength: Int = 0,
+    val mismatchIndex: Int? = null,
+    val grantIdPresent: Boolean = false,
+    val anomalyKind: GrantSelfDomainAnomalyKind = GrantSelfDomainAnomalyKind.UNAVAILABLE,
+    val detail: String = "",
+)
+
+enum class GrantSelfDomainAnomalyKind {
+    NONE,
+    SELF_CHAIN_SPLIT,
+    UNAVAILABLE,
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantSelfDomainFullChainSplitProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantSelfDomainFullChainSplitProbe.kt
@@ -67,8 +67,17 @@ class GrantSelfDomainFullChainSplitProbe(
             val grantId = runCatching {
                 keyStoreManager.grantKeyAccess(alias, selfUid)
             }.getOrElse { throwable ->
+                // owner 可见 alias 却被 grant path 报 key-not-found，说明 framework 叙事和 Keystore2 授权域发生断裂。
+                // If owner sees the alias but the grant path reports key-not-found, framework narrative and Keystore2 grant state diverged.
+                val anomalyKind = if (GrantDomainFullChainSplitProbe.isGrantAliasNotFound(throwable)) {
+                    GrantSelfDomainAnomalyKind.SELF_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN
+                } else {
+                    GrantSelfDomainAnomalyKind.UNAVAILABLE
+                }
                 return GrantSelfDomainFullChainSplitResult(
+                    executed = anomalyKind == GrantSelfDomainAnomalyKind.SELF_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN,
                     ownerChainLength = ownerChain.certificates.size,
+                    anomalyKind = anomalyKind,
                     detail = "self grantKeyAccess failed: ${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}",
                 )
             }
@@ -147,5 +156,6 @@ data class GrantSelfDomainFullChainSplitResult(
 enum class GrantSelfDomainAnomalyKind {
     NONE,
     SELF_CHAIN_SPLIT,
+    SELF_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN,
     UNAVAILABLE,
 }

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantSelfDomainFullChainSplitProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantSelfDomainFullChainSplitProbe.kt
@@ -64,11 +64,13 @@ class GrantSelfDomainFullChainSplitProbe(
                     detail = "Owner KeyStore certificate chain was empty.",
                 )
             }
+            // self-domain 是 isolated-domain 的去噪版本：同 UID grant 排除了 isolated_app SELinux/service 可达性变量。
+            // self-domain is the de-noised counterpart to isolated-domain: same-UID grant removes isolated_app SELinux/service reachability variables.
             val grantId = runCatching {
                 keyStoreManager.grantKeyAccess(alias, selfUid)
             }.getOrElse { throwable ->
-                // owner 可见 alias 却被 grant path 报 key-not-found，说明 framework 叙事和 Keystore2 授权域发生断裂。
-                // If owner sees the alias but the grant path reports key-not-found, framework narrative and Keystore2 grant state diverged.
+                // owner chain 已经证明 alias 在 Java KeyStore 视图中存在；同 UID grant 仍 key-not-found 指向 keystore2 alias 查找被 hook/缓存叙事污染。
+                // The owner chain proves the alias exists in Java KeyStore view; same-UID key-not-found points to hook/cache contamination in keystore2 alias lookup.
                 val anomalyKind = if (GrantDomainFullChainSplitProbe.isGrantAliasNotFound(throwable)) {
                     GrantSelfDomainAnomalyKind.SELF_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN
                 } else {
@@ -82,6 +84,8 @@ class GrantSelfDomainFullChainSplitProbe(
                 )
             }
             grantCreated = true
+            // grant 成功后读取 Domain.GRANT 证书链，验证授权域叙事是否与 owner alias 的 attested chain 一致。
+            // Once grant succeeds, read Domain.GRANT chain to verify whether grant-domain narrative matches owner alias attested chain.
             val grantCertificates = runCatching {
                 keyStoreManager.getGrantedCertificateChainFromId(grantId)
                     .filterIsInstance<X509Certificate>()

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/ImportKeyRetainedAttestationNarrativeProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/ImportKeyRetainedAttestationNarrativeProbe.kt
@@ -448,6 +448,8 @@ enum class ImportKeyRetainedAttestationAnomalyKind {
     NONE,
     IMPORT_UNSUPPORTED,
     IMPORTED_RETAINED_PRIOR_CHAIN,
+    // Import support was proven separately; GENERATED plus prior-chain overlap means a stale attestation narrative was replayed after overwrite.
+    // 已经单独证明 import 支持；GENERATED 且与旧链重叠表示覆盖后仍回放了陈旧认证叙事。
     STALE_GENERATED_AFTER_IMPORT,
     UNAVAILABLE,
 }

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/ImportKeyRetainedAttestationNarrativeProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/ImportKeyRetainedAttestationNarrativeProbe.kt
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.verification.keystore
+
+import android.content.Context
+import android.os.Build
+import android.security.keystore.KeyProtection
+import android.security.keystore.KeyProperties
+import com.eltavine.duckdetector.features.tee.data.keystore.AndroidKeyStoreTools
+import java.io.ByteArrayInputStream
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.util.Locale
+
+class ImportKeyRetainedAttestationNarrativeProbe internal constructor(
+    private val runtime: Runtime,
+    private val aliasFactory: () -> String = { "duck_importkey_retained_${System.nanoTime()}" },
+) {
+
+    constructor(
+        context: Context,
+        binderClient: Keystore2PrivateBinderClient = Keystore2PrivateBinderClient(),
+    ) : this(AndroidRuntime(context.applicationContext, binderClient))
+
+    fun inspect(): ImportKeyRetainedAttestationNarrativeResult {
+        if (!runtime.supported) {
+            return unavailable("ImportKey retained narrative probe requires Android 12 or newer.")
+        }
+        val alias = aliasFactory()
+        return try {
+            val challenge = ByteArray(CHALLENGE_SIZE_BYTES).also(SecureRandom()::nextBytes)
+            val priorChain = runtime.generatePriorAttestedChain(alias, challenge)
+            if (priorChain.isEmpty()) {
+                return unavailable("Prior attested chain was unavailable for the importKey probe alias.")
+            }
+            runtime.importMarkerKey(alias)
+            val metadata = runtime.readPostImportMetadata(alias)
+                ?: return unavailable("Keystore2 getKeyEntry() metadata was unavailable after import.")
+            evaluatePostImportState(
+                priorChain = priorChain,
+                postImportChain = metadata.certificateChain,
+                originValue = metadata.originValue,
+                importedOriginValues = runtime.importedOriginValues,
+                originLabel = runtime.originLabel(metadata.originValue),
+            )
+        } catch (throwable: Throwable) {
+            unavailable(runtime.describeThrowable(throwable))
+        } finally {
+            runtime.cleanup(alias)
+        }
+    }
+
+    internal interface Runtime {
+        val supported: Boolean
+        val importedOriginValues: Set<Int>
+
+        fun generatePriorAttestedChain(alias: String, challenge: ByteArray): List<ByteArray>
+        fun importMarkerKey(alias: String)
+        fun readPostImportMetadata(alias: String): PostImportMetadata?
+        fun cleanup(alias: String)
+
+        fun originLabel(value: Int?): String = when (value) {
+            null -> "unknown"
+            else -> value.toString()
+        }
+
+        fun describeThrowable(throwable: Throwable): String {
+            return throwable.message ?: "ImportKey retained narrative probe failed."
+        }
+    }
+
+    internal data class PostImportMetadata(
+        val originValue: Int?,
+        val certificateChain: List<ByteArray>,
+    )
+
+    private class AndroidRuntime(
+        context: Context,
+        private val binderClient: Keystore2PrivateBinderClient,
+    ) : Runtime {
+        private val appContext = context.applicationContext
+        private val certificateFactory = CertificateFactory.getInstance("X.509")
+        private val keyStore = AndroidKeyStoreTools.loadKeyStore()
+
+        override val supported: Boolean
+            get() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
+
+        override val importedOriginValues: Set<Int>
+            get() = setOfNotNull(
+                binderClient.getKeyOriginValue("IMPORTED"),
+                binderClient.getKeyOriginValue("SECURELY_IMPORTED"),
+                ORIGIN_IMPORTED_FALLBACK,
+                ORIGIN_SECURELY_IMPORTED_FALLBACK,
+            )
+
+        override fun generatePriorAttestedChain(alias: String, challenge: ByteArray): List<ByteArray> {
+            AndroidKeyStoreTools.generateSigningEcKey(
+                keyStore = keyStore,
+                alias = alias,
+                subject = "CN=DuckDetector ImportKey Retained, O=Eltavine",
+                useStrongBox = false,
+                challenge = challenge,
+            )
+            return AndroidKeyStoreTools.readCertificateChain(keyStore, alias)
+                .map(X509Certificate::getEncoded)
+        }
+
+        override fun importMarkerKey(alias: String) {
+            val fixture = KeyboxFixtureLoader(appContext).load()
+            val protection = KeyProtection.Builder(
+                KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY,
+            )
+                .setDigests(KeyProperties.DIGEST_SHA256)
+                .build()
+            keyStore.setEntry(
+                alias,
+                java.security.KeyStore.PrivateKeyEntry(fixture.privateKey, arrayOf(fixture.certificate)),
+                protection,
+            )
+        }
+
+        override fun readPostImportMetadata(alias: String): PostImportMetadata? {
+            val service = binderClient.getKeystoreService() ?: return null
+            val response = binderClient.getKeyEntryResponse(service, binderClient.createKeyDescriptor(alias))
+                ?: return null
+            val metadata = binderClient.getMetadata(response) ?: return null
+            val originTag = binderClient.getTagValue("ORIGIN")
+            val originValue = originTag?.let { tag ->
+                binderClient.getMetadataAuthorizations(metadata)
+                    .firstOrNull { authorization ->
+                        authorization?.let(binderClient::getAuthorizationTag) == tag
+                    }
+                    ?.let { authorization -> binderClient.getAuthorizationIntValue(authorization) }
+            }
+            val chainBlob = binderClient.getCertificateChainBlob(response)
+            return PostImportMetadata(
+                originValue = originValue,
+                certificateChain = parseCertificates(chainBlob),
+            )
+        }
+
+        override fun cleanup(alias: String) {
+            AndroidKeyStoreTools.safeDelete(keyStore, alias)
+        }
+
+        override fun originLabel(value: Int?): String {
+            return when (value) {
+                null -> "unknown"
+                binderClient.getKeyOriginValue("GENERATED") -> "GENERATED"
+                binderClient.getKeyOriginValue("DERIVED") -> "DERIVED"
+                binderClient.getKeyOriginValue("IMPORTED") -> "IMPORTED"
+                binderClient.getKeyOriginValue("UNKNOWN") -> "UNKNOWN"
+                binderClient.getKeyOriginValue("SECURELY_IMPORTED") -> "SECURELY_IMPORTED"
+                else -> value.toString()
+            }
+        }
+
+        override fun describeThrowable(throwable: Throwable): String {
+            return binderClient.describeThrowable(throwable)
+        }
+
+        private fun parseCertificates(blob: ByteArray?): List<ByteArray> {
+            if (blob == null || blob.isEmpty()) {
+                return emptyList()
+            }
+            return runCatching {
+                certificateFactory.generateCertificates(ByteArrayInputStream(blob))
+                    .filterIsInstance<X509Certificate>()
+                    .map(X509Certificate::getEncoded)
+            }.getOrDefault(emptyList())
+        }
+    }
+
+    companion object {
+        private const val CHALLENGE_SIZE_BYTES = 32
+        private const val ORIGIN_IMPORTED_FALLBACK = 2
+        private const val ORIGIN_SECURELY_IMPORTED_FALLBACK = 4
+
+        internal fun evaluatePostImportState(
+            priorChain: List<ByteArray>,
+            postImportChain: List<ByteArray>,
+            originValue: Int?,
+            importedOriginValues: Set<Int> = setOf(
+                ORIGIN_IMPORTED_FALLBACK,
+                ORIGIN_SECURELY_IMPORTED_FALLBACK,
+            ),
+            originLabel: String = originValue?.toString() ?: "unknown",
+        ): ImportKeyRetainedAttestationNarrativeResult {
+            val priorFingerprints = fingerprintChain(priorChain)
+            val postImportFingerprints = fingerprintChain(postImportChain)
+            if (originValue == null || originValue !in importedOriginValues) {
+                return unavailable(
+                    detail = "Imported key ORIGIN was not established after alias overwrite: origin=$originLabel.",
+                    priorChainLength = priorFingerprints.size,
+                    postImportChainLength = postImportFingerprints.size,
+                    originLabel = originLabel,
+                )
+            }
+            if (postImportFingerprints.isEmpty()) {
+                return ImportKeyRetainedAttestationNarrativeResult(
+                    executed = true,
+                    originImported = true,
+                    retainedNarrativeDetected = false,
+                    priorChainLength = priorFingerprints.size,
+                    postImportChainLength = 0,
+                    retainedCertificateCount = 0,
+                    originLabel = originLabel,
+                    detail = "origin=$originLabel, imported key returned no certificateChain after alias overwrite.",
+                )
+            }
+            val retained = postImportFingerprints.filter { post ->
+                priorFingerprints.any { prior -> prior.sha256 == post.sha256 }
+            }
+            if (retained.isEmpty()) {
+                return unavailable(
+                    detail = "origin=$originLabel, post-import certificateChain was present but did not match the prior attestation narrative.",
+                    priorChainLength = priorFingerprints.size,
+                    postImportChainLength = postImportFingerprints.size,
+                    originLabel = originLabel,
+                )
+            }
+            return ImportKeyRetainedAttestationNarrativeResult(
+                executed = true,
+                originImported = true,
+                retainedNarrativeDetected = true,
+                priorChainLength = priorFingerprints.size,
+                postImportChainLength = postImportFingerprints.size,
+                retainedCertificateCount = retained.size,
+                originLabel = originLabel,
+                retainedFingerprint = retained.first().shortSha256,
+                detail = "origin=$originLabel, retained=${retained.size}, priorChain=${priorFingerprints.size}, postImportChain=${postImportFingerprints.size}, firstRetained=${retained.first().shortSha256}.",
+            )
+        }
+
+        private fun unavailable(
+            detail: String,
+            priorChainLength: Int = 0,
+            postImportChainLength: Int = 0,
+            originLabel: String = "unknown",
+        ): ImportKeyRetainedAttestationNarrativeResult {
+            return ImportKeyRetainedAttestationNarrativeResult(
+                executed = false,
+                originImported = false,
+                retainedNarrativeDetected = false,
+                priorChainLength = priorChainLength,
+                postImportChainLength = postImportChainLength,
+                retainedCertificateCount = 0,
+                originLabel = originLabel,
+                detail = detail,
+            )
+        }
+
+        private fun fingerprintChain(chain: List<ByteArray>): List<CertificateFingerprint> {
+            return chain.mapIndexed { index, der ->
+                val sha256 = der.sha256Hex()
+                CertificateFingerprint(
+                    index = index,
+                    derLength = der.size,
+                    sha256 = sha256,
+                    shortSha256 = sha256.take(12),
+                )
+            }
+        }
+
+        private fun ByteArray.sha256Hex(): String {
+            val digest = MessageDigest.getInstance("SHA-256").digest(this)
+            return digest.joinToString(separator = "") { byte ->
+                "%02x".format(Locale.US, byte)
+            }
+        }
+    }
+}
+
+data class ImportKeyRetainedAttestationNarrativeResult(
+    val executed: Boolean,
+    val originImported: Boolean = false,
+    val retainedNarrativeDetected: Boolean = false,
+    val priorChainLength: Int = 0,
+    val postImportChainLength: Int = 0,
+    val retainedCertificateCount: Int = 0,
+    val originLabel: String = "unknown",
+    val retainedFingerprint: String? = null,
+    val detail: String,
+)
+
+private data class CertificateFingerprint(
+    val index: Int,
+    val derLength: Int,
+    val sha256: String,
+    val shortSha256: String,
+)

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/ImportKeyRetainedAttestationNarrativeProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/ImportKeyRetainedAttestationNarrativeProbe.kt
@@ -42,37 +42,69 @@ class ImportKeyRetainedAttestationNarrativeProbe internal constructor(
         if (!runtime.supported) {
             return unavailable("ImportKey retained narrative probe requires Android 12 or newer.")
         }
-        val alias = aliasFactory()
+        val supportAlias = "${aliasFactory()}_support"
+        val attackAlias = "${aliasFactory()}_attack"
         return try {
-            val challenge = ByteArray(CHALLENGE_SIZE_BYTES).also(SecureRandom()::nextBytes)
-            val priorChain = runtime.generatePriorAttestedChain(alias, challenge)
-            if (priorChain.isEmpty()) {
-                return unavailable("Prior attested chain was unavailable for the importKey probe alias.")
+            // 防误报 gate：先证明本 ROM 对普通 APP alias 的 importKey 路径可用且可观测，再进入攻击态对比。
+            // False-positive gate: prove ordinary APP-alias importKey is supported and observable before comparing attack-state narratives.
+            val support = runtime.verifyImportSupport(supportAlias)
+            if (!support.supported) {
+                return unavailable(
+                    detail = support.detail,
+                    anomalyKind = ImportKeyRetainedAttestationAnomalyKind.IMPORT_UNSUPPORTED,
+                    importSupported = false,
+                    markerImportBaselineClean = false,
+                    postImportLeafMatchesMarker = support.leafMatchesMarker,
+                    originLabel = support.originLabel,
+                )
             }
-            runtime.importMarkerKey(alias)
-            val metadata = runtime.readPostImportMetadata(alias)
-                ?: return unavailable("Keystore2 getKeyEntry() metadata was unavailable after import.")
+            val challenge = ByteArray(CHALLENGE_SIZE_BYTES).also(SecureRandom()::nextBytes)
+            val priorChain = runtime.generatePriorAttestedChain(attackAlias, challenge)
+            if (priorChain.isEmpty()) {
+                return unavailable(
+                    detail = "Prior attested chain was unavailable for the importKey probe alias.",
+                    importSupported = true,
+                    markerImportBaselineClean = true,
+                )
+            }
+            runtime.importMarkerKey(attackAlias)
+            // TEES-RS may consume the first getKeyEntry() after framework updateSubcomponents(); read twice to observe the stable post-import state.
+            // TEES-RS 可能会在 framework updateSubcomponents() 之后吞掉第一次 getKeyEntry() patch；双读用于观测稳定的 import 后状态。
+            val snapshots = runtime.readPostImportMetadataSnapshots(attackAlias)
+            if (snapshots.isEmpty()) {
+                return unavailable(
+                    detail = "Keystore2 getKeyEntry() metadata was unavailable after import.",
+                    importSupported = true,
+                    markerImportBaselineClean = true,
+                    priorChainLength = priorChain.size,
+                )
+            }
             evaluatePostImportState(
                 priorChain = priorChain,
-                postImportChain = metadata.certificateChain,
-                originValue = metadata.originValue,
+                snapshots = snapshots,
                 importedOriginValues = runtime.importedOriginValues,
-                originLabel = runtime.originLabel(metadata.originValue),
+                generatedOriginValue = runtime.generatedOriginValue,
+                importSupported = true,
+                markerImportBaselineClean = true,
+                originLabel = { value -> runtime.originLabel(value) },
             )
         } catch (throwable: Throwable) {
             unavailable(runtime.describeThrowable(throwable))
         } finally {
-            runtime.cleanup(alias)
+            runtime.cleanup(supportAlias)
+            runtime.cleanup(attackAlias)
         }
     }
 
     internal interface Runtime {
         val supported: Boolean
         val importedOriginValues: Set<Int>
+        val generatedOriginValue: Int?
 
         fun generatePriorAttestedChain(alias: String, challenge: ByteArray): List<ByteArray>
         fun importMarkerKey(alias: String)
-        fun readPostImportMetadata(alias: String): PostImportMetadata?
+        fun verifyImportSupport(alias: String): ImportSupportResult
+        fun readPostImportMetadataSnapshots(alias: String): List<PostImportMetadata>
         fun cleanup(alias: String)
 
         fun originLabel(value: Int?): String = when (value) {
@@ -87,7 +119,16 @@ class ImportKeyRetainedAttestationNarrativeProbe internal constructor(
 
     internal data class PostImportMetadata(
         val originValue: Int?,
-        val certificateChain: List<ByteArray>,
+        val fullChain: List<ByteArray>,
+        val leafMatchesMarker: Boolean,
+    )
+
+    internal data class ImportSupportResult(
+        val supported: Boolean,
+        val leafMatchesMarker: Boolean,
+        val originValue: Int?,
+        val originLabel: String,
+        val detail: String,
     )
 
     private class AndroidRuntime(
@@ -108,6 +149,9 @@ class ImportKeyRetainedAttestationNarrativeProbe internal constructor(
                 ORIGIN_IMPORTED_FALLBACK,
                 ORIGIN_SECURELY_IMPORTED_FALLBACK,
             )
+
+        override val generatedOriginValue: Int?
+            get() = binderClient.getKeyOriginValue("GENERATED") ?: ORIGIN_GENERATED_FALLBACK
 
         override fun generatePriorAttestedChain(alias: String, challenge: ByteArray): List<ByteArray> {
             AndroidKeyStoreTools.generateSigningEcKey(
@@ -135,7 +179,33 @@ class ImportKeyRetainedAttestationNarrativeProbe internal constructor(
             )
         }
 
-        override fun readPostImportMetadata(alias: String): PostImportMetadata? {
+        override fun verifyImportSupport(alias: String): ImportSupportResult {
+            importMarkerKey(alias)
+            val metadata = readPostImportMetadata(alias)
+            val originImported = metadata?.originValue in importedOriginValues
+            val leafMatchesMarker = metadata?.leafMatchesMarker == true
+            val supported = originImported && leafMatchesMarker
+            return ImportSupportResult(
+                supported = supported,
+                leafMatchesMarker = leafMatchesMarker,
+                originValue = metadata?.originValue,
+                originLabel = originLabel(metadata?.originValue),
+                detail = if (supported) {
+                    "origin=${originLabel(metadata.originValue)}, marker import baseline clean."
+                } else {
+                    "ImportKey support gate failed: origin=${originLabel(metadata?.originValue)}, leafMatchesMarker=$leafMatchesMarker."
+                },
+            )
+        }
+
+        override fun readPostImportMetadataSnapshots(alias: String): List<PostImportMetadata> {
+            return listOfNotNull(
+                readPostImportMetadata(alias),
+                readPostImportMetadata(alias),
+            )
+        }
+
+        private fun readPostImportMetadata(alias: String): PostImportMetadata? {
             val service = binderClient.getKeystoreService() ?: return null
             val response = binderClient.getKeyEntryResponse(service, binderClient.createKeyDescriptor(alias))
                 ?: return null
@@ -148,10 +218,15 @@ class ImportKeyRetainedAttestationNarrativeProbe internal constructor(
                     }
                     ?.let { authorization -> binderClient.getAuthorizationIntValue(authorization) }
             }
+            val markerLeaf = KeyboxFixtureLoader(appContext).load().certificate.encoded
+            val leafBlob = binderClient.getCertificateBlob(response)
             val chainBlob = binderClient.getCertificateChainBlob(response)
             return PostImportMetadata(
                 originValue = originValue,
-                certificateChain = parseCertificates(chainBlob),
+                // Keystore2 stores the leaf separately from the remaining chain; compare the ordered full narrative, not only certificateChain.
+                // Keystore2 会把叶证书和剩余链分开放；这里必须比较有序完整叙事，而不是只比较 certificateChain。
+                fullChain = buildFullChain(leafBlob, chainBlob),
+                leafMatchesMarker = leafBlob?.contentEquals(markerLeaf) == true,
             )
         }
 
@@ -175,6 +250,10 @@ class ImportKeyRetainedAttestationNarrativeProbe internal constructor(
             return binderClient.describeThrowable(throwable)
         }
 
+        private fun buildFullChain(leafBlob: ByteArray?, chainBlob: ByteArray?): List<ByteArray> {
+            return listOfNotNull(leafBlob?.takeIf { it.isNotEmpty() }) + parseCertificates(chainBlob)
+        }
+
         private fun parseCertificates(blob: ByteArray?): List<ByteArray> {
             if (blob == null || blob.isEmpty()) {
                 return emptyList()
@@ -189,79 +268,157 @@ class ImportKeyRetainedAttestationNarrativeProbe internal constructor(
 
     companion object {
         private const val CHALLENGE_SIZE_BYTES = 32
+        private const val ORIGIN_GENERATED_FALLBACK = 0
         private const val ORIGIN_IMPORTED_FALLBACK = 2
         private const val ORIGIN_SECURELY_IMPORTED_FALLBACK = 4
 
         internal fun evaluatePostImportState(
             priorChain: List<ByteArray>,
-            postImportChain: List<ByteArray>,
-            originValue: Int?,
+            snapshots: List<PostImportMetadata>,
             importedOriginValues: Set<Int> = setOf(
                 ORIGIN_IMPORTED_FALLBACK,
                 ORIGIN_SECURELY_IMPORTED_FALLBACK,
             ),
-            originLabel: String = originValue?.toString() ?: "unknown",
+            generatedOriginValue: Int? = ORIGIN_GENERATED_FALLBACK,
+            importSupported: Boolean = true,
+            markerImportBaselineClean: Boolean = true,
+            originLabel: (Int?) -> String = { value -> value?.toString() ?: "unknown" },
         ): ImportKeyRetainedAttestationNarrativeResult {
-            val priorFingerprints = fingerprintChain(priorChain)
-            val postImportFingerprints = fingerprintChain(postImportChain)
-            if (originValue == null || originValue !in importedOriginValues) {
+            if (!importSupported) {
                 return unavailable(
-                    detail = "Imported key ORIGIN was not established after alias overwrite: origin=$originLabel.",
-                    priorChainLength = priorFingerprints.size,
-                    postImportChainLength = postImportFingerprints.size,
-                    originLabel = originLabel,
+                    detail = "ImportKey support gate failed before retained narrative comparison.",
+                    anomalyKind = ImportKeyRetainedAttestationAnomalyKind.IMPORT_UNSUPPORTED,
+                    importSupported = false,
+                    markerImportBaselineClean = false,
                 )
             }
-            if (postImportFingerprints.isEmpty()) {
+            val priorFingerprints = fingerprintChain(priorChain)
+            if (snapshots.isEmpty()) {
+                return unavailable(
+                    detail = "Keystore2 getKeyEntry() returned no post-import metadata snapshots.",
+                    importSupported = true,
+                    markerImportBaselineClean = markerImportBaselineClean,
+                    priorChainLength = priorFingerprints.size,
+                )
+            }
+            val evaluated = snapshots.map { snapshot ->
+                EvaluatedSnapshot(
+                    metadata = snapshot,
+                    fingerprints = fingerprintChain(snapshot.fullChain),
+                    retained = fingerprintChain(snapshot.fullChain).filter { post ->
+                        priorFingerprints.any { prior -> prior.sha256 == post.sha256 }
+                    },
+                )
+            }
+            val importedRetained = evaluated.firstOrNull { item ->
+                item.metadata.originValue in importedOriginValues && item.retained.isNotEmpty()
+            }
+            if (importedRetained != null) {
+                return matched(
+                    anomalyKind = ImportKeyRetainedAttestationAnomalyKind.IMPORTED_RETAINED_PRIOR_CHAIN,
+                    priorFingerprints = priorFingerprints,
+                    postImportFingerprints = importedRetained.fingerprints,
+                    retained = importedRetained.retained,
+                    originLabel = originLabel(importedRetained.metadata.originValue),
+                    postImportLeafMatchesMarker = importedRetained.metadata.leafMatchesMarker,
+                    detailPrefix = "kind=IMPORTED_RETAINED_PRIOR_CHAIN",
+                )
+            }
+            val staleGenerated = evaluated.firstOrNull { item ->
+                item.metadata.originValue == generatedOriginValue && item.retained.isNotEmpty()
+            }
+            if (staleGenerated != null) {
+                // TEES-RS stale-cache variant: import support was proven, but getKeyEntry still replays the previous GENERATED attestation story.
+                // TEES-RS stale-cache 变体：import 支持已被 gate 证明，但 getKeyEntry 仍回放旧 GENERATED 认证叙事。
+                return matched(
+                    anomalyKind = ImportKeyRetainedAttestationAnomalyKind.STALE_GENERATED_AFTER_IMPORT,
+                    priorFingerprints = priorFingerprints,
+                    postImportFingerprints = staleGenerated.fingerprints,
+                    retained = staleGenerated.retained,
+                    originLabel = originLabel(staleGenerated.metadata.originValue),
+                    postImportLeafMatchesMarker = staleGenerated.metadata.leafMatchesMarker,
+                    detailPrefix = "kind=STALE_GENERATED_AFTER_IMPORT",
+                )
+            }
+            val cleanImported = evaluated.firstOrNull { item ->
+                item.metadata.originValue in importedOriginValues && item.metadata.leafMatchesMarker
+            }
+            if (cleanImported != null) {
                 return ImportKeyRetainedAttestationNarrativeResult(
                     executed = true,
+                    importSupported = true,
+                    markerImportBaselineClean = markerImportBaselineClean,
                     originImported = true,
+                    postImportLeafMatchesMarker = true,
                     retainedNarrativeDetected = false,
                     priorChainLength = priorFingerprints.size,
-                    postImportChainLength = 0,
+                    postImportChainLength = cleanImported.fingerprints.size,
                     retainedCertificateCount = 0,
-                    originLabel = originLabel,
-                    detail = "origin=$originLabel, imported key returned no certificateChain after alias overwrite.",
+                    originLabel = originLabel(cleanImported.metadata.originValue),
+                    anomalyKind = ImportKeyRetainedAttestationAnomalyKind.NONE,
+                    detail = "kind=NONE, origin=${originLabel(cleanImported.metadata.originValue)}, imported marker leaf returned without retained prior narrative.",
                 )
             }
-            val retained = postImportFingerprints.filter { post ->
-                priorFingerprints.any { prior -> prior.sha256 == post.sha256 }
-            }
-            if (retained.isEmpty()) {
-                return unavailable(
-                    detail = "origin=$originLabel, post-import certificateChain was present but did not match the prior attestation narrative.",
-                    priorChainLength = priorFingerprints.size,
-                    postImportChainLength = postImportFingerprints.size,
-                    originLabel = originLabel,
-                )
-            }
+            val representative = evaluated.firstOrNull()
+            return unavailable(
+                detail = "Post-import metadata did not produce an imported marker baseline or retained prior narrative: origin=${originLabel(representative?.metadata?.originValue)}, leafMatchesMarker=${representative?.metadata?.leafMatchesMarker == true}.",
+                importSupported = true,
+                markerImportBaselineClean = markerImportBaselineClean,
+                priorChainLength = priorFingerprints.size,
+                postImportChainLength = representative?.fingerprints?.size ?: 0,
+                originLabel = originLabel(representative?.metadata?.originValue),
+                postImportLeafMatchesMarker = representative?.metadata?.leafMatchesMarker == true,
+            )
+        }
+
+        private fun matched(
+            anomalyKind: ImportKeyRetainedAttestationAnomalyKind,
+            priorFingerprints: List<CertificateFingerprint>,
+            postImportFingerprints: List<CertificateFingerprint>,
+            retained: List<CertificateFingerprint>,
+            originLabel: String,
+            postImportLeafMatchesMarker: Boolean,
+            detailPrefix: String,
+        ): ImportKeyRetainedAttestationNarrativeResult {
             return ImportKeyRetainedAttestationNarrativeResult(
                 executed = true,
-                originImported = true,
+                importSupported = true,
+                markerImportBaselineClean = true,
+                originImported = anomalyKind == ImportKeyRetainedAttestationAnomalyKind.IMPORTED_RETAINED_PRIOR_CHAIN,
+                postImportLeafMatchesMarker = postImportLeafMatchesMarker,
                 retainedNarrativeDetected = true,
                 priorChainLength = priorFingerprints.size,
                 postImportChainLength = postImportFingerprints.size,
                 retainedCertificateCount = retained.size,
                 originLabel = originLabel,
+                anomalyKind = anomalyKind,
                 retainedFingerprint = retained.first().shortSha256,
-                detail = "origin=$originLabel, retained=${retained.size}, priorChain=${priorFingerprints.size}, postImportChain=${postImportFingerprints.size}, firstRetained=${retained.first().shortSha256}.",
+                detail = "$detailPrefix, origin=$originLabel, retained=${retained.size}, priorChain=${priorFingerprints.size}, postImportChain=${postImportFingerprints.size}, leafMatchesMarker=$postImportLeafMatchesMarker, firstRetained=${retained.first().shortSha256}.",
             )
         }
 
         private fun unavailable(
             detail: String,
+            anomalyKind: ImportKeyRetainedAttestationAnomalyKind = ImportKeyRetainedAttestationAnomalyKind.UNAVAILABLE,
+            importSupported: Boolean = false,
+            markerImportBaselineClean: Boolean = false,
+            postImportLeafMatchesMarker: Boolean = false,
             priorChainLength: Int = 0,
             postImportChainLength: Int = 0,
             originLabel: String = "unknown",
         ): ImportKeyRetainedAttestationNarrativeResult {
             return ImportKeyRetainedAttestationNarrativeResult(
                 executed = false,
+                importSupported = importSupported,
+                markerImportBaselineClean = markerImportBaselineClean,
                 originImported = false,
+                postImportLeafMatchesMarker = postImportLeafMatchesMarker,
                 retainedNarrativeDetected = false,
                 priorChainLength = priorChainLength,
                 postImportChainLength = postImportChainLength,
                 retainedCertificateCount = 0,
                 originLabel = originLabel,
+                anomalyKind = anomalyKind,
                 detail = detail,
             )
         }
@@ -287,16 +444,34 @@ class ImportKeyRetainedAttestationNarrativeProbe internal constructor(
     }
 }
 
+enum class ImportKeyRetainedAttestationAnomalyKind {
+    NONE,
+    IMPORT_UNSUPPORTED,
+    IMPORTED_RETAINED_PRIOR_CHAIN,
+    STALE_GENERATED_AFTER_IMPORT,
+    UNAVAILABLE,
+}
+
 data class ImportKeyRetainedAttestationNarrativeResult(
     val executed: Boolean,
+    val importSupported: Boolean = false,
+    val markerImportBaselineClean: Boolean = false,
     val originImported: Boolean = false,
+    val postImportLeafMatchesMarker: Boolean = false,
     val retainedNarrativeDetected: Boolean = false,
     val priorChainLength: Int = 0,
     val postImportChainLength: Int = 0,
     val retainedCertificateCount: Int = 0,
     val originLabel: String = "unknown",
+    val anomalyKind: ImportKeyRetainedAttestationAnomalyKind = ImportKeyRetainedAttestationAnomalyKind.UNAVAILABLE,
     val retainedFingerprint: String? = null,
     val detail: String,
+)
+
+private data class EvaluatedSnapshot(
+    val metadata: ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata,
+    val fingerprints: List<CertificateFingerprint>,
+    val retained: List<CertificateFingerprint>,
 )
 
 private data class CertificateFingerprint(

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/KeyboxFixtureLoader.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/KeyboxFixtureLoader.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.verification.keystore
+
+import android.content.Context
+import com.eltavine.duckdetector.R
+import java.security.KeyFactory
+import java.security.PrivateKey
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.Base64
+
+internal class KeyboxFixtureLoader(
+    private val context: Context,
+) {
+    private val certificateFactory = CertificateFactory.getInstance("X.509")
+
+    fun load(): KeyboxFixture {
+        val certificatePem = context.resources.openRawResource(R.raw.eltavine_marker_cert)
+            .bufferedReader()
+            .use { it.readText() }
+        val keyPem = context.resources.openRawResource(R.raw.eltavine_marker_key)
+            .bufferedReader()
+            .use { it.readText() }
+        val cert =
+            certificateFactory.generateCertificate(certificatePem.byteInputStream()) as X509Certificate
+        val key = decodeEcPrivateKey(keyPem)
+        return KeyboxFixture(privateKey = key, certificate = cert)
+    }
+
+    private fun decodeEcPrivateKey(pem: String): PrivateKey {
+        val body = pem.lineSequence()
+            .filterNot { it.startsWith("-----") }
+            .joinToString(separator = "")
+        val bytes = Base64.getDecoder().decode(body)
+        return KeyFactory.getInstance("EC").generatePrivate(PKCS8EncodedKeySpec(bytes))
+    }
+}
+
+internal data class KeyboxFixture(
+    val privateKey: PrivateKey,
+    val certificate: X509Certificate,
+)

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/KeyboxImportProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/KeyboxImportProbe.kt
@@ -20,15 +20,9 @@ import android.content.Context
 import android.os.Build
 import android.security.keystore.KeyProtection
 import android.security.keystore.KeyProperties
-import com.eltavine.duckdetector.R
 import com.eltavine.duckdetector.features.tee.data.keystore.AndroidKeyStoreTools
-import java.security.KeyFactory
 import java.security.KeyStore
-import java.security.PrivateKey
-import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
-import java.security.spec.PKCS8EncodedKeySpec
-import java.util.Base64
 
 class KeyboxImportProbe(
     private val context: Context,
@@ -96,38 +90,6 @@ class KeyboxImportProbe(
             AndroidKeyStoreTools.safeDelete(keyStore, alias)
         }
     }
-
-    private class KeyboxFixtureLoader(
-        private val context: Context,
-    ) {
-        private val certificateFactory = CertificateFactory.getInstance("X.509")
-
-        fun load(): KeyboxFixture {
-            val certificatePem = context.resources.openRawResource(R.raw.eltavine_marker_cert)
-                .bufferedReader()
-                .use { it.readText() }
-            val keyPem = context.resources.openRawResource(R.raw.eltavine_marker_key)
-                .bufferedReader()
-                .use { it.readText() }
-            val cert =
-                certificateFactory.generateCertificate(certificatePem.byteInputStream()) as X509Certificate
-            val key = decodeEcPrivateKey(keyPem)
-            return KeyboxFixture(privateKey = key, certificate = cert)
-        }
-
-        private fun decodeEcPrivateKey(pem: String): PrivateKey {
-            val body = pem.lineSequence()
-                .filterNot { it.startsWith("-----") }
-                .joinToString(separator = "")
-            val bytes = Base64.getDecoder().decode(body)
-            return KeyFactory.getInstance("EC").generatePrivate(PKCS8EncodedKeySpec(bytes))
-        }
-    }
-
-    private data class KeyboxFixture(
-        val privateKey: PrivateKey,
-        val certificate: X509Certificate,
-    )
 
     companion object {
         const val FIXTURE_MARKER = "EltavineMarker-Keybox"

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/Keystore2PrivateBinderClient.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/Keystore2PrivateBinderClient.kt
@@ -336,6 +336,18 @@ class Keystore2PrivateBinderClient {
         return getFieldValue(keyParameter, "tag") as? Int
     }
 
+    fun getAuthorizationIntValue(authorization: Any): Int? {
+        val keyParameter = getFieldValue(authorization, "keyParameter") ?: return null
+        return getKeyParameterIntValue(keyParameter)
+    }
+
+    fun getKeyOriginValue(name: String): Int? {
+        return runCatching {
+            val originClass = loadClass("android.hardware.security.keymint.KeyOrigin")
+            originClass.getField(name).getInt(null)
+        }.getOrNull()
+    }
+
     fun createKeyIdDescriptor(nspace: Long, aliasHint: String? = null): Any {
         val descriptorClass = loadClass(CLASS_KEY_DESCRIPTOR)
         val descriptor = descriptorClass.getDeclaredConstructor().newInstance()
@@ -917,6 +929,23 @@ class Keystore2PrivateBinderClient {
         return rawReply
             .take(MAX_REPLY_PREFIX_BYTES)
             .joinToString(" ") { "%02X".format(it.toInt() and 0xFF) }
+    }
+
+    private fun getKeyParameterIntValue(keyParameter: Any): Int? {
+        val value = getFieldValue(keyParameter, "value") ?: return null
+        sequenceOf("getKeyPurpose", "getAlgorithm", "getOrigin", "getSecurityLevel", "getInteger")
+            .forEach { methodName ->
+                runCatching {
+                    val method = value.javaClass.getMethod(methodName)
+                    method.isAccessible = true
+                    return method.invoke(value) as? Int
+                }
+            }
+        sequenceOf("keyPurpose", "algorithm", "origin", "securityLevel", "integer")
+            .forEach { fieldName ->
+                (getFieldValue(value, fieldName) as? Int)?.let { return it }
+            }
+        return null
     }
 
     private fun generateKeyTransactionCode(): Int {

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/TeeGrantDomainGranteeManager.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/TeeGrantDomainGranteeManager.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.verification.keystore
+
+import android.app.Service
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.resume
+
+class TeeGrantDomainGranteeManager(
+    context: Context? = null,
+    private val serviceClass: Class<out Service> = TeeGrantDomainGranteeService::class.java,
+) {
+
+    private val appContext = context?.applicationContext
+
+    suspend fun openSession(): TeeGrantDomainGranteeSessionResult {
+        val context = appContext ?: return TeeGrantDomainGranteeSessionResult(
+            detail = "Grant-domain grantee context unavailable.",
+        )
+        return withTimeoutOrNull(DETECTION_TIMEOUT_MS) {
+            bindGrantee(context)
+        } ?: TeeGrantDomainGranteeSessionResult(
+            detail = "Grant-domain isolated grantee timed out.",
+        )
+    }
+
+    private suspend fun bindGrantee(context: Context): TeeGrantDomainGranteeSessionResult =
+        suspendCancellableCoroutine { continuation ->
+            var bound = false
+            lateinit var connection: ServiceConnection
+
+            fun finish(
+                result: TeeGrantDomainGranteeSessionResult,
+                keepBoundForSession: Boolean = false,
+            ) {
+                if (!continuation.isActive) {
+                    return
+                }
+                if (bound && !keepBoundForSession) {
+                    runCatching { context.unbindService(connection) }
+                    bound = false
+                }
+                continuation.resume(result)
+            }
+
+            connection = object : ServiceConnection {
+                override fun onServiceConnected(
+                    name: ComponentName?,
+                    service: IBinder?,
+                ) {
+                    if (service == null) {
+                        finish(
+                            TeeGrantDomainGranteeSessionResult(
+                                detail = "Grant-domain isolated grantee returned a null binder.",
+                            ),
+                        )
+                        return
+                    }
+                    runCatching {
+                        val proxy = TeeGrantDomainGranteeProxy(service)
+                        val uid = proxy.getUid()
+                        TeeGrantDomainGranteeSession(
+                            context = context,
+                            connection = connection,
+                            proxy = proxy,
+                            uid = uid,
+                            bound = true,
+                        )
+                    }.onSuccess { session ->
+                        bound = false
+                        finish(
+                            TeeGrantDomainGranteeSessionResult(
+                                available = true,
+                                session = session,
+                                detail = "Grant-domain isolated grantee bound with uid=${session.uid}.",
+                            ),
+                            keepBoundForSession = true,
+                        )
+                    }.onFailure { throwable ->
+                        finish(
+                            TeeGrantDomainGranteeSessionResult(
+                                detail = "Grant-domain isolated grantee handshake failed: ${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}",
+                            ),
+                        )
+                    }
+                }
+
+                override fun onServiceDisconnected(name: ComponentName?) = Unit
+            }
+
+            val intent = Intent(context, serviceClass)
+            bound = runCatching {
+                bindIsolatedService(context, intent, connection)
+            }.getOrDefault(false)
+            if (!bound) {
+                finish(
+                    TeeGrantDomainGranteeSessionResult(
+                        detail = "Grant-domain isolated grantee could not be bound.",
+                    ),
+                )
+            }
+
+            continuation.invokeOnCancellation {
+                if (bound) {
+                    runCatching { context.unbindService(connection) }
+                    bound = false
+                }
+            }
+        }
+
+    companion object {
+        private const val DETECTION_TIMEOUT_MS = 6_000L
+
+        private fun bindIsolatedService(
+            context: Context,
+            intent: Intent,
+            connection: ServiceConnection,
+        ): Boolean {
+            return context.bindIsolatedService(
+                intent,
+                Context.BIND_AUTO_CREATE,
+                "duck_grant_domain_${System.nanoTime()}",
+                Runnable::run,
+                connection,
+            )
+        }
+    }
+}
+
+data class TeeGrantDomainGranteeSessionResult(
+    val available: Boolean = false,
+    val session: TeeGrantDomainGranteeSession? = null,
+    val detail: String = "",
+)
+
+class TeeGrantDomainGranteeSession(
+    private val context: Context,
+    private val connection: ServiceConnection,
+    private val proxy: TeeGrantDomainGranteeProxy,
+    val uid: Int,
+    private var bound: Boolean,
+) : AutoCloseable {
+
+    fun readGrantedCertificateChain(grantId: Long): TeeGrantDomainGranteeChainResult {
+        return runCatching {
+            proxy.readGrantedCertificateChain(grantId)
+        }.getOrElse { throwable ->
+            TeeGrantDomainGranteeChainResult(
+                available = false,
+                detail = "Grant-domain grantee binder call failed: ${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}",
+            )
+        }
+    }
+
+    override fun close() {
+        if (bound) {
+            runCatching { context.unbindService(connection) }
+            bound = false
+        }
+    }
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/TeeGrantDomainGranteeProxy.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/TeeGrantDomainGranteeProxy.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.verification.keystore
+
+import android.os.IBinder
+import android.os.Parcel
+
+class TeeGrantDomainGranteeProxy(
+    private val remote: IBinder,
+) {
+
+    fun getUid(): Int {
+        val data = Parcel.obtain()
+        val reply = Parcel.obtain()
+        return try {
+            data.writeInterfaceToken(TeeGrantDomainGranteeProtocol.DESCRIPTOR)
+            remote.transact(
+                TeeGrantDomainGranteeProtocol.TRANSACTION_GET_UID,
+                data,
+                reply,
+                0,
+            )
+            reply.readException()
+            reply.readInt()
+        } finally {
+            data.recycle()
+            reply.recycle()
+        }
+    }
+
+    fun readGrantedCertificateChain(grantId: Long): TeeGrantDomainGranteeChainResult {
+        val data = Parcel.obtain()
+        val reply = Parcel.obtain()
+        return try {
+            data.writeInterfaceToken(TeeGrantDomainGranteeProtocol.DESCRIPTOR)
+            data.writeLong(grantId)
+            remote.transact(
+                TeeGrantDomainGranteeProtocol.TRANSACTION_READ_GRANTED_CHAIN,
+                data,
+                reply,
+                0,
+            )
+            reply.readException()
+            TeeGrantDomainGranteeChainResult.readFromParcel(reply)
+        } finally {
+            data.recycle()
+            reply.recycle()
+        }
+    }
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/TeeGrantDomainGranteeService.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/TeeGrantDomainGranteeService.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.verification.keystore
+
+import android.app.Service
+import android.content.Intent
+import android.os.Binder
+import android.os.Build
+import android.os.IBinder
+import android.os.Parcel
+import android.os.Process
+import android.security.keystore.KeyStoreManager
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.BAKLAVA)
+class TeeGrantDomainGranteeService : Service() {
+
+    private val binder = object : Binder() {
+        override fun onTransact(
+            code: Int,
+            data: Parcel,
+            reply: Parcel?,
+            flags: Int,
+        ): Boolean {
+            return when (code) {
+                INTERFACE_TRANSACTION -> {
+                    reply?.writeString(TeeGrantDomainGranteeProtocol.DESCRIPTOR)
+                    true
+                }
+
+                TeeGrantDomainGranteeProtocol.TRANSACTION_GET_UID -> {
+                    data.enforceInterface(TeeGrantDomainGranteeProtocol.DESCRIPTOR)
+                    reply?.writeNoException()
+                    reply?.writeInt(Process.myUid())
+                    true
+                }
+
+                TeeGrantDomainGranteeProtocol.TRANSACTION_READ_GRANTED_CHAIN -> {
+                    data.enforceInterface(TeeGrantDomainGranteeProtocol.DESCRIPTOR)
+                    val grantId = data.readLong()
+                    val result = readGrantedCertificateChain(grantId)
+                    reply?.writeNoException()
+                    result.writeToParcel(reply)
+                    true
+                }
+
+                else -> super.onTransact(code, data, reply, flags)
+            }
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder = binder
+
+    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
+    private fun readGrantedCertificateChain(grantId: Long): TeeGrantDomainGranteeChainResult {
+        val keyStoreManager = getSystemService(KeyStoreManager::class.java)
+            ?: return TeeGrantDomainGranteeChainResult(
+                available = false,
+                detail = "KeyStoreManager unavailable in isolated grantee.",
+            )
+        return runCatching {
+            val chain = keyStoreManager.getGrantedCertificateChainFromId(grantId)
+                .filterIsInstance<java.security.cert.X509Certificate>()
+            TeeGrantDomainGranteeChainResult(
+                available = true,
+                chain = GrantDomainCertificateChain.fromCertificates(chain),
+                detail = "granteeChainLength=${chain.size}",
+            )
+        }.getOrElse { throwable ->
+            TeeGrantDomainGranteeChainResult(
+                available = false,
+                detail = "getGrantedCertificateChainFromId failed: ${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}",
+            )
+        }
+    }
+}
+
+object TeeGrantDomainGranteeProtocol {
+    const val DESCRIPTOR = "com.eltavine.duckdetector.features.tee.data.verification.keystore.ITeeGrantDomainGrantee"
+    const val TRANSACTION_GET_UID = IBinder.FIRST_CALL_TRANSACTION
+    const val TRANSACTION_READ_GRANTED_CHAIN = IBinder.FIRST_CALL_TRANSACTION + 1
+}
+
+data class TeeGrantDomainGranteeChainResult(
+    val available: Boolean = false,
+    val chain: GrantDomainCertificateChain = GrantDomainCertificateChain(),
+    val detail: String = "",
+) {
+    fun writeToParcel(reply: Parcel?) {
+        reply ?: return
+        reply.writeInt(if (available) 1 else 0)
+        reply.writeInt(chain.certificates.size)
+        chain.certificates.forEach { certificate ->
+            reply.writeInt(certificate.derLength)
+            reply.writeString(certificate.sha256)
+        }
+        reply.writeString(detail)
+    }
+
+    companion object {
+        fun readFromParcel(reply: Parcel): TeeGrantDomainGranteeChainResult {
+            val available = reply.readInt() != 0
+            val size = reply.readInt().coerceAtLeast(0)
+            val certificates = buildList {
+                repeat(size) {
+                    add(
+                        GrantDomainCertificateFingerprint(
+                            derLength = reply.readInt(),
+                            sha256 = reply.readString().orEmpty(),
+                        ),
+                    )
+                }
+            }
+            return TeeGrantDomainGranteeChainResult(
+                available = available,
+                chain = GrantDomainCertificateChain(certificates),
+                detail = reply.readString().orEmpty(),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/TimingSideChannelProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/TimingSideChannelProbe.kt
@@ -135,12 +135,18 @@ class TimingSideChannelProbe(
                 val avgAttested = filteredSeries.attestedSamples.averageOrNull()
                 val avgNonAttested = filteredSeries.nonAttestedSamples.averageOrNull()
                 val diff = if (avgAttested != null && avgNonAttested != null) avgAttested - avgNonAttested else null
-                val suspicious = isPositiveTimingSideChannelRatio(avgAttested, avgNonAttested)
-                val filteredCount = pairedSeries.pairedSampleCount - filteredSeries.pairedSampleCount
-                val filteringNote = if (filteredCount > 0) {
-                    "filteredBadSamples=$filteredCount/${pairedSeries.pairedSampleCount}"
-                } else {
+                val ratioEligible = isTimingSideChannelRatioEligible(filteredSeries.pairedSampleCount)
+                val ratioSkipReason = if (ratioEligible) {
                     null
+                } else {
+                    "insufficientSamples=${filteredSeries.pairedSampleCount}/$MIN_RATIO_SAMPLE_COUNT"
+                }
+                val suspicious = ratioEligible && isPositiveTimingSideChannelRatio(avgAttested, avgNonAttested)
+                val filteredOutlierCount = pairedSeries.pairedSampleCount - filteredSeries.pairedSampleCount
+                val samplingNotes = buildList {
+                    add("failedPairs=${pairedSeries.failedPairCount}/${pairedSeries.attemptedPairCount}")
+                    add("outlierFiltered=$filteredOutlierCount/${pairedSeries.pairedSampleCount}")
+                    ratioSkipReason?.let(::add)
                 }
 
                 TimingSideChannelResult(
@@ -148,6 +154,12 @@ class TimingSideChannelProbe(
                     measurementAvailable = true,
                     suspicious = suspicious,
                     sampleCount = filteredSeries.pairedSampleCount,
+                    attemptedPairCount = pairedSeries.attemptedPairCount,
+                    successfulPairCount = pairedSeries.pairedSampleCount,
+                    failedPairCount = pairedSeries.failedPairCount,
+                    filteredOutlierCount = filteredOutlierCount,
+                    ratioEligible = ratioEligible,
+                    ratioSkipReason = ratioSkipReason,
                     warmupCount = WARMUP_COUNT,
                     avgAttestedMillis = avgAttested,
                     avgNonAttestedMillis = avgNonAttested,
@@ -177,9 +189,8 @@ class TimingSideChannelProbe(
                         warmupCount = WARMUP_COUNT,
                         measurementDetail = measurement.detail,
                         timerFallbackReason = measurementContext.timerFallbackReason,
-                        partialFailureReason = listOfNotNull(partialFailureReason, filteringNote)
-                            .joinToString("; ")
-                            .takeIf { it.isNotBlank() },
+                        partialFailureReason = (listOfNotNull(partialFailureReason) + samplingNotes)
+                            .joinToString("; "),
                     ),
                 )
             } finally {
@@ -253,6 +264,7 @@ class TimingSideChannelProbe(
         val attestedSamples = mutableListOf<Double>()
         val nonAttestedSamples = mutableListOf<Double>()
         var firstFailure: String? = null
+        var failedPairCount = 0
         repeat(LOOP_COUNT) { index ->
             val attested = runCatching { measurement.measureMillis(attestedDescriptor, measurement.timerSource) }
             val nonAttested = runCatching { measurement.measureMillis(nonAttestedDescriptor, measurement.timerSource) }
@@ -267,13 +279,16 @@ class TimingSideChannelProbe(
                 if (firstFailure == null) {
                     firstFailure = failure
                 }
+                failedPairCount += 1
                 warnings += "sample.paired[$index]=$failure"
             }
             throttleSamplingLoop(index)
         }
         return PairedSampleSeries(
+            attemptedPairCount = LOOP_COUNT,
             attestedSamples = attestedSamples,
             nonAttestedSamples = nonAttestedSamples,
+            failedPairCount = failedPairCount,
             failureReason = firstFailure,
         )
     }
@@ -354,8 +369,10 @@ class TimingSideChannelProbe(
     )
 
     private data class PairedSampleSeries(
+        val attemptedPairCount: Int,
         val attestedSamples: List<Double>,
         val nonAttestedSamples: List<Double>,
+        val failedPairCount: Int,
         val failureReason: String? = null,
     ) {
         val pairedSampleCount: Int
@@ -379,8 +396,10 @@ class TimingSideChannelProbe(
                 return this
             }
             return PairedSampleSeries(
+                attemptedPairCount = attemptedPairCount,
                 attestedSamples = keepIndices.map { attestedSamples[it] },
                 nonAttestedSamples = keepIndices.map { nonAttestedSamples[it] },
+                failedPairCount = failedPairCount,
                 failureReason = failureReason,
             )
         }
@@ -396,8 +415,8 @@ class TimingSideChannelProbe(
     companion object {
         private const val WARMUP_COUNT = 5
         private const val LOOP_COUNT = 500
-        private const val SAMPLE_THROTTLE_EVERY_PAIRS = 25
-        private const val SAMPLE_THROTTLE_SLEEP_MS = 8L
+        private const val SAMPLE_THROTTLE_EVERY_PAIRS = 20
+        private const val SAMPLE_THROTTLE_SLEEP_MS = 25L
     }
 }
 
@@ -428,6 +447,10 @@ internal fun isPositiveTimingSideChannelRatio(
 ): Boolean {
     val ratio = timingSideChannelRatio(avgAttestedMillis, avgNonAttestedMillis) ?: return false
     return ratio > TIMING_SIDE_CHANNEL_THRESHOLD_RATIO
+}
+
+internal fun isTimingSideChannelRatioEligible(sampleCount: Int): Boolean {
+    return sampleCount >= MIN_RATIO_SAMPLE_COUNT
 }
 
 internal fun timingSideChannelRatio(
@@ -546,6 +569,12 @@ data class TimingSideChannelResult(
     val measurementAvailable: Boolean = false,
     val suspicious: Boolean = false,
     val sampleCount: Int = 0,
+    val attemptedPairCount: Int = 0,
+    val successfulPairCount: Int = 0,
+    val failedPairCount: Int = 0,
+    val filteredOutlierCount: Int = 0,
+    val ratioEligible: Boolean = true,
+    val ratioSkipReason: String? = null,
     val warmupCount: Int = 0,
     val avgAttestedMillis: Double? = null,
     val avgNonAttestedMillis: Double? = null,
@@ -569,3 +598,4 @@ data class TimingSideChannelResult(
 
 // 阈值故意保持单点常量，避免 probe/reducer/test 三处漂移。 / Keep the threshold as a single source of truth so probe, reducer, and tests cannot drift.
 internal const val TIMING_SIDE_CHANNEL_THRESHOLD_RATIO = 1.1
+internal const val MIN_RATIO_SAMPLE_COUNT = 300

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
@@ -225,6 +225,10 @@ class TeeCardModelMapper {
                         item.level == TeeSignalLevel.FAIL &&
                             item.body.hasImportKeyRetainedNarrativeDangerKind()
 
+                    "Grant domain" ->
+                        item.level == TeeSignalLevel.FAIL &&
+                            item.body.contains("Matched", ignoreCase = true)
+
                     else -> false
                 }
             }

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
@@ -244,11 +244,15 @@ class TeeCardModelMapper {
     }
 
     private fun String.hasGrantIsolatedDomainDangerKind(): Boolean {
+        // Dashboard only sees TeeCardModel.status, so reducer-level FAIL kinds must be mirrored here deliberately.
+        // Dashboard 只看到 TeeCardModel.status，因此 reducer 的 FAIL kind 必须在这里显式镜像。
         return contains("kind=ISOLATED_CHAIN_SPLIT", ignoreCase = true) ||
             contains("kind=ISOLATED_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN", ignoreCase = true)
     }
 
     private fun String.hasGrantSelfDomainDangerKind(): Boolean {
+        // Match stable kind tokens, not prose; prose can change, but these tokens encode the reviewed root cause.
+        // 匹配稳定 kind token，而不是自然语言文案；文案可调整，kind 承载已审阅的根因。
         return contains("kind=SELF_CHAIN_SPLIT", ignoreCase = true) ||
             contains("kind=SELF_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN", ignoreCase = true)
     }

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
@@ -249,7 +249,8 @@ class TeeCardModelMapper {
     }
 
     private fun String.hasGrantSelfDomainDangerKind(): Boolean {
-        return contains("kind=SELF_CHAIN_SPLIT", ignoreCase = true)
+        return contains("kind=SELF_CHAIN_SPLIT", ignoreCase = true) ||
+            contains("kind=SELF_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN", ignoreCase = true)
     }
 
     private fun TeeReport.tierStatus(): DetectorStatus = when (tier) {

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
@@ -221,6 +221,10 @@ class TeeCardModelMapper {
                         item.level == TeeSignalLevel.FAIL &&
                             item.body.contains("Matched TEE Simulator generate-mode fingerprint.", ignoreCase = true)
 
+                    "ImportKey narrative" ->
+                        item.level == TeeSignalLevel.FAIL &&
+                            item.body.contains("ImportKey retained attestation narrative detected.", ignoreCase = true)
+
                     else -> false
                 }
             }

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
@@ -225,9 +225,9 @@ class TeeCardModelMapper {
                         item.level == TeeSignalLevel.FAIL &&
                             item.body.hasImportKeyRetainedNarrativeDangerKind()
 
-                    "Grant domain" ->
+                    "Grant isolated-domain" ->
                         item.level == TeeSignalLevel.FAIL &&
-                            item.body.contains("Matched", ignoreCase = true)
+                            item.body.hasGrantIsolatedDomainDangerKind()
 
                     else -> false
                 }
@@ -237,6 +237,11 @@ class TeeCardModelMapper {
     private fun String.hasImportKeyRetainedNarrativeDangerKind(): Boolean {
         return contains("kind=IMPORTED_RETAINED_PRIOR_CHAIN", ignoreCase = true) ||
             contains("kind=STALE_GENERATED_AFTER_IMPORT", ignoreCase = true)
+    }
+
+    private fun String.hasGrantIsolatedDomainDangerKind(): Boolean {
+        return contains("kind=ISOLATED_CHAIN_SPLIT", ignoreCase = true) ||
+            contains("kind=ISOLATED_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN", ignoreCase = true)
     }
 
     private fun TeeReport.tierStatus(): DetectorStatus = when (tier) {

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
@@ -210,8 +210,8 @@ class TeeCardModelMapper {
         return sections.asSequence()
             .flatMap { it.items.asSequence() }
             .any { item ->
-                // 这里只把已经收敛成“恶意模块指纹”语义的强本地证据透传成 danger，普通 supplementary review 仍保持 warning。
-                // Only escalate locally conclusive malicious-module fingerprint findings to danger; ordinary supplementary review stays at warning.
+                // TEE card status is the only value the dashboard aggregates, so red-card local evidence must be recognized from reducer-built Checks rows here.
+                // Dashboard 只聚合 TEE card status；因此红卡级本地证据必须在这里从 reducer 生成的 Checks 行识别出来。
                 when (item.title) {
                     "Timing side-channel" -> item.level == TeeSignalLevel.FAIL && (
                         item.body.contains("Detected malicious-module fingerprint", ignoreCase = true)
@@ -223,11 +223,16 @@ class TeeCardModelMapper {
 
                     "ImportKey narrative" ->
                         item.level == TeeSignalLevel.FAIL &&
-                            item.body.contains("ImportKey retained attestation narrative detected.", ignoreCase = true)
+                            item.body.hasImportKeyRetainedNarrativeDangerKind()
 
                     else -> false
                 }
             }
+    }
+
+    private fun String.hasImportKeyRetainedNarrativeDangerKind(): Boolean {
+        return contains("kind=IMPORTED_RETAINED_PRIOR_CHAIN", ignoreCase = true) ||
+            contains("kind=STALE_GENERATED_AFTER_IMPORT", ignoreCase = true)
     }
 
     private fun TeeReport.tierStatus(): DetectorStatus = when (tier) {

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
@@ -229,6 +229,10 @@ class TeeCardModelMapper {
                         item.level == TeeSignalLevel.FAIL &&
                             item.body.hasGrantIsolatedDomainDangerKind()
 
+                    "Grant self-domain" ->
+                        item.level == TeeSignalLevel.FAIL &&
+                            item.body.hasGrantSelfDomainDangerKind()
+
                     else -> false
                 }
             }
@@ -242,6 +246,10 @@ class TeeCardModelMapper {
     private fun String.hasGrantIsolatedDomainDangerKind(): Boolean {
         return contains("kind=ISOLATED_CHAIN_SPLIT", ignoreCase = true) ||
             contains("kind=ISOLATED_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN", ignoreCase = true)
+    }
+
+    private fun String.hasGrantSelfDomainDangerKind(): Boolean {
+        return contains("kind=SELF_CHAIN_SPLIT", ignoreCase = true)
     }
 
     private fun TeeReport.tierStatus(): DetectorStatus = when (tier) {

--- a/app/src/test/java/com/eltavine/duckdetector/features/dashboard/ui/model/DashboardUiStateTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/dashboard/ui/model/DashboardUiStateTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.dashboard.ui.model
+
+import com.eltavine.duckdetector.core.ui.model.DetectorStatus
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DashboardUiStateTest {
+
+    @Test
+    fun `danger tee card status propagates to dashboard overview`() {
+        val overview = buildDashboardOverview(
+            contributions = listOf(
+                DashboardDetectorContribution(
+                    id = "tee",
+                    title = "TEE",
+                    status = DetectorStatus.danger(),
+                    headline = "Attestation aligned; local probes need review",
+                    summary = "ImportKey retained attestation narrative detected.",
+                    ready = true,
+                ),
+                DashboardDetectorContribution(
+                    id = "bootloader",
+                    title = "Bootloader",
+                    status = DetectorStatus.allClear(),
+                    headline = "Locked",
+                    summary = "Bootloader state is locked.",
+                    ready = true,
+                ),
+            ),
+        )
+
+        assertEquals(DetectorStatus.danger(), overview.status)
+        assertEquals("Danger", overview.headline)
+        assertEquals("1", overview.metrics.single { it.label == "Danger" }.value)
+    }
+}

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
@@ -403,12 +403,37 @@ class TeeReportReducerTest {
     }
 
     @Test
-    fun `grant self-domain unavailable state stays informational`() {
+    fun `grant self-domain owner-visible key-not-found state becomes supplementary failure`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                grantSelfDomainFullChainSplit = GrantSelfDomainFullChainSplitResult(
+                    executed = true,
+                    ownerChainLength = 4,
+                    anomalyKind = GrantSelfDomainAnomalyKind.SELF_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN,
+                    detail = "self grantKeyAccess failed: UnrecoverableKeyException: No key found by the given alias",
+                ),
+            ),
+        )
+
+        assertEquals(1, report.supplementaryIndicatorCount)
+        assertTrue(report.summary.contains("Grant self-domain key visibility divergence", ignoreCase = true))
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "Grant self-domain" &&
+                it.level == TeeSignalLevel.FAIL &&
+                it.body.contains("Unavailable", ignoreCase = true) &&
+                it.body.contains("kind=SELF_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN") &&
+                it.body.contains("owner=4") &&
+                it.body.contains("No key found by the given alias")
+        })
+    }
+
+    @Test
+    fun `grant self-domain ordinary unavailable state stays informational`() {
         val report = reducer.reduce(
             baseArtifacts(
                 grantSelfDomainFullChainSplit = GrantSelfDomainFullChainSplitResult(
                     executed = false,
-                    detail = "self grantKeyAccess failed: UnrecoverableKeyException: No key found by the given alias",
+                    detail = "self grantKeyAccess failed: IllegalStateException: transient service unavailable",
                 ),
             ),
         )
@@ -418,7 +443,7 @@ class TeeReportReducerTest {
             it.title == "Grant self-domain" &&
                 it.level == TeeSignalLevel.INFO &&
                 it.body.contains("Unavailable", ignoreCase = true) &&
-                it.body.contains("No key found by the given alias")
+                it.body.contains("transient service unavailable")
         })
     }
 

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
@@ -34,6 +34,7 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderC
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderHookBootstrapResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderPatchModeResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BiometricTeeIntegrationResult
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationNarrativeResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyLifecycleResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyMetadataSemanticsResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyMetadataShapeResult
@@ -181,7 +182,54 @@ class TeeReportReducerTest {
         assertTrue(report.sections.single { it.title == "Checks" }.items.any {
             it.title == "TEE Simulator generate-mode fingerprint" &&
                 it.body.contains("probe unavailable", ignoreCase = true) &&
-                it.hiddenCopyText == "unavailable diagnostic"
+            it.hiddenCopyText == "unavailable diagnostic"
+        })
+    }
+
+    @Test
+    fun `importKey retained narrative becomes supplementary review without changing attestation verdict`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                importKeyRetainedAttestationNarrative = ImportKeyRetainedAttestationNarrativeResult(
+                    executed = true,
+                    originImported = true,
+                    retainedNarrativeDetected = true,
+                    priorChainLength = 3,
+                    postImportChainLength = 2,
+                    retainedCertificateCount = 2,
+                    originLabel = "IMPORTED",
+                    retainedFingerprint = "abc123def456",
+                    detail = "origin=IMPORTED, retained=2",
+                ),
+            ),
+        )
+
+        assertEquals(TeeVerdict.CONSISTENT, report.verdict)
+        assertEquals(1, report.supplementaryIndicatorCount)
+        assertTrue(report.summary.contains("ImportKey retained attestation narrative", ignoreCase = true))
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "ImportKey narrative" &&
+                it.body.contains("Matched", ignoreCase = true) &&
+                it.level == TeeSignalLevel.FAIL
+        })
+    }
+
+    @Test
+    fun `importKey retained narrative unavailable state stays informational`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                importKeyRetainedAttestationNarrative = ImportKeyRetainedAttestationNarrativeResult(
+                    executed = false,
+                    detail = "Keystore2 getKeyEntry metadata unavailable.",
+                ),
+            ),
+        )
+
+        assertEquals(0, report.supplementaryIndicatorCount)
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "ImportKey narrative" &&
+                it.body.contains("Unavailable", ignoreCase = true) &&
+                it.level == TeeSignalLevel.INFO
         })
     }
 
@@ -1502,6 +1550,11 @@ class TeeReportReducerTest {
             executed = false,
             detail = "skipped",
         ),
+        importKeyRetainedAttestationNarrative: ImportKeyRetainedAttestationNarrativeResult =
+            ImportKeyRetainedAttestationNarrativeResult(
+                executed = false,
+                detail = "skipped",
+            ),
         keyMetadataSemantics: KeyMetadataSemanticsResult = KeyMetadataSemanticsResult(
             executed = false,
             detail = "skipped",
@@ -1596,6 +1649,7 @@ class TeeReportReducerTest {
                 marker = KeyboxImportProbe.FIXTURE_MARKER,
                 detail = "skipped",
             ),
+            importKeyRetainedAttestationNarrative = importKeyRetainedAttestationNarrative,
             keystore2Hook = keystore2Hook,
             generateModeParcelFingerprint = generateModeParcelFingerprint,
             legacyKeystorePath = legacyKeystorePath,

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
@@ -34,6 +34,7 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderC
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderHookBootstrapResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderPatchModeResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BiometricTeeIntegrationResult
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationNarrativeResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyLifecycleResult
@@ -288,6 +289,53 @@ class TeeReportReducerTest {
                 it.body.contains("Unavailable", ignoreCase = true) &&
                 it.body.contains("ImportKey support gate failed") &&
                 it.level == TeeSignalLevel.INFO
+        })
+    }
+
+    @Test
+    fun `grant domain full-chain split becomes supplementary review without changing attestation verdict`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                grantDomainFullChainSplit = GrantDomainFullChainSplitResult(
+                    executed = true,
+                    available = true,
+                    splitDetected = true,
+                    ownerChainLength = 3,
+                    granteeChainLength = 2,
+                    mismatchIndex = 2,
+                    granteeUid = 99001,
+                    detail = "lengthMismatch owner=3 grantee=2",
+                ),
+            ),
+        )
+
+        assertEquals(TeeVerdict.CONSISTENT, report.verdict)
+        assertEquals(1, report.supplementaryIndicatorCount)
+        assertTrue(report.summary.contains("Grant-domain", ignoreCase = true))
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "Grant domain" &&
+                it.level == TeeSignalLevel.FAIL &&
+                it.body.contains("Matched", ignoreCase = true) &&
+                it.body.contains("mismatchIndex=2")
+        })
+    }
+
+    @Test
+    fun `grant domain unavailable state stays informational`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                grantDomainFullChainSplit = GrantDomainFullChainSplitResult(
+                    executed = false,
+                    detail = "Grant-domain full-chain split probe requires Android 16 or newer.",
+                ),
+            ),
+        )
+
+        assertEquals(0, report.supplementaryIndicatorCount)
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "Grant domain" &&
+                it.level == TeeSignalLevel.INFO &&
+                it.body.contains("Unavailable", ignoreCase = true)
         })
     }
 
@@ -1613,6 +1661,9 @@ class TeeReportReducerTest {
                 executed = false,
                 detail = "skipped",
             ),
+        grantDomainFullChainSplit: GrantDomainFullChainSplitResult = GrantDomainFullChainSplitResult(
+            detail = "skipped",
+        ),
         keyMetadataSemantics: KeyMetadataSemanticsResult = KeyMetadataSemanticsResult(
             executed = false,
             detail = "skipped",
@@ -1710,6 +1761,7 @@ class TeeReportReducerTest {
             importKeyRetainedAttestationNarrative = importKeyRetainedAttestationNarrative,
             keystore2Hook = keystore2Hook,
             generateModeParcelFingerprint = generateModeParcelFingerprint,
+            grantDomainFullChainSplit = grantDomainFullChainSplit,
             legacyKeystorePath = legacyKeystorePath,
             listEntriesConsistency = listEntriesConsistency,
             listEntriesBatched = listEntriesBatched,

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
@@ -34,6 +34,7 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderC
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderHookBootstrapResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderPatchModeResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BiometricTeeIntegrationResult
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationNarrativeResult
@@ -293,7 +294,7 @@ class TeeReportReducerTest {
     }
 
     @Test
-    fun `grant domain full-chain split becomes supplementary review without changing attestation verdict`() {
+    fun `grant isolated-domain full-chain split becomes supplementary review without changing attestation verdict`() {
         val report = reducer.reduce(
             baseArtifacts(
                 grantDomainFullChainSplit = GrantDomainFullChainSplitResult(
@@ -304,6 +305,7 @@ class TeeReportReducerTest {
                     granteeChainLength = 2,
                     mismatchIndex = 2,
                     granteeUid = 99001,
+                    anomalyKind = GrantDomainAnomalyKind.ISOLATED_CHAIN_SPLIT,
                     detail = "lengthMismatch owner=3 grantee=2",
                 ),
             ),
@@ -311,17 +313,46 @@ class TeeReportReducerTest {
 
         assertEquals(TeeVerdict.CONSISTENT, report.verdict)
         assertEquals(1, report.supplementaryIndicatorCount)
-        assertTrue(report.summary.contains("Grant-domain", ignoreCase = true))
+        assertTrue(report.summary.contains("Grant isolated-domain", ignoreCase = true))
         assertTrue(report.sections.single { it.title == "Checks" }.items.any {
-            it.title == "Grant domain" &&
+            it.title == "Grant isolated-domain" &&
                 it.level == TeeSignalLevel.FAIL &&
                 it.body.contains("Matched", ignoreCase = true) &&
+                it.body.contains("kind=ISOLATED_CHAIN_SPLIT") &&
                 it.body.contains("mismatchIndex=2")
         })
     }
 
     @Test
-    fun `grant domain unavailable state stays informational`() {
+    fun `grant isolated-domain key not found after owner chain becomes supplementary review`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                grantDomainFullChainSplit = GrantDomainFullChainSplitResult(
+                    executed = true,
+                    available = false,
+                    splitDetected = false,
+                    ownerChainLength = 3,
+                    granteeUid = 99001,
+                    anomalyKind = GrantDomainAnomalyKind.ISOLATED_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN,
+                    detail = "grantKeyAccess failed: UnrecoverableKeyException: No key found by the given alias",
+                ),
+            ),
+        )
+
+        assertEquals(TeeVerdict.CONSISTENT, report.verdict)
+        assertEquals(1, report.supplementaryIndicatorCount)
+        assertTrue(report.summary.contains("Grant isolated-domain key visibility divergence", ignoreCase = true))
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "Grant isolated-domain" &&
+                it.level == TeeSignalLevel.FAIL &&
+                it.body.contains("Unavailable", ignoreCase = true) &&
+                it.body.contains("kind=ISOLATED_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN") &&
+                it.body.contains("No key found by the given alias")
+        })
+    }
+
+    @Test
+    fun `grant isolated-domain unavailable state stays informational`() {
         val report = reducer.reduce(
             baseArtifacts(
                 grantDomainFullChainSplit = GrantDomainFullChainSplitResult(
@@ -333,7 +364,7 @@ class TeeReportReducerTest {
 
         assertEquals(0, report.supplementaryIndicatorCount)
         assertTrue(report.sections.single { it.title == "Checks" }.items.any {
-            it.title == "Grant domain" &&
+            it.title == "Grant isolated-domain" &&
                 it.level == TeeSignalLevel.INFO &&
                 it.body.contains("Unavailable", ignoreCase = true)
         })

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
@@ -36,6 +36,8 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderP
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BiometricTeeIntegrationResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainAnomalyKind
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationNarrativeResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyLifecycleResult
@@ -367,6 +369,56 @@ class TeeReportReducerTest {
             it.title == "Grant isolated-domain" &&
                 it.level == TeeSignalLevel.INFO &&
                 it.body.contains("Unavailable", ignoreCase = true)
+        })
+    }
+
+    @Test
+    fun `grant self-domain full-chain split becomes supplementary review without changing attestation verdict`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                grantSelfDomainFullChainSplit = GrantSelfDomainFullChainSplitResult(
+                    executed = true,
+                    available = true,
+                    splitDetected = true,
+                    ownerChainLength = 3,
+                    grantChainLength = 2,
+                    mismatchIndex = 2,
+                    grantIdPresent = true,
+                    anomalyKind = GrantSelfDomainAnomalyKind.SELF_CHAIN_SPLIT,
+                    detail = "lengthMismatch owner=3 grantee=2",
+                ),
+            ),
+        )
+
+        assertEquals(TeeVerdict.CONSISTENT, report.verdict)
+        assertEquals(1, report.supplementaryIndicatorCount)
+        assertTrue(report.summary.contains("Grant self-domain certificate-chain split", ignoreCase = true))
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "Grant self-domain" &&
+                it.level == TeeSignalLevel.FAIL &&
+                it.body.contains("Matched", ignoreCase = true) &&
+                it.body.contains("kind=SELF_CHAIN_SPLIT") &&
+                it.body.contains("mismatchIndex=2")
+        })
+    }
+
+    @Test
+    fun `grant self-domain unavailable state stays informational`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                grantSelfDomainFullChainSplit = GrantSelfDomainFullChainSplitResult(
+                    executed = false,
+                    detail = "self grantKeyAccess failed: UnrecoverableKeyException: No key found by the given alias",
+                ),
+            ),
+        )
+
+        assertEquals(0, report.supplementaryIndicatorCount)
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "Grant self-domain" &&
+                it.level == TeeSignalLevel.INFO &&
+                it.body.contains("Unavailable", ignoreCase = true) &&
+                it.body.contains("No key found by the given alias")
         })
     }
 
@@ -1695,6 +1747,9 @@ class TeeReportReducerTest {
         grantDomainFullChainSplit: GrantDomainFullChainSplitResult = GrantDomainFullChainSplitResult(
             detail = "skipped",
         ),
+        grantSelfDomainFullChainSplit: GrantSelfDomainFullChainSplitResult = GrantSelfDomainFullChainSplitResult(
+            detail = "skipped",
+        ),
         keyMetadataSemantics: KeyMetadataSemanticsResult = KeyMetadataSemanticsResult(
             executed = false,
             detail = "skipped",
@@ -1793,6 +1848,7 @@ class TeeReportReducerTest {
             keystore2Hook = keystore2Hook,
             generateModeParcelFingerprint = generateModeParcelFingerprint,
             grantDomainFullChainSplit = grantDomainFullChainSplit,
+            grantSelfDomainFullChainSplit = grantSelfDomainFullChainSplit,
             legacyKeystorePath = legacyKeystorePath,
             listEntriesConsistency = listEntriesConsistency,
             listEntriesBatched = listEntriesBatched,

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
@@ -872,11 +872,16 @@ class TeeReportReducerTest {
                     measurementAvailable = true,
                     suspicious = true,
                     sampleCount = 18,
+                    attemptedPairCount = 20,
+                    successfulPairCount = 20,
+                    failedPairCount = 0,
+                    filteredOutlierCount = 2,
+                    ratioEligible = true,
                     warmupCount = 5,
                     avgAttestedMillis = 0.612,
                     avgNonAttestedMillis = 0.400,
                     diffMillis = 0.212,
-                    detail = "register timer source; avgAttested=0.612ms, avgNonAttested=0.400ms, diff=0.212ms partialFailure=filteredBadSamples=2/20",
+                    detail = "register timer source; avgAttested=0.612ms, avgNonAttested=0.400ms, diff=0.212ms",
                 ),
             ),
         )
@@ -892,10 +897,51 @@ class TeeReportReducerTest {
                     it.body.contains("attested 0.612ms") &&
                     it.body.contains("non-attested 0.400ms") &&
                     it.body.contains("diff 0.212ms") &&
-                    it.body.contains("filteredBadSamples=2/20") &&
+                    it.body.contains("failedPairs=0/20") &&
+                    it.body.contains("outlierFiltered=2/20") &&
+                    it.body.contains("samples=18") &&
                     it.body.contains("ratio 1.530x") &&
                     it.body.contains("threshold > 1.1x") &&
                     it.level == TeeSignalLevel.WARN
+        })
+    }
+
+    @Test
+    fun `timing side-channel insufficient samples skip ratio without supplementary review`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                timingSideChannel = TimingSideChannelResult(
+                    probeRan = true,
+                    measurementAvailable = true,
+                    suspicious = true,
+                    sampleCount = 299,
+                    attemptedPairCount = 500,
+                    successfulPairCount = 320,
+                    failedPairCount = 180,
+                    filteredOutlierCount = 21,
+                    ratioEligible = false,
+                    ratioSkipReason = "insufficientSamples=299/300",
+                    warmupCount = 5,
+                    avgAttestedMillis = 0.612,
+                    avgNonAttestedMillis = 0.400,
+                    diffMillis = 0.212,
+                    detail = "register timer source; insufficientSamples=299/300",
+                ),
+            ),
+        )
+
+        assertEquals(TeeVerdict.CONSISTENT, report.verdict)
+        assertEquals(0, report.supplementaryIndicatorCount)
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "Timing side-channel" &&
+                    it.body.contains("ratio skipped") &&
+                    it.body.contains("failedPairs=180/500") &&
+                    it.body.contains("outlierFiltered=21/320") &&
+                    it.body.contains("samples=299") &&
+                    it.body.contains("insufficientSamples=299/300") &&
+                    it.body.contains("Ratio skipped") &&
+                    !it.body.contains("Positive") &&
+                    it.level == TeeSignalLevel.INFO
         })
     }
 

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
@@ -34,6 +34,7 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderC
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderHookBootstrapResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BinderPatchModeResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.BiometricTeeIntegrationResult
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationNarrativeResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyLifecycleResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyMetadataSemanticsResult
@@ -192,14 +193,17 @@ class TeeReportReducerTest {
             baseArtifacts(
                 importKeyRetainedAttestationNarrative = ImportKeyRetainedAttestationNarrativeResult(
                     executed = true,
+                    importSupported = true,
+                    markerImportBaselineClean = true,
                     originImported = true,
                     retainedNarrativeDetected = true,
                     priorChainLength = 3,
                     postImportChainLength = 2,
                     retainedCertificateCount = 2,
                     originLabel = "IMPORTED",
+                    anomalyKind = ImportKeyRetainedAttestationAnomalyKind.IMPORTED_RETAINED_PRIOR_CHAIN,
                     retainedFingerprint = "abc123def456",
-                    detail = "origin=IMPORTED, retained=2",
+                    detail = "kind=IMPORTED_RETAINED_PRIOR_CHAIN, origin=IMPORTED, retained=2",
                 ),
             ),
         )
@@ -210,6 +214,38 @@ class TeeReportReducerTest {
         assertTrue(report.sections.single { it.title == "Checks" }.items.any {
             it.title == "ImportKey narrative" &&
                 it.body.contains("Matched", ignoreCase = true) &&
+                it.level == TeeSignalLevel.FAIL
+        })
+    }
+
+    @Test
+    fun `stale generated importKey retained narrative becomes supplementary review`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                importKeyRetainedAttestationNarrative = ImportKeyRetainedAttestationNarrativeResult(
+                    executed = true,
+                    importSupported = true,
+                    markerImportBaselineClean = true,
+                    originImported = false,
+                    postImportLeafMatchesMarker = false,
+                    retainedNarrativeDetected = true,
+                    priorChainLength = 3,
+                    postImportChainLength = 3,
+                    retainedCertificateCount = 3,
+                    originLabel = "GENERATED",
+                    anomalyKind = ImportKeyRetainedAttestationAnomalyKind.STALE_GENERATED_AFTER_IMPORT,
+                    retainedFingerprint = "abc123def456",
+                    detail = "kind=STALE_GENERATED_AFTER_IMPORT, origin=GENERATED, retained=3",
+                ),
+            ),
+        )
+
+        assertEquals(TeeVerdict.CONSISTENT, report.verdict)
+        assertEquals(1, report.supplementaryIndicatorCount)
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "ImportKey narrative" &&
+                it.body.contains("Matched", ignoreCase = true) &&
+                it.body.contains("STALE_GENERATED_AFTER_IMPORT") &&
                 it.level == TeeSignalLevel.FAIL
         })
     }
@@ -229,6 +265,28 @@ class TeeReportReducerTest {
         assertTrue(report.sections.single { it.title == "Checks" }.items.any {
             it.title == "ImportKey narrative" &&
                 it.body.contains("Unavailable", ignoreCase = true) &&
+                it.level == TeeSignalLevel.INFO
+        })
+    }
+
+    @Test
+    fun `importKey unsupported state stays informational`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                importKeyRetainedAttestationNarrative = ImportKeyRetainedAttestationNarrativeResult(
+                    executed = false,
+                    importSupported = false,
+                    anomalyKind = ImportKeyRetainedAttestationAnomalyKind.IMPORT_UNSUPPORTED,
+                    detail = "ImportKey support gate failed.",
+                ),
+            ),
+        )
+
+        assertEquals(0, report.supplementaryIndicatorCount)
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "ImportKey narrative" &&
+                it.body.contains("Unavailable", ignoreCase = true) &&
+                it.body.contains("ImportKey support gate failed") &&
                 it.level == TeeSignalLevel.INFO
         })
     }

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GenerateKeyReplyParcelParserTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GenerateKeyReplyParcelParserTest.kt
@@ -68,6 +68,18 @@ class GenerateKeyReplyParcelParserTest {
     }
 
     @Test
+    fun `stable fingerprint accepts tee security level in last authorization`() {
+        val result = parser.parse(rawReply = variableCountGenerateModeReply(lastSecLevel = 4))
+
+        assertTrue(result.parseSucceeded)
+        assertEquals(4L, result.lastAuthorizationSecLevel)
+        assertEquals(1L, result.lastAuthorizationTag)
+        assertEquals(32L, result.lastAuthorizationUnionTag)
+        assertEquals(4_294_967_297L, result.modificationTimeMs)
+        assertTrue(result.matched)
+    }
+
+    @Test
     fun `normal fixture keeps non hit shape metadata`() {
         val result = parser.parse(rawReply = hexToBytes(NORMAL_REPLY_HEX))
 
@@ -117,6 +129,18 @@ class GenerateKeyReplyParcelParserTest {
     }
 
     @Test
+    fun `fingerprint does not match when last authorization tag differs`() {
+        val result = parser.parse(rawReply = variableCountGenerateModeReply(lastTag = 0x00000020))
+
+        assertTrue(result.parseSucceeded)
+        assertEquals(256L, result.lastAuthorizationSecLevel)
+        assertEquals(32L, result.lastAuthorizationTag)
+        assertEquals(32L, result.lastAuthorizationUnionTag)
+        assertEquals(4_294_967_297L, result.modificationTimeMs)
+        assertFalse(result.matched)
+    }
+
+    @Test
     fun `fingerprint does not match when unknown union tag is not on last authorization`() {
         val result = parser.parse(
             rawReply = variableCountGenerateModeReply(
@@ -153,6 +177,7 @@ class GenerateKeyReplyParcelParserTest {
     private fun variableCountGenerateModeReply(
         firstUnionTag: Int = 1,
         lastSecLevel: Int = 256,
+        lastTag: Int = 0x00000001,
         lastUnionTag: Int = 32,
         modificationTimeMs: Long = 4_294_967_297L,
     ): ByteArray {
@@ -162,7 +187,7 @@ class GenerateKeyReplyParcelParserTest {
             addIntLe(1)
             addIntLe(2)
             addAuthorization(secLevel = 1, tag = 0x00000020, unionTag = firstUnionTag, value = 1)
-            addAuthorization(secLevel = lastSecLevel, tag = 0x00000001, unionTag = lastUnionTag, value = 1)
+            addAuthorization(secLevel = lastSecLevel, tag = lastTag, unionTag = lastUnionTag, value = 1)
             addIntLe(1)
             addIntLe(1)
             add(0xAA.toByte())

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantDomainFullChainSplitProbeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantDomainFullChainSplitProbeTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.verification.keystore
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GrantDomainFullChainSplitProbeTest {
+
+    @Test
+    fun `matching ordered full chains stay clean`() {
+        val chain = chain("leaf", "intermediate", "root")
+
+        val comparison = GrantDomainFullChainSplitProbe.compareChains(chain, chain)
+
+        assertFalse(comparison.splitDetected)
+        assertEquals(null, comparison.mismatchIndex)
+        assertTrue(comparison.detail.contains("matched", ignoreCase = true))
+    }
+
+    @Test
+    fun `length mismatch detects split`() {
+        val comparison = GrantDomainFullChainSplitProbe.compareChains(
+            ownerChain = chain("leaf", "intermediate", "root"),
+            granteeChain = chain("leaf", "intermediate"),
+        )
+
+        assertTrue(comparison.splitDetected)
+        assertEquals(2, comparison.mismatchIndex)
+        assertTrue(comparison.detail.contains("lengthMismatch"))
+    }
+
+    @Test
+    fun `leaf mismatch detects split at zero`() {
+        val comparison = GrantDomainFullChainSplitProbe.compareChains(
+            ownerChain = chain("owner-leaf", "intermediate"),
+            granteeChain = chain("grantee-leaf", "intermediate"),
+        )
+
+        assertTrue(comparison.splitDetected)
+        assertEquals(0, comparison.mismatchIndex)
+        assertTrue(comparison.detail.contains("leafMismatch"))
+    }
+
+    @Test
+    fun `ordered remaining chain mismatch detects split`() {
+        val comparison = GrantDomainFullChainSplitProbe.compareChains(
+            ownerChain = chain("leaf", "intermediate-a", "root"),
+            granteeChain = chain("leaf", "intermediate-b", "root"),
+        )
+
+        assertTrue(comparison.splitDetected)
+        assertEquals(1, comparison.mismatchIndex)
+        assertTrue(comparison.detail.contains("chainMismatch"))
+    }
+
+    @Test
+    fun `remaining chain ordering mismatch detects split`() {
+        val comparison = GrantDomainFullChainSplitProbe.compareChains(
+            ownerChain = chain("leaf", "intermediate", "root"),
+            granteeChain = chain("leaf", "root", "intermediate"),
+        )
+
+        assertTrue(comparison.splitDetected)
+        assertEquals(1, comparison.mismatchIndex)
+    }
+
+    private fun chain(vararg labels: String): GrantDomainCertificateChain {
+        return GrantDomainCertificateChain(
+            labels.map { label ->
+                GrantDomainCertificateFingerprint.fromDer(label.toByteArray())
+            },
+        )
+    }
+}

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantDomainFullChainSplitProbeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantDomainFullChainSplitProbeTest.kt
@@ -16,6 +16,7 @@
 
 package com.eltavine.duckdetector.features.tee.data.verification.keystore
 
+import java.security.UnrecoverableKeyException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -79,6 +80,25 @@ class GrantDomainFullChainSplitProbeTest {
 
         assertTrue(comparison.splitDetected)
         assertEquals(1, comparison.mismatchIndex)
+    }
+
+    @Test
+    fun `grant alias not found detection requires unrecoverable key exception wording`() {
+        assertTrue(
+            GrantDomainFullChainSplitProbe.isGrantAliasNotFound(
+                UnrecoverableKeyException("No key found by the given alias"),
+            ),
+        )
+        assertFalse(
+            GrantDomainFullChainSplitProbe.isGrantAliasNotFound(
+                UnrecoverableKeyException("Permission denied"),
+            ),
+        )
+        assertFalse(
+            GrantDomainFullChainSplitProbe.isGrantAliasNotFound(
+                IllegalStateException("No key found by the given alias"),
+            ),
+        )
     }
 
     private fun chain(vararg labels: String): GrantDomainCertificateChain {

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantSelfDomainFullChainSplitProbeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GrantSelfDomainFullChainSplitProbeTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.verification.keystore
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GrantSelfDomainFullChainSplitProbeTest {
+
+    @Test
+    fun `matching owner and self grant chains stay clean`() {
+        val chain = chain("leaf", "intermediate", "root")
+
+        val comparison = GrantSelfDomainFullChainSplitProbe.compareChains(chain, chain)
+
+        assertFalse(comparison.splitDetected)
+        assertEquals(null, comparison.mismatchIndex)
+    }
+
+    @Test
+    fun `leaf mismatch detects self grant split`() {
+        val comparison = GrantSelfDomainFullChainSplitProbe.compareChains(
+            ownerChain = chain("owner-leaf", "intermediate"),
+            grantChain = chain("grant-leaf", "intermediate"),
+        )
+
+        assertTrue(comparison.splitDetected)
+        assertEquals(0, comparison.mismatchIndex)
+        assertTrue(comparison.detail.contains("leafMismatch"))
+    }
+
+    @Test
+    fun `ordered chain mismatch detects self grant split`() {
+        val comparison = GrantSelfDomainFullChainSplitProbe.compareChains(
+            ownerChain = chain("leaf", "intermediate", "root"),
+            grantChain = chain("leaf", "root", "intermediate"),
+        )
+
+        assertTrue(comparison.splitDetected)
+        assertEquals(1, comparison.mismatchIndex)
+    }
+
+    @Test
+    fun `length mismatch detects self grant split`() {
+        val comparison = GrantSelfDomainFullChainSplitProbe.compareChains(
+            ownerChain = chain("leaf", "intermediate", "root"),
+            grantChain = chain("leaf", "intermediate"),
+        )
+
+        assertTrue(comparison.splitDetected)
+        assertEquals(2, comparison.mismatchIndex)
+    }
+
+    private fun chain(vararg labels: String): GrantDomainCertificateChain {
+        return GrantDomainCertificateChain(
+            labels.map { label ->
+                GrantDomainCertificateFingerprint.fromDer(label.toByteArray())
+            },
+        )
+    }
+}

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/ImportKeyRetainedAttestationNarrativeProbeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/ImportKeyRetainedAttestationNarrativeProbeTest.kt
@@ -24,70 +24,166 @@ import org.junit.Test
 class ImportKeyRetainedAttestationNarrativeProbeTest {
 
     @Test
-    fun `retained prior chain in imported-origin response is matched`() {
+    fun `support gate failure is unavailable and does not match`() {
+        val runtime = FakeRuntime(
+            support = ImportKeyRetainedAttestationNarrativeProbe.ImportSupportResult(
+                supported = false,
+                leafMatchesMarker = false,
+                originValue = null,
+                originLabel = "unknown",
+                detail = "ImportKey support gate failed.",
+            ),
+        )
+        val probe = ImportKeyRetainedAttestationNarrativeProbe(
+            runtime = runtime,
+            aliasFactory = { "duck_test" },
+        )
+
+        val result = probe.inspect()
+
+        assertFalse(result.executed)
+        assertFalse(result.importSupported)
+        assertFalse(result.retainedNarrativeDetected)
+        assertEquals(ImportKeyRetainedAttestationAnomalyKind.IMPORT_UNSUPPORTED, result.anomalyKind)
+        assertEquals(listOf("duck_test_support", "duck_test_attack"), runtime.cleanedAliases)
+    }
+
+    @Test
+    fun `normal imported marker baseline is clean`() {
+        val result = ImportKeyRetainedAttestationNarrativeProbe.evaluatePostImportState(
+            priorChain = listOf(cert(1), cert(2)),
+            snapshots = listOf(
+                ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata(
+                    originValue = ORIGIN_IMPORTED,
+                    fullChain = listOf(MARKER_CERT),
+                    leafMatchesMarker = true,
+                ),
+            ),
+            importedOriginValues = setOf(ORIGIN_IMPORTED),
+            generatedOriginValue = ORIGIN_GENERATED,
+            originLabel = ::labelOrigin,
+        )
+
+        assertTrue(result.executed)
+        assertTrue(result.importSupported)
+        assertTrue(result.markerImportBaselineClean)
+        assertTrue(result.originImported)
+        assertTrue(result.postImportLeafMatchesMarker)
+        assertFalse(result.retainedNarrativeDetected)
+        assertEquals(ImportKeyRetainedAttestationAnomalyKind.NONE, result.anomalyKind)
+        assertTrue(result.detail.contains("kind=NONE"))
+    }
+
+    @Test
+    fun `imported-origin retained prior full-chain is matched`() {
         val prior = listOf(cert(1), cert(2), cert(3))
         val result = ImportKeyRetainedAttestationNarrativeProbe.evaluatePostImportState(
             priorChain = prior,
-            postImportChain = listOf(cert(2), cert(3)),
-            originValue = ORIGIN_IMPORTED,
+            snapshots = listOf(
+                ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata(
+                    originValue = ORIGIN_IMPORTED,
+                    fullChain = listOf(cert(2), cert(3)),
+                    leafMatchesMarker = false,
+                ),
+            ),
             importedOriginValues = setOf(ORIGIN_IMPORTED),
-            originLabel = "IMPORTED",
+            generatedOriginValue = ORIGIN_GENERATED,
+            originLabel = ::labelOrigin,
         )
 
         assertTrue(result.executed)
-        assertTrue(result.originImported)
         assertTrue(result.retainedNarrativeDetected)
+        assertEquals(
+            ImportKeyRetainedAttestationAnomalyKind.IMPORTED_RETAINED_PRIOR_CHAIN,
+            result.anomalyKind,
+        )
         assertEquals(3, result.priorChainLength)
         assertEquals(2, result.postImportChainLength)
         assertEquals(2, result.retainedCertificateCount)
-        assertTrue(result.detail.contains("firstRetained"))
+        assertTrue(result.detail.contains("kind=IMPORTED_RETAINED_PRIOR_CHAIN"))
     }
 
     @Test
-    fun `imported-origin response without certificate chain is clean`() {
+    fun `generated-origin stale cached prior chain is matched after support gate`() {
+        val prior = listOf(cert(1), cert(2), cert(3))
         val result = ImportKeyRetainedAttestationNarrativeProbe.evaluatePostImportState(
-            priorChain = listOf(cert(1), cert(2)),
-            postImportChain = emptyList(),
-            originValue = ORIGIN_IMPORTED,
+            priorChain = prior,
+            snapshots = listOf(
+                ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata(
+                    originValue = ORIGIN_GENERATED,
+                    fullChain = listOf(cert(1), cert(2), cert(3)),
+                    leafMatchesMarker = false,
+                ),
+            ),
             importedOriginValues = setOf(ORIGIN_IMPORTED),
-            originLabel = "IMPORTED",
+            generatedOriginValue = ORIGIN_GENERATED,
+            originLabel = ::labelOrigin,
         )
 
         assertTrue(result.executed)
-        assertTrue(result.originImported)
-        assertFalse(result.retainedNarrativeDetected)
-        assertEquals(0, result.postImportChainLength)
-        assertTrue(result.detail.contains("no certificateChain"))
+        assertTrue(result.importSupported)
+        assertTrue(result.retainedNarrativeDetected)
+        assertFalse(result.postImportLeafMatchesMarker)
+        assertEquals(
+            ImportKeyRetainedAttestationAnomalyKind.STALE_GENERATED_AFTER_IMPORT,
+            result.anomalyKind,
+        )
+        assertEquals(3, result.retainedCertificateCount)
+        assertTrue(result.detail.contains("kind=STALE_GENERATED_AFTER_IMPORT"))
     }
 
     @Test
-    fun `missing origin is unavailable and does not match`() {
-        val result = ImportKeyRetainedAttestationNarrativeProbe.evaluatePostImportState(
-            priorChain = listOf(cert(1)),
-            postImportChain = listOf(cert(1)),
-            originValue = null,
-            importedOriginValues = setOf(ORIGIN_IMPORTED),
+    fun `first post-import read can be ignored when second read exposes stale generated response`() {
+        val runtime = FakeRuntime(
+            snapshots = listOf(
+                ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata(
+                    originValue = ORIGIN_IMPORTED,
+                    fullChain = listOf(MARKER_CERT),
+                    leafMatchesMarker = true,
+                ),
+                ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata(
+                    originValue = ORIGIN_GENERATED,
+                    fullChain = listOf(cert(1), cert(2)),
+                    leafMatchesMarker = false,
+                ),
+            ),
+        )
+        val probe = ImportKeyRetainedAttestationNarrativeProbe(
+            runtime = runtime,
+            aliasFactory = { "duck_test" },
         )
 
-        assertFalse(result.executed)
-        assertFalse(result.originImported)
-        assertFalse(result.retainedNarrativeDetected)
-        assertTrue(result.detail.contains("ORIGIN"))
+        val result = probe.inspect()
+
+        assertTrue(result.executed)
+        assertTrue(result.retainedNarrativeDetected)
+        assertEquals(
+            ImportKeyRetainedAttestationAnomalyKind.STALE_GENERATED_AFTER_IMPORT,
+            result.anomalyKind,
+        )
+        assertEquals(listOf("duck_test_support", "duck_test_attack"), runtime.cleanedAliases)
     }
 
     @Test
-    fun `non-matching post-import chain is unavailable and does not match`() {
+    fun `generated-origin without retained overlap is unavailable`() {
         val result = ImportKeyRetainedAttestationNarrativeProbe.evaluatePostImportState(
             priorChain = listOf(cert(1), cert(2)),
-            postImportChain = listOf(cert(4), cert(5)),
-            originValue = ORIGIN_IMPORTED,
+            snapshots = listOf(
+                ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata(
+                    originValue = ORIGIN_GENERATED,
+                    fullChain = listOf(cert(4), cert(5)),
+                    leafMatchesMarker = false,
+                ),
+            ),
             importedOriginValues = setOf(ORIGIN_IMPORTED),
-            originLabel = "IMPORTED",
+            generatedOriginValue = ORIGIN_GENERATED,
+            originLabel = ::labelOrigin,
         )
 
         assertFalse(result.executed)
         assertFalse(result.retainedNarrativeDetected)
-        assertTrue(result.detail.contains("did not match"))
+        assertEquals(ImportKeyRetainedAttestationAnomalyKind.UNAVAILABLE, result.anomalyKind)
+        assertTrue(result.detail.contains("did not produce"))
     }
 
     @Test
@@ -97,39 +193,34 @@ class ImportKeyRetainedAttestationNarrativeProbeTest {
         )
         val probe = ImportKeyRetainedAttestationNarrativeProbe(
             runtime = runtime,
-            aliasFactory = { "duck_test_alias" },
+            aliasFactory = { "duck_test" },
         )
 
         val result = probe.inspect()
 
         assertFalse(result.executed)
         assertFalse(result.retainedNarrativeDetected)
-        assertEquals(listOf("duck_test_alias"), runtime.cleanedAliases)
+        assertEquals(listOf("duck_test_support", "duck_test_attack"), runtime.cleanedAliases)
         assertTrue(result.detail.contains("import failed"))
-    }
-
-    @Test
-    fun `runtime binder metadata unavailable does not escape scan`() {
-        val runtime = FakeRuntime(metadata = null)
-        val probe = ImportKeyRetainedAttestationNarrativeProbe(
-            runtime = runtime,
-            aliasFactory = { "duck_test_alias" },
-        )
-
-        val result = probe.inspect()
-
-        assertFalse(result.executed)
-        assertFalse(result.retainedNarrativeDetected)
-        assertEquals(listOf("duck_test_alias"), runtime.cleanedAliases)
-        assertTrue(result.detail.contains("metadata"))
     }
 
     private class FakeRuntime(
         private val priorChain: List<ByteArray> = listOf(cert(1), cert(2)),
-        private val metadata: ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata? =
-            ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata(
+        private val support: ImportKeyRetainedAttestationNarrativeProbe.ImportSupportResult =
+            ImportKeyRetainedAttestationNarrativeProbe.ImportSupportResult(
+                supported = true,
+                leafMatchesMarker = true,
                 originValue = ORIGIN_IMPORTED,
-                certificateChain = listOf(cert(2)),
+                originLabel = "IMPORTED",
+                detail = "origin=IMPORTED, marker import baseline clean.",
+            ),
+        private val snapshots: List<ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata> =
+            listOf(
+                ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata(
+                    originValue = ORIGIN_IMPORTED,
+                    fullChain = listOf(MARKER_CERT),
+                    leafMatchesMarker = true,
+                ),
             ),
         private val importFailure: Throwable? = null,
     ) : ImportKeyRetainedAttestationNarrativeProbe.Runtime {
@@ -137,6 +228,7 @@ class ImportKeyRetainedAttestationNarrativeProbeTest {
 
         override val supported: Boolean = true
         override val importedOriginValues: Set<Int> = setOf(ORIGIN_IMPORTED)
+        override val generatedOriginValue: Int = ORIGIN_GENERATED
 
         override fun generatePriorAttestedChain(alias: String, challenge: ByteArray): List<ByteArray> {
             return priorChain
@@ -146,17 +238,35 @@ class ImportKeyRetainedAttestationNarrativeProbeTest {
             importFailure?.let { throw it }
         }
 
-        override fun readPostImportMetadata(alias: String): ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata? {
-            return metadata
+        override fun verifyImportSupport(alias: String): ImportKeyRetainedAttestationNarrativeProbe.ImportSupportResult {
+            importFailure?.let { throw it }
+            return support
+        }
+
+        override fun readPostImportMetadataSnapshots(alias: String): List<ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata> {
+            return snapshots
         }
 
         override fun cleanup(alias: String) {
             cleanedAliases += alias
         }
+
+        override fun originLabel(value: Int?): String = labelOrigin(value)
     }
 
     companion object {
+        private const val ORIGIN_GENERATED = 0
         private const val ORIGIN_IMPORTED = 2
+        private val MARKER_CERT = cert(99)
+
+        private fun labelOrigin(value: Int?): String {
+            return when (value) {
+                ORIGIN_GENERATED -> "GENERATED"
+                ORIGIN_IMPORTED -> "IMPORTED"
+                null -> "unknown"
+                else -> value.toString()
+            }
+        }
 
         private fun cert(seed: Int): ByteArray {
             return ByteArray(24) { index -> (seed + index).toByte() }

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/ImportKeyRetainedAttestationNarrativeProbeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/ImportKeyRetainedAttestationNarrativeProbeTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.verification.keystore
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImportKeyRetainedAttestationNarrativeProbeTest {
+
+    @Test
+    fun `retained prior chain in imported-origin response is matched`() {
+        val prior = listOf(cert(1), cert(2), cert(3))
+        val result = ImportKeyRetainedAttestationNarrativeProbe.evaluatePostImportState(
+            priorChain = prior,
+            postImportChain = listOf(cert(2), cert(3)),
+            originValue = ORIGIN_IMPORTED,
+            importedOriginValues = setOf(ORIGIN_IMPORTED),
+            originLabel = "IMPORTED",
+        )
+
+        assertTrue(result.executed)
+        assertTrue(result.originImported)
+        assertTrue(result.retainedNarrativeDetected)
+        assertEquals(3, result.priorChainLength)
+        assertEquals(2, result.postImportChainLength)
+        assertEquals(2, result.retainedCertificateCount)
+        assertTrue(result.detail.contains("firstRetained"))
+    }
+
+    @Test
+    fun `imported-origin response without certificate chain is clean`() {
+        val result = ImportKeyRetainedAttestationNarrativeProbe.evaluatePostImportState(
+            priorChain = listOf(cert(1), cert(2)),
+            postImportChain = emptyList(),
+            originValue = ORIGIN_IMPORTED,
+            importedOriginValues = setOf(ORIGIN_IMPORTED),
+            originLabel = "IMPORTED",
+        )
+
+        assertTrue(result.executed)
+        assertTrue(result.originImported)
+        assertFalse(result.retainedNarrativeDetected)
+        assertEquals(0, result.postImportChainLength)
+        assertTrue(result.detail.contains("no certificateChain"))
+    }
+
+    @Test
+    fun `missing origin is unavailable and does not match`() {
+        val result = ImportKeyRetainedAttestationNarrativeProbe.evaluatePostImportState(
+            priorChain = listOf(cert(1)),
+            postImportChain = listOf(cert(1)),
+            originValue = null,
+            importedOriginValues = setOf(ORIGIN_IMPORTED),
+        )
+
+        assertFalse(result.executed)
+        assertFalse(result.originImported)
+        assertFalse(result.retainedNarrativeDetected)
+        assertTrue(result.detail.contains("ORIGIN"))
+    }
+
+    @Test
+    fun `non-matching post-import chain is unavailable and does not match`() {
+        val result = ImportKeyRetainedAttestationNarrativeProbe.evaluatePostImportState(
+            priorChain = listOf(cert(1), cert(2)),
+            postImportChain = listOf(cert(4), cert(5)),
+            originValue = ORIGIN_IMPORTED,
+            importedOriginValues = setOf(ORIGIN_IMPORTED),
+            originLabel = "IMPORTED",
+        )
+
+        assertFalse(result.executed)
+        assertFalse(result.retainedNarrativeDetected)
+        assertTrue(result.detail.contains("did not match"))
+    }
+
+    @Test
+    fun `runtime import failure is unavailable and cleaned up`() {
+        val runtime = FakeRuntime(
+            importFailure = IllegalStateException("import failed"),
+        )
+        val probe = ImportKeyRetainedAttestationNarrativeProbe(
+            runtime = runtime,
+            aliasFactory = { "duck_test_alias" },
+        )
+
+        val result = probe.inspect()
+
+        assertFalse(result.executed)
+        assertFalse(result.retainedNarrativeDetected)
+        assertEquals(listOf("duck_test_alias"), runtime.cleanedAliases)
+        assertTrue(result.detail.contains("import failed"))
+    }
+
+    @Test
+    fun `runtime binder metadata unavailable does not escape scan`() {
+        val runtime = FakeRuntime(metadata = null)
+        val probe = ImportKeyRetainedAttestationNarrativeProbe(
+            runtime = runtime,
+            aliasFactory = { "duck_test_alias" },
+        )
+
+        val result = probe.inspect()
+
+        assertFalse(result.executed)
+        assertFalse(result.retainedNarrativeDetected)
+        assertEquals(listOf("duck_test_alias"), runtime.cleanedAliases)
+        assertTrue(result.detail.contains("metadata"))
+    }
+
+    private class FakeRuntime(
+        private val priorChain: List<ByteArray> = listOf(cert(1), cert(2)),
+        private val metadata: ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata? =
+            ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata(
+                originValue = ORIGIN_IMPORTED,
+                certificateChain = listOf(cert(2)),
+            ),
+        private val importFailure: Throwable? = null,
+    ) : ImportKeyRetainedAttestationNarrativeProbe.Runtime {
+        val cleanedAliases = mutableListOf<String>()
+
+        override val supported: Boolean = true
+        override val importedOriginValues: Set<Int> = setOf(ORIGIN_IMPORTED)
+
+        override fun generatePriorAttestedChain(alias: String, challenge: ByteArray): List<ByteArray> {
+            return priorChain
+        }
+
+        override fun importMarkerKey(alias: String) {
+            importFailure?.let { throw it }
+        }
+
+        override fun readPostImportMetadata(alias: String): ImportKeyRetainedAttestationNarrativeProbe.PostImportMetadata? {
+            return metadata
+        }
+
+        override fun cleanup(alias: String) {
+            cleanedAliases += alias
+        }
+    }
+
+    companion object {
+        private const val ORIGIN_IMPORTED = 2
+
+        private fun cert(seed: Int): ByteArray {
+            return ByteArray(24) { index -> (seed + index).toByte() }
+        }
+    }
+}

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/TimingSideChannelFormattingTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/TimingSideChannelFormattingTest.kt
@@ -66,7 +66,7 @@ class TimingSideChannelFormattingTest {
     }
 
     @Test
-    fun `detail includes filtered bad sample count when post filtering removes outliers`() {
+    fun `detail includes sample count and ratio skip reason independently`() {
         val detail = buildTimingSideChannelDetail(
             source = "keystore2_security_level_proxy",
             timerSource = "arm64_cntvct",
@@ -74,16 +74,44 @@ class TimingSideChannelFormattingTest {
             avgAttestedMillis = 0.612,
             avgNonAttestedMillis = 0.300,
             diffMillis = 0.312,
-            suspicious = true,
-            sampleCount = 18,
+            suspicious = false,
+            sampleCount = 299,
             warmupCount = 5,
             measurementDetail = "service.getKeyEntry timing via private binder proxy",
             timerFallbackReason = null,
-            partialFailureReason = "filteredBadSamples=2/20",
+            partialFailureReason = "insufficientSamples=299/300",
         )
 
-        assertTrue(detail.contains("filteredBadSamples=2/20"))
-        assertTrue(detail.contains("samples=18"))
+        assertTrue(detail.contains("insufficientSamples=299/300"))
+        assertTrue(detail.contains("samples=299"))
+    }
+
+    @Test
+    fun `detail can carry separate sampling failure and outlier counts`() {
+        val detail = buildTimingSideChannelDetail(
+            source = "keystore2_security_level_proxy",
+            timerSource = "arm64_cntvct",
+            affinity = "bound_cpu0",
+            avgAttestedMillis = 0.612,
+            avgNonAttestedMillis = 0.400,
+            diffMillis = 0.212,
+            suspicious = true,
+            sampleCount = 450,
+            warmupCount = 5,
+            measurementDetail = "service.getKeyEntry timing via private binder proxy",
+            timerFallbackReason = null,
+            partialFailureReason = "failedPairs=25/500; outlierFiltered=25/475",
+        )
+
+        assertTrue(detail.contains("failedPairs=25/500"))
+        assertTrue(detail.contains("outlierFiltered=25/475"))
+        assertTrue(detail.contains("samples=450"))
+    }
+
+    @Test
+    fun `ratio eligibility requires at least minimum filtered samples`() {
+        assertFalse(isTimingSideChannelRatioEligible(MIN_RATIO_SAMPLE_COUNT - 1))
+        assertTrue(isTimingSideChannelRatioEligible(MIN_RATIO_SAMPLE_COUNT))
     }
 
     @Test

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/TimingSideChannelThresholdTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/TimingSideChannelThresholdTest.kt
@@ -67,4 +67,14 @@ class TimingSideChannelThresholdTest {
         assertFalse(isPositiveTimingSideChannelRatio(null, 1.00))
         assertFalse(isPositiveTimingSideChannelRatio(1.00, 0.0))
     }
+
+    @Test
+    fun `filtered sample count below minimum is not ratio eligible`() {
+        assertFalse(isTimingSideChannelRatioEligible(299))
+    }
+
+    @Test
+    fun `filtered sample count at minimum remains ratio eligible`() {
+        assertTrue(isTimingSideChannelRatioEligible(300))
+    }
 }

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapperTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapperTest.kt
@@ -392,6 +392,49 @@ class TeeCardModelMapperTest {
     }
 
     @Test
+    fun `matched grant domain split escalates aligned tee card to danger`() {
+        val model = mapper.map(
+            report = TeeReport(
+                stage = TeeScanStage.READY,
+                verdict = TeeVerdict.CONSISTENT,
+                tier = TeeTier.TEE,
+                headline = "Attestation aligned; local probes need review",
+                summary = "Grant-domain certificate-chain narrative split detected. Attestation and trust-path checks still aligned.",
+                collapsedSummary = "Aligned • local review",
+                trustRoot = TeeTrustRoot.GOOGLE,
+                trustSummary = "Local trust path",
+                tamperScore = 10,
+                evidenceCount = 1,
+                supplementaryIndicatorCount = 1,
+                supplementaryReviewLevel = TeeSignalLevel.WARN,
+                signals = listOf(
+                    TeeSignal(
+                        "Grant domain",
+                        "Matched",
+                        TeeSignalLevel.FAIL,
+                    ),
+                ),
+                sections = listOf(
+                    TeeEvidenceSection(
+                        title = "Checks",
+                        items = listOf(
+                            TeeEvidenceItem(
+                                "Grant domain",
+                                "Matched • mismatchIndex=2 • owner=3 grantee=2",
+                                TeeSignalLevel.FAIL,
+                            ),
+                        ),
+                    ),
+                ),
+                certificates = emptyList(),
+            ),
+            isExpanded = false,
+        )
+
+        assertEquals(DetectorStatus.danger(), model.status)
+    }
+
+    @Test
     fun `rkp badge is hidden when local trust chain needs review`() {
         val model = mapper.map(
             report = TeeReport(

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapperTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapperTest.kt
@@ -478,6 +478,49 @@ class TeeCardModelMapperTest {
     }
 
     @Test
+    fun `matched grant self-domain split escalates aligned tee card to danger`() {
+        val model = mapper.map(
+            report = TeeReport(
+                stage = TeeScanStage.READY,
+                verdict = TeeVerdict.CONSISTENT,
+                tier = TeeTier.TEE,
+                headline = "Attestation aligned; local probes need review",
+                summary = "Grant self-domain certificate-chain split detected. Attestation and trust-path checks still aligned.",
+                collapsedSummary = "Aligned • local review",
+                trustRoot = TeeTrustRoot.GOOGLE,
+                trustSummary = "Local trust path",
+                tamperScore = 10,
+                evidenceCount = 1,
+                supplementaryIndicatorCount = 1,
+                supplementaryReviewLevel = TeeSignalLevel.WARN,
+                signals = listOf(
+                    TeeSignal(
+                        "Grant self-domain",
+                        "Matched",
+                        TeeSignalLevel.FAIL,
+                    ),
+                ),
+                sections = listOf(
+                    TeeEvidenceSection(
+                        title = "Checks",
+                        items = listOf(
+                            TeeEvidenceItem(
+                                "Grant self-domain",
+                                "Matched kind=SELF_CHAIN_SPLIT owner=3 grant=2 mismatchIndex=2",
+                                TeeSignalLevel.FAIL,
+                            ),
+                        ),
+                    ),
+                ),
+                certificates = emptyList(),
+            ),
+            isExpanded = false,
+        )
+
+        assertEquals(DetectorStatus.danger(), model.status)
+    }
+
+    @Test
     fun `rkp badge is hidden when local trust chain needs review`() {
         val model = mapper.map(
             report = TeeReport(

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapperTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapperTest.kt
@@ -392,14 +392,14 @@ class TeeCardModelMapperTest {
     }
 
     @Test
-    fun `matched grant domain split escalates aligned tee card to danger`() {
+    fun `matched grant isolated-domain split escalates aligned tee card to danger`() {
         val model = mapper.map(
             report = TeeReport(
                 stage = TeeScanStage.READY,
                 verdict = TeeVerdict.CONSISTENT,
                 tier = TeeTier.TEE,
                 headline = "Attestation aligned; local probes need review",
-                summary = "Grant-domain certificate-chain narrative split detected. Attestation and trust-path checks still aligned.",
+                summary = "Grant isolated-domain certificate-chain narrative split detected. Attestation and trust-path checks still aligned.",
                 collapsedSummary = "Aligned • local review",
                 trustRoot = TeeTrustRoot.GOOGLE,
                 trustSummary = "Local trust path",
@@ -409,7 +409,7 @@ class TeeCardModelMapperTest {
                 supplementaryReviewLevel = TeeSignalLevel.WARN,
                 signals = listOf(
                     TeeSignal(
-                        "Grant domain",
+                        "Grant isolated-domain",
                         "Matched",
                         TeeSignalLevel.FAIL,
                     ),
@@ -419,8 +419,51 @@ class TeeCardModelMapperTest {
                         title = "Checks",
                         items = listOf(
                             TeeEvidenceItem(
-                                "Grant domain",
-                                "Matched • mismatchIndex=2 • owner=3 grantee=2",
+                                "Grant isolated-domain",
+                                "Matched kind=ISOLATED_CHAIN_SPLIT • mismatchIndex=2 • owner=3 grantee=2",
+                                TeeSignalLevel.FAIL,
+                            ),
+                        ),
+                    ),
+                ),
+                certificates = emptyList(),
+            ),
+            isExpanded = false,
+        )
+
+        assertEquals(DetectorStatus.danger(), model.status)
+    }
+
+    @Test
+    fun `grant isolated-domain key visibility divergence escalates aligned tee card to danger`() {
+        val model = mapper.map(
+            report = TeeReport(
+                stage = TeeScanStage.READY,
+                verdict = TeeVerdict.CONSISTENT,
+                tier = TeeTier.TEE,
+                headline = "Attestation aligned; local probes need review",
+                summary = "Grant isolated-domain key visibility divergence detected. Attestation and trust-path checks still aligned.",
+                collapsedSummary = "Aligned • local review",
+                trustRoot = TeeTrustRoot.GOOGLE,
+                trustSummary = "Local trust path",
+                tamperScore = 10,
+                evidenceCount = 1,
+                supplementaryIndicatorCount = 1,
+                supplementaryReviewLevel = TeeSignalLevel.WARN,
+                signals = listOf(
+                    TeeSignal(
+                        "Grant isolated-domain",
+                        "Unavailable",
+                        TeeSignalLevel.FAIL,
+                    ),
+                ),
+                sections = listOf(
+                    TeeEvidenceSection(
+                        title = "Checks",
+                        items = listOf(
+                            TeeEvidenceItem(
+                                "Grant isolated-domain",
+                                "Unavailable kind=ISOLATED_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN • grantKeyAccess failed: UnrecoverableKeyException: No key found by the given alias",
                                 TeeSignalLevel.FAIL,
                             ),
                         ),

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapperTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapperTest.kt
@@ -349,6 +349,49 @@ class TeeCardModelMapperTest {
     }
 
     @Test
+    fun `matched importKey retained narrative escalates aligned tee card to danger`() {
+        val model = mapper.map(
+            report = TeeReport(
+                stage = TeeScanStage.READY,
+                verdict = TeeVerdict.CONSISTENT,
+                tier = TeeTier.TEE,
+                headline = "Attestation aligned; local probes need review",
+                summary = "ImportKey retained attestation narrative detected. Attestation and trust-path checks still aligned.",
+                collapsedSummary = "Aligned • local review",
+                trustRoot = TeeTrustRoot.GOOGLE,
+                trustSummary = "Local trust path",
+                tamperScore = 10,
+                evidenceCount = 1,
+                supplementaryIndicatorCount = 1,
+                supplementaryReviewLevel = TeeSignalLevel.WARN,
+                signals = listOf(
+                    TeeSignal(
+                        "ImportKey narrative",
+                        "Matched",
+                        TeeSignalLevel.FAIL,
+                    ),
+                ),
+                sections = listOf(
+                    TeeEvidenceSection(
+                        title = "Checks",
+                        items = listOf(
+                            TeeEvidenceItem(
+                                "ImportKey narrative",
+                                "ImportKey retained attestation narrative detected.",
+                                TeeSignalLevel.FAIL,
+                            ),
+                        ),
+                    ),
+                ),
+                certificates = emptyList(),
+            ),
+            isExpanded = false,
+        )
+
+        assertEquals(DetectorStatus.danger(), model.status)
+    }
+
+    @Test
     fun `rkp badge is hidden when local trust chain needs review`() {
         val model = mapper.map(
             report = TeeReport(

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapperTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapperTest.kt
@@ -377,7 +377,7 @@ class TeeCardModelMapperTest {
                         items = listOf(
                             TeeEvidenceItem(
                                 "ImportKey narrative",
-                                "ImportKey retained attestation narrative detected.",
+                                "Matched • kind=STALE_GENERATED_AFTER_IMPORT, origin=GENERATED, retained=3",
                                 TeeSignalLevel.FAIL,
                             ),
                         ),

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapperTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapperTest.kt
@@ -521,6 +521,49 @@ class TeeCardModelMapperTest {
     }
 
     @Test
+    fun `matched grant self-domain key visibility divergence escalates aligned tee card to danger`() {
+        val model = mapper.map(
+            report = TeeReport(
+                stage = TeeScanStage.READY,
+                verdict = TeeVerdict.CONSISTENT,
+                tier = TeeTier.TEE,
+                headline = "Attestation aligned; local probes need review",
+                summary = "Grant self-domain key visibility divergence detected. Attestation and trust-path checks still aligned.",
+                collapsedSummary = "Aligned • local review",
+                trustRoot = TeeTrustRoot.GOOGLE,
+                trustSummary = "Local trust path",
+                tamperScore = 10,
+                evidenceCount = 1,
+                supplementaryIndicatorCount = 1,
+                supplementaryReviewLevel = TeeSignalLevel.WARN,
+                signals = listOf(
+                    TeeSignal(
+                        "Grant self-domain",
+                        "Unavailable",
+                        TeeSignalLevel.FAIL,
+                    ),
+                ),
+                sections = listOf(
+                    TeeEvidenceSection(
+                        title = "Checks",
+                        items = listOf(
+                            TeeEvidenceItem(
+                                "Grant self-domain",
+                                "Unavailable kind=SELF_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN owner=4 • self grantKeyAccess failed: UnrecoverableKeyException: No key found by the given alias",
+                                TeeSignalLevel.FAIL,
+                            ),
+                        ),
+                    ),
+                ),
+                certificates = emptyList(),
+            ),
+            isExpanded = false,
+        )
+
+        assertEquals(DetectorStatus.danger(), model.status)
+    }
+
+    @Test
     fun `rkp badge is hidden when local trust chain needs review`() {
         val model = mapper.map(
             report = TeeReport(


### PR DESCRIPTION
## Summary

This PR enhances and adds TEE/Keystore-related detections in the TEE deep-check pipeline.

Main changes:

- Add ImportKey retained attestation narrative detection.
- Add Grant isolated-domain and Grant self-domain certificate-chain consistency checks.
- Tighten TEE-Simulator generate-mode Parcel fingerprint matching.
- Improve TimingSideChannel sampling stability and sample diagnostics.
- Propagate reviewed TEE supplementary FAIL evidence to the TEE card and dashboard danger state.

## Details

### ImportKey retained narrative

Adds a two-stage ImportKey probe that first verifies ordinary app importKey observability with a fresh marker alias, then checks whether overwriting an attested alias retains stale attestation narrative material.

Unsupported importKey/Binder paths remain unavailable/INFO and do not escalate.

### Grant-domain checks

Adds two grant-path checks:

- `Grant isolated-domain`: uses an isolated grantee service and classifies owner-visible alias vs native grant-path divergence.
- `Grant self-domain`: grants to the current UID and compares owner chain vs Domain.GRANT chain without relying on isolated process Keystore2 service access.

Reviewed danger kinds are surfaced through reducer-built Checks rows and explicitly mapped by `TeeCardModelMapper` so the dashboard receives the correct danger status.

### Generate-mode Parcel fingerprint

Tightens the generate-mode fingerprint so matching requires the reviewed KeyMetadata structure and modification timestamp combination, instead of relying on a broad or partial raw pattern.

Partial or malformed data stays diagnostic and does not match.

### TimingSideChannel stability

Improves timing sampling behavior:

- throttles every 20 pairs with a 25ms sleep
- skips ratio classification when filtered valid samples are below 300
- keeps measurement diagnostics available when ratio is skipped
- separately reports failed sample pairs and outlier-filtered pairs

Patch-mode skip signature detection is unchanged and still only applies when the timing measurement is unavailable.

## UI / Reporting

- `TeeReportReducer` remains the source of TEE security conclusions.
- `TeeCardModelMapper` explicitly propagates reviewed TEE supplementary FAIL kinds to the TEE card.
- Dashboard danger state follows the TEE card status, not raw report sections.
- Hidden raw/diagnostic payloads remain limited to existing hidden-copy fields.

## Tests

Verified locally:

```powershell
./gradlew.bat :app:compileDebugKotlin
./gradlew.bat :app:testDebugUnitTest --tests "com.eltavine.duckdetector.features.tee.data.verification.keystore.*ImportKey*"
./gradlew.bat :app:testDebugUnitTest --tests "com.eltavine.duckdetector.features.tee.data.verification.keystore.*Grant*"
./gradlew.bat :app:testDebugUnitTest --tests "com.eltavine.duckdetector.features.tee.data.verification.keystore.GenerateKeyReplyParcelParserTest"
./gradlew.bat :app:testDebugUnitTest --tests "com.eltavine.duckdetector.features.tee.data.verification.keystore.*TimingSideChannel*"
./gradlew.bat :app:testDebugUnitTest --tests "com.eltavine.duckdetector.features.tee.data.report.TeeReportReducerTest"
./gradlew.bat :app:testDebugUnitTest --tests "com.eltavine.duckdetector.features.tee.presentation.TeeCardModelMapperTest"
./gradlew.bat :app:testDebugUnitTest --tests "com.eltavine.duckdetector.features.dashboard.ui.model.DashboardUiStateTest"
git diff --check
```

Notes:

- `git diff --check` only reported Windows LF-to-CRLF warnings during local editing; no whitespace errors.
- Runtime device validation is still required for OEM/Android-version-specific Keystore2 behavior.