### PR TITLE
feat(probes): support new loopback ports for Scene 9.3.0

### DIFF
--- a/app/src/main/java/com/eltavine/duckdetector/features/dangerousapps/data/probes/SceneLoopbackProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/dangerousapps/data/probes/SceneLoopbackProbe.kt
@@ -28,30 +28,42 @@ class SceneLoopbackProbe(
 ) {
 
     fun probe(): SceneLoopbackProbeResult {
-        val httpGet = transport.exchange(
-            port = HTTP_PORT,
-            payload = HTTP_GET_PAYLOAD,
+        for ((httpPort, sidecarPort) in PORT_PAIRS) {
+            val httpGet = transport.exchange(
+                port = httpPort,
+                payload = HTTP_GET_PAYLOAD,
+            )
+            val invalidPayload = transport.exchange(
+                port = httpPort,
+                payload = JSON_PING_PAYLOAD,
+            )
+            val sideChannel =
+                if (matchesHttpStatus(httpGet, 404) && matchesHttpStatus(invalidPayload, 400)) {
+                    transport.exchange(
+                        port = sidecarPort,
+                        payload = JSON_PING_PAYLOAD,
+                    )
+                } else {
+                    ProbeExchange.unavailable()
+                }
+            val result = evaluate(httpGet, invalidPayload, sideChannel,
+                httpPort = httpPort, sidecarPort = sidecarPort)
+            if (result.detected) return result
+        }
+        return SceneLoopbackProbeResult(
+            detected = false,
+            get404Matched = false,
+            invalid400Matched = false,
+            sideChannelClosed = false,
         )
-        val invalidPayload = transport.exchange(
-            port = HTTP_PORT,
-            payload = JSON_PING_PAYLOAD,
-        )
-        val sideChannel =
-            if (matchesHttpStatus(httpGet, 404) && matchesHttpStatus(invalidPayload, 400)) {
-                transport.exchange(
-                    port = SIDECAR_PORT,
-                    payload = JSON_PING_PAYLOAD,
-                )
-            } else {
-                ProbeExchange.unavailable()
-            }
-        return evaluate(httpGet, invalidPayload, sideChannel)
     }
 
     internal fun evaluate(
         httpGet: ProbeExchange,
         invalidPayload: ProbeExchange,
         sideChannel: ProbeExchange,
+        httpPort: Int,
+        sidecarPort: Int,
     ): SceneLoopbackProbeResult {
         val get404Matched = matchesHttpStatus(httpGet, 404)
         val invalid400Matched = matchesHttpStatus(invalidPayload, 400)
@@ -65,13 +77,13 @@ class SceneLoopbackProbe(
         }
 
         val details = mutableListOf(
-            "127.0.0.1:$HTTP_PORT GET->404",
-            "127.0.0.1:$HTTP_PORT invalid payload->400",
+            "127.0.0.1:$httpPort GET->404",
+            "127.0.0.1:$httpPort invalid payload->400",
         )
         val sideChannelClosed =
             sideChannel.connected && sideChannel.firstLine == null && !sideChannel.timedOut
         if (sideChannelClosed) {
-            details += "127.0.0.1:$SIDECAR_PORT invalid payload closed immediately"
+            details += "127.0.0.1:$sidecarPort invalid payload closed immediately"
         }
 
         return SceneLoopbackProbeResult(
@@ -164,8 +176,13 @@ class SceneLoopbackProbe(
 
     private companion object {
         private const val LOOPBACK_HOST = "127.0.0.1"
-        private const val HTTP_PORT = 8765
-        private const val SIDECAR_PORT = 8788
+        // Scene 8.x:           HTTP_PORT=8765,  SIDECAR_PORT=8788
+        // Scene 9.3.0 Alpha13: HTTP_PORT=14731, SIDECAR_PORT=14754
+        // Probe both port pairs for backward compatibility.
+        private val PORT_PAIRS = listOf(
+            8765 to 8788,
+            14731 to 14754,
+        )
         private const val CONNECT_TIMEOUT_MS = 350
         private const val READ_TIMEOUT_MS = 350
         private const val HTTP_STATUS_PATTERN = "^HTTP/\\d(?:\\.\\d)?\\s+%d(?:\\s+.*)?$"

--- a/app/src/main/java/com/eltavine/duckdetector/features/dangerousapps/data/probes/SceneLoopbackProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/dangerousapps/data/probes/SceneLoopbackProbe.kt
@@ -28,6 +28,7 @@ class SceneLoopbackProbe(
 ) {
 
     fun probe(): SceneLoopbackProbeResult {
+        var lastResult: SceneLoopbackProbeResult? = null
         for ((httpPort, sidecarPort) in PORT_PAIRS) {
             val httpGet = transport.exchange(
                 port = httpPort,
@@ -49,8 +50,9 @@ class SceneLoopbackProbe(
             val result = evaluate(httpGet, invalidPayload, sideChannel,
                 httpPort = httpPort, sidecarPort = sidecarPort)
             if (result.detected) return result
+            lastResult = result
         }
-        return SceneLoopbackProbeResult(
+        return lastResult ?: SceneLoopbackProbeResult(
             detected = false,
             get404Matched = false,
             invalid400Matched = false,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.2.1"
 coreKtx = "1.18.0"
-json = "20251224"
+json = "20260522"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"


### PR DESCRIPTION
Update SceneLoopbackProbe to iterate through a list of known port pairs instead of relying on hardcoded constants. Scene 9.3.0 Alpha13 changed its default HTTP and sidecar ports (to 14731 and 14754, respectively).

This change ensures backward compatibility by probing both the legacy Scene 8.x ports (8765/8788) and the newly introduced ports, returning immediately if a match is detected. The `evaluate` function is also updated to accept dynamic port parameters for accurate detail logging.

没什么好说的喵，直接看代码吧喵