### PR TITLE
fix(lsposed): suppress SELinux AVC self-noise in logcat scanner

### DIFF
--- a/app/src/main/java/com/eltavine/duckdetector/features/dashboard/ui/DashboardScreen.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/dashboard/ui/DashboardScreen.kt
@@ -93,9 +93,9 @@ import com.eltavine.duckdetector.features.virtualization.ui.card.VirtualizationD
 import com.eltavine.duckdetector.features.zygisk.ui.card.ZygiskDetectorCard
 import com.eltavine.duckdetector.ui.theme.ShapeTokens
 
-private const val DUCK_DETECTOR_QQ_GROUP = "1079283524"
+private const val DUCK_DETECTOR_QQ_GROUP = "789344870"
 private const val DUCK_DETECTOR_QQ_GROUP_URL =
-    "https://qun.qq.com/universal-share/share?ac=1&authKey=VWdSICnmxMiNF1t409UcE%2FjdQVeorZKvrKP85I2pepXf4rfv9IFfdAw8kAuMdk5v&busi_data=eyJncm91cENvZGUiOiIxMDc5MjgzNTI0IiwidG9rZW4iOiJ2Q3VSSll2QndhK3JoZlhHZFU4VmxUSFREdjBVVHhFNHlTbXVPVDkzY0twTHlJTldSZVFlUmxncjlnM0Rac2dwIiwidWluIjoiMzMzNDcxMzIzMyJ9&data=ms9NmidW7tH7vZrZkYOux0z9cAUWBOp4THmPYdBeCpt6sBVyd1oP9E3lL-0yToQMBBTK3X7aZQ9SLnzxEmxWlQ&svctype=4&tempid=h5_group_info"
+    "https://qun.qq.com/universal-share/share?ac=1&authKey=VWdSICnmxMiNF1t409UcE%2FjdQVeorZKvrKP85I2pepXf4rfv9IFfdAw8kAuMdk5v&busi_data=eyJncm91cENvZGUiOiI3ODkzNDQ4NzAiLCJ0b2tlbiI6InZDdVJKWXZCd2ErcmhmWEdkVThWbFRIVER2MFVUeEU0eVNtdk9UOTNjS3BMeUlOV1JlUWVSbGdyOWczRFpzZ3AiLCJ1aW4iOiIzMzM0NzEzMjMzIn0=&data=ms9NmidW7tH7vZrZkYOux0z9cAUWBOp4THmPYdBeCpt6sBVyd1oP9E3lL-0yToQMBBTK3X7aZQ9SLnzxEmxWlQ&svctype=4&tempid=h5_group_info"
 
 @Composable
 fun DashboardScreen(

--- a/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/probes/LSPosedLogcatProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/lsposed/data/probes/LSPosedLogcatProbe.kt
@@ -171,6 +171,10 @@ class LSPosedLogcatProbe(
                 }
             }
 
+            if (line.isSelinuxAvcLine()) {
+                return@forEach
+            }
+
             val lowerLine = line.lowercase()
             if (
                 lowerLine.contains("lsposed") ||
@@ -271,13 +275,20 @@ class LSPosedLogcatProbe(
 
     private fun String.isDirtyPolicyLsposedFileAvc(): Boolean {
         val lower = lowercase()
-        return "type=1400" in lower &&
-                "avc:" in lower &&
+        return "avc:" in lower &&
                 "denied" in lower &&
                 "scontext=u:r:untrusted_app" in lower &&
                 "tcontext=u:object_r:lsposed_file:s0" in lower &&
                 "tclass=file" in lower &&
                 DIRTY_POLICY_LSPOSED_FILE_READ_REGEX.containsMatchIn(this)
+    }
+
+    private fun String.isSelinuxAvcLine(): Boolean {
+        val lower = lowercase()
+        return "avc:" in lower &&
+                "denied" in lower &&
+                "scontext=" in lower &&
+                "tcontext=" in lower
     }
 
     private fun String.matchesPattern(

--- a/app/src/test/java/com/eltavine/duckdetector/features/lsposed/data/probes/LSPosedLogcatProbeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/lsposed/data/probes/LSPosedLogcatProbeTest.kt
@@ -114,6 +114,25 @@ class LSPosedLogcatProbeTest {
     }
 
     @Test
+    fun `selinux avc without type marker does not become direct lsposed hit`() {
+        val probe = LSPosedLogcatProbe()
+        val result = probe.evaluate(
+            mapOf(
+                "overview" to LSPosedLogcatCommandOutput(
+                    output = "05-26 09:07:16.652 28028 28028 E SELinux : avc:  denied  { read } for  scontext=u:r:untrusted_app:s0 tcontext=u:object_r:lsposed_file:s0 tclass=file permissive=0",
+                ),
+                "tag:LSPosed" to LSPosedLogcatCommandOutput(),
+                "tag:LSPosed-Bridge" to LSPosedLogcatCommandOutput(),
+                "tag:LSPosedService" to LSPosedLogcatCommandOutput(),
+                "process" to LSPosedLogcatCommandOutput(),
+            ),
+        )
+
+        assertTrue(result.available)
+        assertTrue(result.signals.isEmpty())
+    }
+
+    @Test
     fun `log access denied downgrades to unavailable`() {
         val probe = LSPosedLogcatProbe(
             commandRunner = LSPosedLogcatCommandRunner { _, _ ->


### PR DESCRIPTION
Skip canonical SELinux AVC denial lines before the broad direct-hit lsposed/lspd keyword check so that self-generated audit logs from the

native dirty-policy probe no longer surface as LSPosed evidence.
- Add isSelinuxAvcLine() to exclude any line containing avc:, denied, scontext=, and tcontext= from direct-hit matching.
- Drop the type=1400 prerequisite from isDirtyPolicyLsposedFileAvc() so the fallback filter also covers real-world AVC formats that lack that field (e.g. E/SELinux tag on some devices).
- Add regression test for a real AVC sample without type=1400.

Also update QQ group number to 789344870 and corresponding deep-link.
