### PR TITLE
Add integrity probe for ART entrypoint

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -30,3 +30,6 @@
 
 # Native preload launches MainActivity by explicit component name before Compose starts.
 -keepnames class com.eltavine.duckdetector.MainActivity
+
+# ART entrypoint integrity uses reflection against these local sentinel methods.
+-keep class com.eltavine.duckdetector.features.lsposed.data.art.ArtMethodSentinel { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -81,6 +81,10 @@ limitations under the License.
             android:isolatedProcess="true"
             android:useAppZygote="true" />
         <service
+            android:name=".features.lsposed.data.art.ArtMethodProbeService"
+            android:exported="false"
+            android:isolatedProcess="true" />
+        <service
             android:name=".features.tee.data.verification.keystore.TeeGrantDomainGranteeService"
             android:exported="false"
             android:isolatedProcess="true"

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -109,6 +109,7 @@ set(NATIVE_ROOT_SOURCES
 
 set(LSPOSED_SOURCES
     lsposed/common/codec.cpp
+    lsposed/art_method_probe.cpp
     lsposed/probes/maps_probe.cpp
     lsposed/probes/heap_probe.cpp
     lsposed/snapshot_builder.cpp

--- a/app/src/main/cpp/lsposed/art_method_probe.cpp
+++ b/app/src/main/cpp/lsposed/art_method_probe.cpp
@@ -1,0 +1,343 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <jni.h>
+
+#include <fcntl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <cstdint>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+    struct MapEntry {
+        uintptr_t start = 0;
+        uintptr_t end = 0;
+        std::string perms;
+        std::string path;
+
+        bool contains(uintptr_t value) const {
+            return value >= start && value < end;
+        }
+
+        bool executable() const {
+            return perms.size() > 2 && perms[2] == 'x';
+        }
+    };
+
+    std::string trim_copy(std::string value) {
+        while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front())) != 0) {
+            value.erase(value.begin());
+        }
+        while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back())) != 0) {
+            value.pop_back();
+        }
+        return value;
+    }
+
+    std::string lowercase_copy(std::string value) {
+        std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+            return static_cast<char>(std::tolower(ch));
+        });
+        return value;
+    }
+
+    bool contains_ignore_case(const std::string &haystack, const std::string &needle) {
+        return lowercase_copy(haystack).find(lowercase_copy(needle)) != std::string::npos;
+    }
+
+    std::string escape_value(const std::string &value) {
+        std::string escaped;
+        escaped.reserve(value.size());
+        for (const char ch: value) {
+            switch (ch) {
+                case '\\':
+                    escaped += "\\\\";
+                    break;
+                case '\n':
+                    escaped += "\\n";
+                    break;
+                case '\r':
+                    escaped += "\\r";
+                    break;
+                case '\t':
+                    escaped += "\\t";
+                    break;
+                default:
+                    escaped += ch;
+                    break;
+            }
+        }
+        return escaped;
+    }
+
+    std::string read_text_file(const char *path, size_t max_size) {
+        const int fd = static_cast<int>(syscall(__NR_openat, AT_FDCWD, path, O_RDONLY | O_CLOEXEC));
+        if (fd < 0) {
+            return "";
+        }
+
+        std::string content;
+        content.reserve(8192);
+        char buffer[4096];
+        ssize_t bytes_read = 0;
+        while ((bytes_read = syscall(__NR_read, fd, buffer, sizeof(buffer))) > 0) {
+            content.append(buffer, static_cast<size_t>(bytes_read));
+            if (content.size() >= max_size) {
+                break;
+            }
+        }
+        syscall(__NR_close, fd);
+        return content;
+    }
+
+    bool parse_hex_range(const std::string &range, uintptr_t &start, uintptr_t &end) {
+        const size_t dash = range.find('-');
+        if (dash == std::string::npos) {
+            return false;
+        }
+        start = static_cast<uintptr_t>(std::strtoull(range.substr(0, dash).c_str(), nullptr, 16));
+        end = static_cast<uintptr_t>(std::strtoull(range.substr(dash + 1).c_str(), nullptr, 16));
+        return start != 0 && end > start;
+    }
+
+    std::vector<MapEntry> read_maps() {
+        std::vector<MapEntry> entries;
+        const std::string raw = read_text_file("/proc/self/maps", 512 * 1024);
+        std::istringstream stream(raw);
+        std::string line;
+        while (std::getline(stream, line)) {
+            std::istringstream line_stream(line);
+            std::string range;
+            std::string perms;
+            std::string offset;
+            std::string dev;
+            std::string inode;
+            if (!(line_stream >> range >> perms >> offset >> dev >> inode)) {
+                continue;
+            }
+
+            uintptr_t start = 0;
+            uintptr_t end = 0;
+            if (!parse_hex_range(range, start, end)) {
+                continue;
+            }
+
+            std::string path;
+            std::getline(line_stream, path);
+            entries.push_back(MapEntry{
+                    .start = start,
+                    .end = end,
+                    .perms = perms,
+                    .path = trim_copy(path),
+            });
+        }
+        return entries;
+    }
+
+    const MapEntry *find_map(const std::vector<MapEntry> &maps, uintptr_t value) {
+        for (const MapEntry &entry: maps) {
+            if (entry.contains(value)) {
+                return &entry;
+            }
+        }
+        return nullptr;
+    }
+
+    std::string hex_value(uintptr_t value) {
+        std::ostringstream out;
+        out << "0x" << std::hex << std::nouppercase << value;
+        return out.str();
+    }
+
+    std::string classify_region(const MapEntry &entry) {
+        const std::string lower = lowercase_copy(entry.path);
+        if (lower.empty() || lower.rfind("[anon:", 0) == 0 || lower.rfind("[anon_shmem:", 0) == 0) {
+            if (lower.find("jit") != std::string::npos ||
+                lower.find("dalvik") != std::string::npos) {
+                return "JIT_CACHE";
+            }
+            return "ANON_EXEC";
+        }
+        if (lower.find("(deleted)") != std::string::npos) {
+            return "DELETED_EXEC";
+        }
+        if (lower.find("memfd:") != std::string::npos) {
+            if (lower.find("jit") != std::string::npos ||
+                lower.find("dalvik") != std::string::npos) {
+                return "JIT_CACHE";
+            }
+            return "MEMFD_EXEC";
+        }
+        if (lower.find("ashmem") != std::string::npos) {
+            if (lower.find("jit") != std::string::npos ||
+                lower.find("dalvik") != std::string::npos) {
+                return "JIT_CACHE";
+            }
+            return "ASHMEM_EXEC";
+        }
+        if (lower.find("lsposed") != std::string::npos ||
+            lower.find("xposed") != std::string::npos ||
+            lower.find("lsplant") != std::string::npos ||
+            lower.find("edxposed") != std::string::npos ||
+            lower.find("riru") != std::string::npos ||
+            lower.find("frida") != std::string::npos ||
+            lower.find("substrate") != std::string::npos ||
+            lower.find("zygisk") != std::string::npos ||
+            lower.find("magisk") != std::string::npos ||
+            lower.find("/data/adb/") != std::string::npos) {
+            return "SUSPICIOUS_EXEC";
+        }
+        if (lower.find("/apex/com.android.art/") != std::string::npos ||
+            lower.find("/apex/com.android.runtime/") != std::string::npos ||
+            lower.find("/libart.so") != std::string::npos) {
+            return "ART_RUNTIME";
+        }
+        if (lower.find("boot.oat") != std::string::npos ||
+            lower.find("boot.art") != std::string::npos ||
+            lower.find("/system/framework/") != std::string::npos) {
+            return "BOOT_IMAGE";
+        }
+        if (lower.find("/oat/") != std::string::npos ||
+            lower.find(".odex") != std::string::npos ||
+            lower.find(".oat") != std::string::npos) {
+            return "APP_OAT";
+        }
+        if (lower.find("jit-cache") != std::string::npos ||
+            lower.find("dalvik-jit") != std::string::npos) {
+            return "JIT_CACHE";
+        }
+        return "OTHER_EXEC";
+    }
+
+    bool suspicious_region(const std::string &kind) {
+        return kind == "SUSPICIOUS_EXEC" ||
+               kind == "DELETED_EXEC" ||
+               kind == "MEMFD_EXEC" ||
+               kind == "ASHMEM_EXEC" ||
+               kind == "ANON_EXEC" ||
+               kind == "OTHER_EXEC";
+    }
+
+    std::string jstring_to_string(JNIEnv *env, jstring value) {
+        if (value == nullptr) {
+            return "";
+        }
+        const char *chars = env->GetStringUTFChars(value, nullptr);
+        if (chars == nullptr) {
+            return "";
+        }
+        std::string result(chars);
+        env->ReleaseStringUTFChars(value, chars);
+        return result;
+    }
+
+    jstring to_jstring(JNIEnv *env, const std::string &value) {
+        return env->NewStringUTF(value.c_str());
+    }
+
+}  // namespace
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_eltavine_duckdetector_features_lsposed_data_art_ArtMethodNativeBridge_nativeCollectSnapshot(
+        JNIEnv *env,
+        jobject,
+        jobjectArray methods,
+        jobjectArray labels
+) {
+    const std::vector<MapEntry> maps = read_maps();
+    std::ostringstream output;
+    output << "AVAILABLE=" << (!maps.empty() ? '1' : '0') << '\n';
+    if (methods == nullptr || labels == nullptr || maps.empty()) {
+        return to_jstring(env, output.str());
+    }
+
+    const jsize method_count = env->GetArrayLength(methods);
+    const jsize label_count = env->GetArrayLength(labels);
+    const jsize count = std::min(method_count, label_count);
+
+    for (jsize index = 0; index < count; ++index) {
+        jobject method = env->GetObjectArrayElement(methods, index);
+        auto label_string = static_cast<jstring>(env->GetObjectArrayElement(labels, index));
+        const std::string label = jstring_to_string(env, label_string);
+        env->DeleteLocalRef(label_string);
+
+        if (method == nullptr) {
+            output << "METHOD=" << escape_value(label) << "\t0x0\t0\n";
+            continue;
+        }
+
+        jmethodID method_id = env->FromReflectedMethod(method);
+        env->DeleteLocalRef(method);
+        const auto art_method = reinterpret_cast<uintptr_t>(method_id);
+        const MapEntry *art_map = find_map(maps, art_method);
+        const uintptr_t max_end = art_map != nullptr ? art_map->end : art_method;
+        const size_t readable_bytes = art_method < max_end
+                                      ? std::min<size_t>(160U, static_cast<size_t>(max_end - art_method))
+                                      : 0U;
+
+        std::vector<std::string> candidate_lines;
+        if (readable_bytes >= sizeof(uintptr_t)) {
+            for (size_t offset = 0; offset + sizeof(uintptr_t) <= readable_bytes;
+                 offset += sizeof(uintptr_t)) {
+                const auto *slot = reinterpret_cast<const uintptr_t *>(art_method + offset);
+                const uintptr_t target = *slot;
+                const MapEntry *target_map = find_map(maps, target);
+                if (target_map == nullptr || !target_map->executable()) {
+                    continue;
+                }
+                const std::string kind = classify_region(*target_map);
+                const bool suspicious = suspicious_region(kind);
+                std::ostringstream detail;
+                detail << "ArtMethod+" << offset << " -> "
+                       << kind << " " << target_map->perms << " "
+                       << hex_value(target - target_map->start);
+                std::ostringstream line;
+                line << "CANDIDATE="
+                     << escape_value(label) << '\t'
+                     << offset << '\t'
+                     << hex_value(target) << '\t'
+                     << kind << '\t'
+                     << hex_value(target_map->start) << '\t'
+                     << hex_value(target - target_map->start) << '\t'
+                     << target_map->perms << '\t'
+                     << (suspicious ? '1' : '0') << '\t'
+                     << escape_value(target_map->path) << '\t'
+                     << escape_value(detail.str())
+                     << '\n';
+                candidate_lines.push_back(line.str());
+            }
+        }
+
+        output << "METHOD="
+               << escape_value(label) << '\t'
+               << hex_value(art_method) << '\t'
+               << candidate_lines.size() << '\n';
+        for (const std::string &line: candidate_lines) {
+            output << line;
+        }
+    }
+
+    return to_jstring(env, output.str());
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodIntegrityProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodIntegrityProbe.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.lsposed.data.art
+
+import android.content.Context
+import com.eltavine.duckdetector.features.lsposed.domain.LSPosedSignalSeverity
+
+internal class ArtMethodIntegrityProbe(
+    context: Context,
+    private val nativeBridge: ArtMethodNativeBridge = ArtMethodNativeBridge(),
+    private val probeManager: ArtMethodProbeManager = ArtMethodProbeManager(context),
+) {
+
+    suspend fun run(): ArtMethodIntegrityResult {
+        val behaviorClean = verifySentinelBehavior()
+        val mainSnapshot = nativeBridge.collectSnapshot()
+        val isolatedSnapshot = probeManager.collectIsolatedSnapshot()
+        val available = mainSnapshot.available && isolatedSnapshot.available
+
+        val signals = buildList {
+            if (!behaviorClean) {
+                add(
+                    artSignal(
+                        id = "sentinel_behavior",
+                        label = "ART sentinel behavior",
+                        value = "Changed",
+                        severity = LSPosedSignalSeverity.DANGER,
+                        detail = "One or more local sentinel methods returned an unexpected value before entrypoint comparison.",
+                    ),
+                )
+            }
+            addAll(buildSuspiciousCandidateSignals(mainSnapshot, isolatedSnapshot))
+            if (available) {
+                addAll(buildCrossProcessDriftSignals(mainSnapshot, isolatedSnapshot))
+            }
+        }
+
+        return ArtMethodIntegrityResult(
+            available = available,
+            mainSnapshot = mainSnapshot,
+            isolatedSnapshot = isolatedSnapshot,
+            sentinelBehaviorClean = behaviorClean,
+            signals = signals,
+            detail = buildDetail(mainSnapshot, isolatedSnapshot, behaviorClean),
+        )
+    }
+
+    private fun verifySentinelBehavior(): Boolean {
+        return runCatching {
+            ArtMethodSentinel.staticToken(ArtMethodSentinel.STATIC_INPUT) == ArtMethodSentinel.STATIC_EXPECTED &&
+                    ArtMethodSentinel.virtualToken(ArtMethodSentinel.VIRTUAL_INPUT) == ArtMethodSentinel.VIRTUAL_EXPECTED &&
+                    ArtMethodSentinel.stringToken(ArtMethodSentinel.STRING_INPUT) == ArtMethodSentinel.STRING_EXPECTED
+        }.getOrDefault(false)
+    }
+
+    private fun buildSuspiciousCandidateSignals(
+        mainSnapshot: ArtMethodSnapshot,
+        isolatedSnapshot: ArtMethodSnapshot,
+    ): List<com.eltavine.duckdetector.features.lsposed.domain.LSPosedSignal> {
+        val isolatedSuspicious = isolatedSnapshot.methods
+            .flatMap { it.candidates }
+            .map { it.label to it.normalizedSignature }
+            .toSet()
+
+        return mainSnapshot.methods.flatMap { method ->
+            method.candidates
+                .filter { it.suspicious }
+                .filterNot { candidate ->
+                    candidate.label to candidate.normalizedSignature in isolatedSuspicious
+                }
+                .map { candidate ->
+                    artSignal(
+                        id = "candidate_${candidate.label}_${candidate.offset}",
+                        label = "ART entrypoint",
+                        value = candidate.regionKind,
+                        severity = LSPosedSignalSeverity.DANGER,
+                        detail = buildString {
+                            append(candidate.label)
+                            append(" ArtMethod+")
+                            append(candidate.offset)
+                            append(" points to a suspicious executable region in the main process.")
+                            appendLine()
+                            append(candidate.detail)
+                            appendLine()
+                            append(candidate.path.ifBlank { "<anonymous executable mapping>" })
+                        },
+                    )
+                }
+        }
+    }
+
+    private fun buildCrossProcessDriftSignals(
+        mainSnapshot: ArtMethodSnapshot,
+        isolatedSnapshot: ArtMethodSnapshot,
+    ): List<com.eltavine.duckdetector.features.lsposed.domain.LSPosedSignal> {
+        val isolatedByLabel = isolatedSnapshot.methods.associateBy { it.label }
+        return mainSnapshot.methods.mapNotNull { mainMethod ->
+            val isolatedMethod = isolatedByLabel[mainMethod.label] ?: return@mapNotNull null
+            val mainPrimary = mainMethod.primaryCandidate ?: return@mapNotNull null
+            val isolatedPrimary = isolatedMethod.primaryCandidate ?: return@mapNotNull null
+            if (mainPrimary.sameBenignFamily(isolatedPrimary)) {
+                return@mapNotNull null
+            }
+            if (mainPrimary.isJitLike() || isolatedPrimary.isJitLike()) {
+                return@mapNotNull null
+            }
+
+            artSignal(
+                id = "drift_${mainMethod.label}",
+                label = "ART entrypoint drift",
+                value = "${mainPrimary.regionKind} vs ${isolatedPrimary.regionKind}",
+                severity = LSPosedSignalSeverity.WARNING,
+                detail = buildString {
+                    append("Primary executable candidate differs between the app process and the isolated process.")
+                    appendLine()
+                    append("main: ")
+                    append(mainPrimary.detail)
+                    appendLine()
+                    append(mainPrimary.path.ifBlank { "<anonymous>" })
+                    appendLine()
+                    append("isolated: ")
+                    append(isolatedPrimary.detail)
+                    appendLine()
+                    append(isolatedPrimary.path.ifBlank { "<anonymous>" })
+                },
+            )
+        }
+    }
+
+    private fun ArtMethodCandidate.sameBenignFamily(other: ArtMethodCandidate): Boolean {
+        if (regionKind == other.regionKind && normalizedSignature == other.normalizedSignature) {
+            return true
+        }
+        val benign = setOf("ART_RUNTIME", "BOOT_IMAGE", "APP_OAT")
+        return regionKind in benign && other.regionKind in benign
+    }
+
+    private fun ArtMethodCandidate.isJitLike(): Boolean {
+        return regionKind == "JIT_CACHE" || path.contains("jit", ignoreCase = true)
+    }
+
+    private fun buildDetail(
+        mainSnapshot: ArtMethodSnapshot,
+        isolatedSnapshot: ArtMethodSnapshot,
+        behaviorClean: Boolean,
+    ): String {
+        return buildString {
+            append("Sentinel behavior: ")
+            append(if (behaviorClean) "clean" else "changed")
+            appendLine()
+            append("Main process: ")
+            append(mainSnapshot.methodCount)
+            append(" method(s), ")
+            append(mainSnapshot.candidateCount)
+            append(" executable candidate(s), ")
+            append(mainSnapshot.suspiciousCandidateCount)
+            append(" suspicious.")
+            appendLine()
+            append("Isolated process: ")
+            append(isolatedSnapshot.methodCount)
+            append(" method(s), ")
+            append(isolatedSnapshot.candidateCount)
+            append(" executable candidate(s), ")
+            append(isolatedSnapshot.suspiciousCandidateCount)
+            append(" suspicious.")
+        }
+    }
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodIntegrityResult.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodIntegrityResult.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.lsposed.data.art
+
+import com.eltavine.duckdetector.features.lsposed.domain.LSPosedMethodOutcome
+import com.eltavine.duckdetector.features.lsposed.domain.LSPosedSignal
+import com.eltavine.duckdetector.features.lsposed.domain.LSPosedSignalGroup
+import com.eltavine.duckdetector.features.lsposed.domain.LSPosedSignalSeverity
+
+data class ArtMethodIntegrityResult(
+    val available: Boolean = false,
+    val mainSnapshot: ArtMethodSnapshot = ArtMethodSnapshot(),
+    val isolatedSnapshot: ArtMethodSnapshot = ArtMethodSnapshot(),
+    val sentinelBehaviorClean: Boolean = true,
+    val signals: List<LSPosedSignal> = emptyList(),
+    val detail: String = "",
+) {
+    val hitCount: Int
+        get() = signals.size
+
+    val outcome: LSPosedMethodOutcome
+        get() = when {
+            signals.any { it.severity == LSPosedSignalSeverity.DANGER } -> LSPosedMethodOutcome.DETECTED
+            signals.any { it.severity == LSPosedSignalSeverity.WARNING } -> LSPosedMethodOutcome.WARNING
+            available -> LSPosedMethodOutcome.CLEAN
+            else -> LSPosedMethodOutcome.SUPPORT
+        }
+
+    val summary: String
+        get() = when {
+            signals.any { it.severity == LSPosedSignalSeverity.DANGER } -> "${signals.count { it.severity == LSPosedSignalSeverity.DANGER }} strong"
+            signals.isNotEmpty() -> "${signals.size} review"
+            available -> "Clean"
+            else -> "Unavailable"
+        }
+}
+
+internal fun artSignal(
+    id: String,
+    label: String,
+    value: String,
+    severity: LSPosedSignalSeverity,
+    detail: String,
+): LSPosedSignal {
+    return LSPosedSignal(
+        id = "art_$id",
+        label = label,
+        value = value,
+        group = LSPosedSignalGroup.RUNTIME,
+        severity = severity,
+        detail = detail,
+        detailMonospace = detail.contains("0x") ||
+                detail.contains("/apex/") ||
+                detail.contains("/data/") ||
+                detail.contains("memfd:") ||
+                detail.contains("(deleted)"),
+    )
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodNativeBridge.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodNativeBridge.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.lsposed.data.art
+
+import java.lang.reflect.Method
+
+class ArtMethodNativeBridge {
+
+    fun collectSnapshot(): ArtMethodSnapshot {
+        return parse(collectRawSnapshot())
+    }
+
+    internal fun collectRawSnapshot(): String {
+        val targets = ArtMethodTargetCatalog.targets()
+        return runCatching {
+            nativeCollectSnapshot(
+                targets.map { it.method }.toTypedArray(),
+                targets.map { it.label }.toTypedArray(),
+            )
+        }.getOrDefault("")
+    }
+
+    internal fun parse(raw: String): ArtMethodSnapshot {
+        if (raw.isBlank()) {
+            return ArtMethodSnapshot()
+        }
+
+        var available = false
+        val methodBuilders = linkedMapOf<String, MutableMethodEntry>()
+        raw.lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .forEach { line ->
+                when {
+                    line.startsWith("METHOD=") -> {
+                        val parts = line.removePrefix("METHOD=").split('\t', limit = 3)
+                        if (parts.size == 3) {
+                            val label = parts[0].decodeValue()
+                            methodBuilders[label] = MutableMethodEntry(
+                                label = label,
+                                artMethodAddress = parts[1],
+                                declaredCandidateCount = parts[2].toIntOrNull() ?: 0,
+                            )
+                        }
+                    }
+
+                    line.startsWith("CANDIDATE=") -> {
+                        val parts = line.removePrefix("CANDIDATE=").split('\t', limit = 10)
+                        if (parts.size == 10) {
+                            val label = parts[0].decodeValue()
+                            methodBuilders.getOrPut(label) {
+                                MutableMethodEntry(
+                                    label = label,
+                                    artMethodAddress = "",
+                                    declaredCandidateCount = 0,
+                                )
+                            }.candidates += ArtMethodCandidate(
+                                label = label,
+                                offset = parts[1].toIntOrNull() ?: -1,
+                                address = parts[2],
+                                regionKind = parts[3],
+                                mapStart = parts[4],
+                                mapOffset = parts[5],
+                                permissions = parts[6],
+                                suspicious = parts[7].asBool(),
+                                path = parts[8].decodeValue(),
+                                detail = parts[9].decodeValue(),
+                            )
+                        }
+                    }
+
+                    line.contains('=') -> {
+                        val key = line.substringBefore('=')
+                        val value = line.substringAfter('=')
+                        if (key == "AVAILABLE") {
+                            available = value.asBool()
+                        }
+                    }
+                }
+            }
+
+        val methods = methodBuilders.values.map { builder ->
+            ArtMethodEntry(
+                label = builder.label,
+                artMethodAddress = builder.artMethodAddress,
+                declaredCandidateCount = builder.declaredCandidateCount,
+                candidates = builder.candidates.sortedBy { it.offset },
+            )
+        }
+
+        return ArtMethodSnapshot(
+            available = available,
+            methodCount = methods.size,
+            candidateCount = methods.sumOf { it.candidates.size },
+            suspiciousCandidateCount = methods.sumOf { method ->
+                method.candidates.count { it.suspicious }
+            },
+            methods = methods,
+        )
+    }
+
+    private data class MutableMethodEntry(
+        val label: String,
+        val artMethodAddress: String,
+        val declaredCandidateCount: Int,
+        val candidates: MutableList<ArtMethodCandidate> = mutableListOf(),
+    )
+
+    private fun String.asBool(): Boolean {
+        return this == "1" || equals("true", ignoreCase = true)
+    }
+
+    private fun String.decodeValue(): String {
+        return buildString(length) {
+            var index = 0
+            while (index < this@decodeValue.length) {
+                val current = this@decodeValue[index]
+                if (current == '\\' && index + 1 < this@decodeValue.length) {
+                    when (this@decodeValue[index + 1]) {
+                        'n' -> {
+                            append('\n')
+                            index += 2
+                            continue
+                        }
+
+                        'r' -> {
+                            append('\r')
+                            index += 2
+                            continue
+                        }
+
+                        't' -> {
+                            append('\t')
+                            index += 2
+                            continue
+                        }
+
+                        '\\' -> {
+                            append('\\')
+                            index += 2
+                            continue
+                        }
+                    }
+                }
+                append(current)
+                index += 1
+            }
+        }
+    }
+
+    private external fun nativeCollectSnapshot(
+        methods: Array<Method>,
+        labels: Array<String>,
+    ): String
+
+    companion object {
+        init {
+            runCatching { System.loadLibrary("duckdetector") }
+        }
+    }
+}
+
+internal data class ArtMethodProbeTarget(
+    val label: String,
+    val method: Method,
+)
+
+internal object ArtMethodTargetCatalog {
+    fun targets(): List<ArtMethodProbeTarget> {
+        val clazz = ArtMethodSentinel::class.java
+        val intType = requireNotNull(Int::class.javaPrimitiveType)
+        return listOf(
+            ArtMethodProbeTarget(
+                label = "staticToken",
+                method = clazz.getDeclaredMethod("staticToken", intType),
+            ),
+            ArtMethodProbeTarget(
+                label = "virtualToken",
+                method = clazz.getDeclaredMethod("virtualToken", intType),
+            ),
+            ArtMethodProbeTarget(
+                label = "stringToken",
+                method = clazz.getDeclaredMethod("stringToken", String::class.java),
+            ),
+        )
+    }
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodProbeManager.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodProbeManager.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.lsposed.data.art
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.coroutines.resume
+
+internal class ArtMethodProbeManager(
+    private val context: Context,
+    private val nativeBridge: ArtMethodNativeBridge = ArtMethodNativeBridge(),
+) {
+
+    suspend fun collectIsolatedSnapshot(): ArtMethodSnapshot {
+        return withTimeoutOrNull(DETECTION_TIMEOUT_MS) {
+            bindAndCollect(context.applicationContext)
+        } ?: ArtMethodSnapshot()
+    }
+
+    private suspend fun bindAndCollect(
+        appContext: Context,
+    ): ArtMethodSnapshot = suspendCancellableCoroutine { continuation ->
+        var bound = false
+        lateinit var connection: ServiceConnection
+
+        fun finish(snapshot: ArtMethodSnapshot) {
+            if (!continuation.isActive) {
+                return
+            }
+            if (bound) {
+                runCatching { appContext.unbindService(connection) }
+                bound = false
+            }
+            continuation.resume(snapshot)
+        }
+
+        connection = object : ServiceConnection {
+            override fun onServiceConnected(
+                name: ComponentName?,
+                service: IBinder?,
+            ) {
+                if (service == null) {
+                    finish(ArtMethodSnapshot())
+                    return
+                }
+
+                val snapshot = runCatching {
+                    nativeBridge.parse(ArtMethodProbeProxy(service).collectSnapshot())
+                }.getOrDefault(ArtMethodSnapshot())
+                finish(snapshot)
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) = Unit
+        }
+
+        bound = runCatching {
+            appContext.bindService(
+                Intent(appContext, ArtMethodProbeService::class.java),
+                connection,
+                Context.BIND_AUTO_CREATE,
+            )
+        }.getOrDefault(false)
+
+        if (!bound) {
+            finish(ArtMethodSnapshot())
+            return@suspendCancellableCoroutine
+        }
+
+        continuation.invokeOnCancellation {
+            if (bound) {
+                runCatching { appContext.unbindService(connection) }
+                bound = false
+            }
+        }
+    }
+
+    private companion object {
+        private const val DETECTION_TIMEOUT_MS = 4_000L
+    }
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodProbeProtocol.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodProbeProtocol.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.lsposed.data.art
+
+internal object ArtMethodProbeProtocol {
+    const val DESCRIPTOR = "com.eltavine.duckdetector.ART_METHOD_PROBE"
+    const val TRANSACTION_COLLECT_SNAPSHOT = 1
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodProbeProxy.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodProbeProxy.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.lsposed.data.art
+
+import android.os.IBinder
+import android.os.Parcel
+
+internal class ArtMethodProbeProxy(
+    private val remote: IBinder,
+) {
+
+    fun collectSnapshot(): String {
+        val data = Parcel.obtain()
+        val reply = Parcel.obtain()
+        return try {
+            data.writeInterfaceToken(ArtMethodProbeProtocol.DESCRIPTOR)
+            remote.transact(
+                ArtMethodProbeProtocol.TRANSACTION_COLLECT_SNAPSHOT,
+                data,
+                reply,
+                0,
+            )
+            reply.readException()
+            reply.readString().orEmpty()
+        } finally {
+            data.recycle()
+            reply.recycle()
+        }
+    }
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodProbeService.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodProbeService.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.lsposed.data.art
+
+import android.app.Service
+import android.content.Intent
+import android.os.Binder
+import android.os.IBinder
+import android.os.Parcel
+
+class ArtMethodProbeService : Service() {
+
+    private val nativeBridge = ArtMethodNativeBridge()
+
+    private val binder = object : Binder() {
+        override fun onTransact(
+            code: Int,
+            data: Parcel,
+            reply: Parcel?,
+            flags: Int,
+        ): Boolean {
+            return when (code) {
+                INTERFACE_TRANSACTION -> {
+                    reply?.writeString(ArtMethodProbeProtocol.DESCRIPTOR)
+                    true
+                }
+
+                ArtMethodProbeProtocol.TRANSACTION_COLLECT_SNAPSHOT -> {
+                    data.enforceInterface(ArtMethodProbeProtocol.DESCRIPTOR)
+                    reply?.writeNoException()
+                    reply?.writeString(nativeBridge.collectRawSnapshot())
+                    true
+                }
+
+                else -> super.onTransact(code, data, reply, flags)
+            }
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder = binder
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodSentinel.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodSentinel.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.lsposed.data.art
+
+internal object ArtMethodSentinel {
+    private const val STATIC_MASK = 0x5A17
+    private const val VIRTUAL_OFFSET = 0x3311
+    private const val STRING_SUFFIX = "art"
+
+    @JvmStatic
+    fun staticToken(value: Int): Int {
+        return value xor STATIC_MASK
+    }
+
+    fun virtualToken(value: Int): Int {
+        return value + VIRTUAL_OFFSET
+    }
+
+    @JvmStatic
+    fun stringToken(value: String): String {
+        return "$value:$STRING_SUFFIX"
+    }
+
+    const val STATIC_INPUT = 0x1357
+    const val STATIC_EXPECTED = STATIC_INPUT xor STATIC_MASK
+    const val VIRTUAL_INPUT = 0x2468
+    const val VIRTUAL_EXPECTED = VIRTUAL_INPUT + VIRTUAL_OFFSET
+    const val STRING_INPUT = "duck"
+    const val STRING_EXPECTED = "$STRING_INPUT:$STRING_SUFFIX"
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodSnapshot.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/art/ArtMethodSnapshot.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.lsposed.data.art
+
+data class ArtMethodSnapshot(
+    val available: Boolean = false,
+    val methodCount: Int = 0,
+    val candidateCount: Int = 0,
+    val suspiciousCandidateCount: Int = 0,
+    val methods: List<ArtMethodEntry> = emptyList(),
+) {
+    val primaryCandidates: List<ArtMethodCandidate>
+        get() = methods.mapNotNull { it.primaryCandidate }
+}
+
+data class ArtMethodEntry(
+    val label: String,
+    val artMethodAddress: String,
+    val declaredCandidateCount: Int,
+    val candidates: List<ArtMethodCandidate>,
+) {
+    val primaryCandidate: ArtMethodCandidate?
+        get() = candidates.maxByOrNull { it.offset }
+}
+
+data class ArtMethodCandidate(
+    val label: String,
+    val offset: Int,
+    val address: String,
+    val regionKind: String,
+    val mapStart: String,
+    val mapOffset: String,
+    val permissions: String,
+    val suspicious: Boolean,
+    val path: String,
+    val detail: String,
+) {
+    val normalizedSignature: String
+        get() = listOf(regionKind, pathFingerprint(path), mapOffset).joinToString("|")
+
+    private fun pathFingerprint(value: String): String {
+        val lower = value.lowercase()
+        return when {
+            lower.contains("/apex/com.android.art/") -> "/apex/com.android.art"
+            lower.contains("/apex/com.android.runtime/") -> "/apex/com.android.runtime"
+            lower.contains("boot.oat") -> "boot.oat"
+            lower.contains("boot.art") -> "boot.art"
+            lower.contains("/oat/") -> "/oat/"
+            lower.contains("jit") || lower.contains("dalvik") -> "jit"
+            lower.contains("(deleted)") -> "(deleted)"
+            lower.contains("memfd:") -> "memfd"
+            lower.isBlank() -> "<anonymous>"
+            else -> value
+        }
+    }
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/repository/LSPosedRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/repository/LSPosedRepository.kt
@@ -17,6 +17,8 @@
 package com.eltavine.duckdetector.features.lsposed.data.repository
 
 import android.content.Context
+import com.eltavine.duckdetector.features.lsposed.data.art.ArtMethodIntegrityProbe
+import com.eltavine.duckdetector.features.lsposed.data.art.ArtMethodIntegrityResult
 import com.eltavine.duckdetector.features.lsposed.data.native.LSPosedNativeBridge
 import com.eltavine.duckdetector.features.lsposed.data.native.LSPosedNativeSnapshot
 import com.eltavine.duckdetector.features.lsposed.data.native.LSPosedNativeTrace
@@ -69,6 +71,7 @@ class LSPosedRepository(
     private val appContext = context.applicationContext
     private val dirtyPolicyCarrierManager =
         SelinuxContextValidityCarrierManager(appContext)
+    private val artMethodIntegrityProbe = ArtMethodIntegrityProbe(appContext)
 
     suspend fun scan(): LSPosedReport = withContext(Dispatchers.IO) {
         runCatching { scanInternal() }
@@ -90,6 +93,7 @@ class LSPosedRepository(
         val logcatResult = logcatProbe.run()
         val selinuxSnapshot = dirtyPolicyCarrierManager.collectSnapshot()
         val dirtyPolicyResult = dirtyPolicyProbe.run(selinuxSnapshot)
+        val artMethodResult = artMethodIntegrityProbe.run()
         val nativeSnapshot = nativeBridge.collectSnapshot()
         val nativeSignals = nativeSnapshot.traces.mapIndexed(::nativeSignal)
         val dirtyPolicySignals = dirtyPolicyResult.signals
@@ -106,6 +110,7 @@ class LSPosedRepository(
             addAll(runtimeArtifactResult.signals)
             addAll(logcatResult.signals)
             addAll(dirtyPolicySignals)
+            addAll(artMethodResult.signals)
             addAll(nativeSignals)
         }
 
@@ -133,6 +138,7 @@ class LSPosedRepository(
                 runtimeArtifactResult = runtimeArtifactResult,
                 logcatResult = logcatResult,
                 dirtyPolicyResult = dirtyPolicyResult,
+                artMethodResult = artMethodResult,
                 nativeSnapshot = nativeSnapshot,
                 signals = signals,
             ),
@@ -146,6 +152,8 @@ class LSPosedRepository(
             binderHitCount = binderResult.hitCount,
             runtimeArtifactHitCount = runtimeArtifactResult.hitCount,
             logcatHitCount = logcatResult.hitCount,
+            artMethodIntegrityAvailable = artMethodResult.available,
+            artMethodIntegrityHitCount = artMethodResult.hitCount,
             nativeMapsHitCount = nativeSnapshot.mapsHitCount,
             nativeHeapHitCount = nativeSnapshot.heapHitCount,
             nativeHeapScannedRegions = nativeSnapshot.heapScannedRegions,
@@ -166,6 +174,7 @@ class LSPosedRepository(
         runtimeArtifactResult: LSPosedRuntimeArtifactProbeResult,
         logcatResult: LSPosedLogcatProbeResult,
         dirtyPolicyResult: LSPosedDirtyPolicyProbeResult,
+        artMethodResult: ArtMethodIntegrityResult,
         nativeSnapshot: LSPosedNativeSnapshot,
         signals: List<LSPosedSignal>,
     ): List<LSPosedMethodResult> {
@@ -283,6 +292,14 @@ class LSPosedRepository(
                 summary = dirtyPolicyResult.summary,
                 outcome = dirtyPolicyResult.outcome,
                 detail = dirtyPolicyResult.detail,
+            ),
+            LSPosedMethodResult(
+                label = "ART entrypoints",
+                summary = artMethodResult.summary,
+                outcome = artMethodResult.outcome,
+                detail = artMethodResult.detail.ifBlank {
+                    "Compares local sentinel method ArtMethod executable-entry candidates between the app process and an isolated process."
+                },
             ),
             LSPosedMethodResult(
                 label = "Native maps",

--- a/app/src/main/java/com/eltavine/duckdetector/features/lsposed/domain/LSPosedReport.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/lsposed/domain/LSPosedReport.kt
@@ -88,6 +88,8 @@ data class LSPosedReport(
     val binderHitCount: Int,
     val runtimeArtifactHitCount: Int,
     val logcatHitCount: Int,
+    val artMethodIntegrityAvailable: Boolean,
+    val artMethodIntegrityHitCount: Int,
     val nativeMapsHitCount: Int,
     val nativeHeapHitCount: Int,
     val nativeHeapScannedRegions: Int,
@@ -144,6 +146,8 @@ data class LSPosedReport(
                 binderHitCount = 0,
                 runtimeArtifactHitCount = 0,
                 logcatHitCount = 0,
+                artMethodIntegrityAvailable = true,
+                artMethodIntegrityHitCount = 0,
                 nativeMapsHitCount = 0,
                 nativeHeapHitCount = 0,
                 nativeHeapScannedRegions = 0,
@@ -157,6 +161,7 @@ data class LSPosedReport(
                 nativeHeapAvailable = false,
                 zygotePermissionAvailable = false,
                 dirtyPolicyAvailable = false,
+                artMethodIntegrityAvailable = false,
                 errorMessage = message,
             )
         }

--- a/app/src/main/java/com/eltavine/duckdetector/features/lsposed/presentation/LSPosedCardModelMapper.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/lsposed/presentation/LSPosedCardModelMapper.kt
@@ -54,7 +54,7 @@ class LSPosedCardModelMapper {
 
     private fun buildSubtitle(report: LSPosedReport): String {
         return when (report.stage) {
-            LSPosedStage.LOADING -> "class + classloader + bridge fields + callbacks + runtime + logcat + binder + zygote gids + policy + native"
+            LSPosedStage.LOADING -> "class + classloader + bridge fields + callbacks + runtime + logcat + binder + zygote gids + policy + ART + native"
             LSPosedStage.FAILED -> "local LSPosed/Xposed scan failed"
             LSPosedStage.READY -> {
                 buildList {
@@ -63,6 +63,9 @@ class LSPosedCardModelMapper {
                     add("${report.nativeTraceCount} native")
                     if (report.dirtyPolicyAvailable || report.policySignalCount > 0) {
                         add("${report.policySignalCount} policy")
+                    }
+                    if (report.artMethodIntegrityHitCount > 0) {
+                        add("${report.artMethodIntegrityHitCount} art")
                     }
                 }.joinToString(" · ")
             }
@@ -87,7 +90,7 @@ class LSPosedCardModelMapper {
     private fun buildSummary(report: LSPosedReport): String {
         return when (report.stage) {
             LSPosedStage.LOADING ->
-                "Class loading, ClassLoader chains, XposedBridge fields, callbacks, package metadata, stack traces, Binder bridges, zygote permission GID audits, runtime artifacts, logcat leaks, and LSPosed-specific native traces are collecting local evidence."
+                "Class loading, ClassLoader chains, XposedBridge fields, callbacks, package metadata, stack traces, Binder bridges, zygote permission GID audits, runtime artifacts, logcat leaks, ART entrypoint drift, and LSPosed-specific native traces are collecting local evidence."
 
             LSPosedStage.FAILED ->
                 report.errorMessage
@@ -95,7 +98,7 @@ class LSPosedCardModelMapper {
 
             LSPosedStage.READY -> when {
                 report.hasDangerSignals ->
-                    "Binder bridge replies, loaded Xposed classes, XposedBridge fields, callback handlers, runtime artifacts, logcat leaks, zygote permission GID mismatches, dirty SELinux policy rules, stack trace signatures, or native LSPosed keywords point to active hook-framework presence rather than passive install residue."
+                    "Binder bridge replies, loaded Xposed classes, XposedBridge fields, callback handlers, runtime artifacts, logcat leaks, zygote permission GID mismatches, dirty SELinux policy rules, ART entrypoint anomalies, stack trace signatures, or native LSPosed keywords point to active hook-framework presence rather than passive install residue."
 
                 report.hasWarningSignals ->
                     "Installed managers, deep ClassLoader chains, environment residue, dirty SELinux policy drift, or pattern-only logcat traces were found, but the current process did not expose enough stronger runtime evidence to treat the framework as confirmed active here."
@@ -317,6 +320,8 @@ class LSPosedCardModelMapper {
                     "Logcat availability",
                     "Dirty policy hits",
                     "Dirty policy availability",
+                    "ART entry hits",
+                    "ART entry availability",
                     "Manager packages",
                     "Module apps",
                     "Native maps",
@@ -343,6 +348,8 @@ class LSPosedCardModelMapper {
                     "Logcat availability",
                     "Dirty policy hits",
                     "Dirty policy availability",
+                    "ART entry hits",
+                    "ART entry availability",
                     "Manager packages",
                     "Module apps",
                     "Native maps",
@@ -474,6 +481,27 @@ class LSPosedCardModelMapper {
                     ),
                 ),
                 LSPosedDetailRowModel(
+                    label = "ART entry hits",
+                    value = report.artMethodIntegrityHitCount.toString(),
+                    status = when {
+                        report.signals.any {
+                            it.id.startsWith("art_") &&
+                                it.severity == LSPosedSignalSeverity.DANGER
+                        } -> DetectorStatus.danger()
+
+                        report.artMethodIntegrityHitCount > 0 -> DetectorStatus.warning()
+                        report.artMethodIntegrityAvailable -> DetectorStatus.allClear()
+                        else -> DetectorStatus.info(InfoKind.SUPPORT)
+                    },
+                ),
+                LSPosedDetailRowModel(
+                    label = "ART entry availability",
+                    value = if (report.artMethodIntegrityAvailable) "Checked" else "Unavailable",
+                    status = if (report.artMethodIntegrityAvailable) DetectorStatus.allClear() else DetectorStatus.info(
+                        InfoKind.SUPPORT
+                    ),
+                ),
+                LSPosedDetailRowModel(
                     label = "Manager packages",
                     value = report.managerPackageCount.toString(),
                     status = if (report.managerPackageCount > 0) DetectorStatus.warning() else DetectorStatus.allClear(),
@@ -575,6 +603,7 @@ class LSPosedCardModelMapper {
             "Runtime artifacts",
             "Logcat leaks",
             "Dirty sepolicy",
+            "ART entrypoints",
             "Native maps",
             "Native heap",
             "Native library",
@@ -642,6 +671,7 @@ class LSPosedCardModelMapper {
                 !runtimeArtifactAvailable ||
                 !logcatAvailable ||
                 !dirtyPolicyAvailable ||
+                !artMethodIntegrityAvailable ||
                 packageVisibility != LSPosedPackageVisibility.FULL
     }
 
@@ -649,7 +679,9 @@ class LSPosedCardModelMapper {
         return when (group) {
             LSPosedSignalGroup.NATIVE -> !nativeAvailable || !nativeHeapAvailable
             LSPosedSignalGroup.PACKAGES -> packageVisibility != LSPosedPackageVisibility.FULL
-            LSPosedSignalGroup.RUNTIME -> !runtimeArtifactAvailable || !logcatAvailable
+            LSPosedSignalGroup.RUNTIME -> !runtimeArtifactAvailable ||
+                    !logcatAvailable ||
+                    !artMethodIntegrityAvailable
             LSPosedSignalGroup.POLICY -> !dirtyPolicyAvailable
             LSPosedSignalGroup.BINDER -> false
         }


### PR DESCRIPTION
该PR新增了针对ART方法结构体的检测机制，旨在发现针对Java层方法的底层Hook行为。

Native层实现：通过JNI读取ArtMethod结构体，扫描其入口点（Entrypoint）指针。

内存区域识别：新增内存区域分类逻辑，能够识别并区分合法的ART运行库、系统Boot镜像、JIT缓存以及可疑的匿名执行区、已删除文件映射等。

隔离进程对比：利用Android的Isolated Process特性启动独立服务作为基准，通过主进程与隔离进程之间的ArtMethod状态差异来精准定位非法的动态修改。