### PR TITLE
feat(tee): expand private grant detection evidence

### DIFF
--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
@@ -31,6 +31,7 @@ import com.eltavine.duckdetector.features.tee.domain.TeeTier
 import com.eltavine.duckdetector.features.tee.domain.TeeTrustRoot
 import com.eltavine.duckdetector.features.tee.domain.TeeVerdict
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainAnomalyKind
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.MIN_RATIO_SAMPLE_COUNT
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.TIMING_SIDE_CHANNEL_THRESHOLD_RATIO
@@ -326,6 +327,21 @@ class TeeReportReducer(
 
                 GrantDomainAnomalyKind.NONE,
                 GrantDomainAnomalyKind.UNAVAILABLE -> Unit
+            }
+            if (
+                artifacts.syntheticGrantGranteeBlindReadback.anomalyKind ==
+                SyntheticGrantGranteeBlindReadbackAnomalyKind.NON_GRANTEE_READBACK_ALLOWED
+            ) {
+                add(
+                    fact(
+                        "Grant caller binding",
+                        "Grant handle remained readable by its non-grantee owner. " +
+                            syntheticGrantGranteeBlindReadbackValue(artifacts),
+                        TeeSignalLevel.FAIL,
+                        hiddenCopyText = artifacts.syntheticGrantGranteeBlindReadback.diagnosticCopyText
+                            .takeIf { it.isNotBlank() },
+                    )
+                )
             }
             // self-domain removes the isolated-process policy variable; its key-not-found variant is treated like a visibility split.
             // self-domain 排除了 isolated-process 策略变量；其 key-not-found 变体按可见性断裂处理。
@@ -911,6 +927,15 @@ class TeeReportReducer(
                             grantDomainFullChainSplitValue(artifacts),
                             grantDomainFullChainSplitLevel(artifacts),
                             hiddenCopyText = artifacts.grantDomainFullChainSplit.diagnosticCopyText
+                                .takeIf { it.isNotBlank() },
+                        )
+                    )
+                    add(
+                        fact(
+                            "Grant caller binding",
+                            syntheticGrantGranteeBlindReadbackValue(artifacts),
+                            syntheticGrantGranteeBlindReadbackLevel(artifacts),
+                            hiddenCopyText = artifacts.syntheticGrantGranteeBlindReadback.diagnosticCopyText
                                 .takeIf { it.isNotBlank() },
                         )
                     )
@@ -1613,6 +1638,35 @@ class TeeReportReducer(
         }
     }
 
+    private fun syntheticGrantGranteeBlindReadbackValue(artifacts: TeeScanArtifacts): String {
+        val result = artifacts.syntheticGrantGranteeBlindReadback
+        return when {
+            result.anomalyKind == SyntheticGrantGranteeBlindReadbackAnomalyKind.NON_GRANTEE_READBACK_ALLOWED ->
+                buildString {
+                    append("Matched kind=NON_GRANTEE_READBACK_ALLOWED")
+                    result.granteeUid?.let { append(" uid=$it") }
+                    append(" ownerReplay=true")
+                    result.detail.takeIf { it.isNotBlank() }?.let { append(" • $it") }
+                }
+            result.executed && result.available &&
+                result.anomalyKind == SyntheticGrantGranteeBlindReadbackAnomalyKind.NONE ->
+                buildString {
+                    append("Clean kind=NONE")
+                    result.granteeUid?.let { append(" uid=$it") }
+                    append(" ownerReplay=KEY_NOT_FOUND")
+                    result.detail.takeIf { it.isNotBlank() }?.let { append(" • $it") }
+                }
+            result.anomalyKind == SyntheticGrantGranteeBlindReadbackAnomalyKind.SKIPPED_AFTER_EXISTING_GRANT_DANGER ->
+                "Skipped • ${result.detail}"
+            else -> buildString {
+                append("Unavailable kind=")
+                append(result.anomalyKind.name)
+                result.ownerReplayErrorKind?.let { append(" ownerReplay=$it") }
+                result.detail.takeIf { it.isNotBlank() }?.let { append(" • $it") }
+            }
+        }
+    }
+
     private fun grantSelfDomainFullChainSplitValue(artifacts: TeeScanArtifacts): String {
         val result = artifacts.grantSelfDomainFullChainSplit
         return when {
@@ -1947,6 +2001,17 @@ class TeeReportReducer(
             result.executed && result.splitDetected -> TeeSignalLevel.FAIL
             result.executed && result.available -> TeeSignalLevel.PASS
             else -> TeeSignalLevel.INFO
+        }
+    }
+
+    private fun syntheticGrantGranteeBlindReadbackLevel(artifacts: TeeScanArtifacts): TeeSignalLevel {
+        val result = artifacts.syntheticGrantGranteeBlindReadback
+        return when (result.anomalyKind) {
+            SyntheticGrantGranteeBlindReadbackAnomalyKind.NON_GRANTEE_READBACK_ALLOWED -> TeeSignalLevel.FAIL
+            SyntheticGrantGranteeBlindReadbackAnomalyKind.NONE ->
+                if (result.executed && result.available) TeeSignalLevel.PASS else TeeSignalLevel.INFO
+            SyntheticGrantGranteeBlindReadbackAnomalyKind.SKIPPED_AFTER_EXISTING_GRANT_DANGER,
+            SyntheticGrantGranteeBlindReadbackAnomalyKind.UNAVAILABLE -> TeeSignalLevel.INFO
         }
     }
 

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
@@ -18,6 +18,7 @@ package com.eltavine.duckdetector.features.tee.data.report
 
 import android.os.Build
 import com.eltavine.duckdetector.features.tee.data.attestation.AttestationSnapshot
+import com.eltavine.duckdetector.features.tee.data.verification.crl.RevokedCertificateEvidenceKind
 import com.eltavine.duckdetector.features.tee.domain.TeeEvidenceItem
 import com.eltavine.duckdetector.features.tee.domain.TeeEvidenceSection
 import com.eltavine.duckdetector.features.tee.domain.TeeNetworkMode
@@ -221,7 +222,7 @@ class TeeReportReducer(
                     )
                 )
             }
-            if (artifacts.crl.revokedCertificates.isNotEmpty()) {
+            if (hasHardRevocation(artifacts)) {
                 add(
                     fact(
                         "Revocation",
@@ -697,6 +698,15 @@ class TeeReportReducer(
             }
             artifacts.rkp.consistencyIssue?.let { issue ->
                 add(fact("RKP consistency", issue, TeeSignalLevel.WARN))
+            }
+            if (hasLocalMassAbuseRevocation(artifacts)) {
+                add(
+                    fact(
+                        "Revocation",
+                        "Built-in local revocation floor matched a certificate serial associated with mass abuse.",
+                        TeeSignalLevel.WARN,
+                    )
+                )
             }
         }
     }
@@ -1403,6 +1413,8 @@ class TeeReportReducer(
                 append(
                     if (artifacts.crl.revokedCertificates.isEmpty()) {
                         "clean"
+                    } else if (hasLocalMassAbuseRevocation(artifacts) && !hasHardRevocation(artifacts)) {
+                        "mass abuse"
                     } else {
                         "${artifacts.crl.revokedCertificates.size} revoked"
                     },
@@ -2245,7 +2257,8 @@ class TeeReportReducer(
     }
 
     private fun crlSignalValue(artifacts: TeeScanArtifacts): String = when {
-        artifacts.crl.revokedCertificates.isNotEmpty() -> "Revoked"
+        hasHardRevocation(artifacts) -> "Revoked"
+        hasLocalMassAbuseRevocation(artifacts) -> "Mass abuse"
         artifacts.crl.networkState.mode == TeeNetworkMode.ACTIVE -> "Online"
         artifacts.crl.networkState.mode == TeeNetworkMode.CONSENT_REQUIRED -> "Built-in"
         artifacts.crl.networkState.mode == TeeNetworkMode.SKIPPED -> "Built-in"
@@ -2325,7 +2338,8 @@ class TeeReportReducer(
     }
 
     private fun crlSignalLevel(artifacts: TeeScanArtifacts): TeeSignalLevel = when {
-        artifacts.crl.revokedCertificates.isNotEmpty() -> TeeSignalLevel.FAIL
+        hasHardRevocation(artifacts) -> TeeSignalLevel.FAIL
+        hasLocalMassAbuseRevocation(artifacts) -> TeeSignalLevel.WARN
         artifacts.crl.networkState.mode == TeeNetworkMode.ACTIVE -> TeeSignalLevel.PASS
         artifacts.crl.networkState.mode == TeeNetworkMode.ERROR -> TeeSignalLevel.WARN
         else -> TeeSignalLevel.INFO
@@ -2609,6 +2623,19 @@ class TeeReportReducer(
         !artifacts.trust.chainSignatureValid -> TeeSignalLevel.FAIL
         hasLocalTrustReviewSignals(artifacts) -> TeeSignalLevel.WARN
         else -> TeeSignalLevel.PASS
+    }
+
+    private fun hasHardRevocation(artifacts: TeeScanArtifacts): Boolean {
+        return artifacts.crl.revokedCertificates.any {
+            it.evidenceKind == RevokedCertificateEvidenceKind.STANDARD_REVOCATION
+        }
+    }
+
+    private fun hasLocalMassAbuseRevocation(artifacts: TeeScanArtifacts): Boolean {
+        // 临时本地口径：仅 checked-in 硬编码序列号命中时降级为 WARN，远端/联网 CRL 仍按标准吊销处理。
+        return artifacts.crl.revokedCertificates.any {
+            it.evidenceKind == RevokedCertificateEvidenceKind.LOCAL_MASS_ABUSE
+        }
     }
 
     private fun hasLocalTrustReviewSignals(artifacts: TeeScanArtifacts): Boolean {

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
@@ -32,6 +32,7 @@ import com.eltavine.duckdetector.features.tee.domain.TeeTier
 import com.eltavine.duckdetector.features.tee.domain.TeeTrustRoot
 import com.eltavine.duckdetector.features.tee.domain.TeeVerdict
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainAnomalyKind
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.MIN_RATIO_SAMPLE_COUNT
@@ -340,6 +341,21 @@ class TeeReportReducer(
                             syntheticGrantGranteeBlindReadbackValue(artifacts),
                         TeeSignalLevel.FAIL,
                         hiddenCopyText = artifacts.syntheticGrantGranteeBlindReadback.diagnosticCopyText
+                            .takeIf { it.isNotBlank() },
+                    )
+                )
+            }
+            if (
+                artifacts.syntheticGrantGetKeyEntryAccessVectorBlindness.anomalyKind ==
+                SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.GET_KEY_ENTRY_WITHOUT_GET_INFO_ALLOWED
+            ) {
+                add(
+                    fact(
+                        "Grant access vector",
+                        "Domain.GRANT handle without GET_INFO still allowed getKeyEntry metadata readback. " +
+                            syntheticGrantGetKeyEntryAccessVectorBlindnessValue(artifacts),
+                        TeeSignalLevel.FAIL,
+                        hiddenCopyText = artifacts.syntheticGrantGetKeyEntryAccessVectorBlindness.diagnosticCopyText
                             .takeIf { it.isNotBlank() },
                     )
                 )
@@ -946,6 +962,15 @@ class TeeReportReducer(
                             syntheticGrantGranteeBlindReadbackValue(artifacts),
                             syntheticGrantGranteeBlindReadbackLevel(artifacts),
                             hiddenCopyText = artifacts.syntheticGrantGranteeBlindReadback.diagnosticCopyText
+                                .takeIf { it.isNotBlank() },
+                        )
+                    )
+                    add(
+                        fact(
+                            "Grant access vector",
+                            syntheticGrantGetKeyEntryAccessVectorBlindnessValue(artifacts),
+                            syntheticGrantGetKeyEntryAccessVectorBlindnessLevel(artifacts),
+                            hiddenCopyText = artifacts.syntheticGrantGetKeyEntryAccessVectorBlindness.diagnosticCopyText
                                 .takeIf { it.isNotBlank() },
                         )
                     )
@@ -1679,6 +1704,40 @@ class TeeReportReducer(
         }
     }
 
+    private fun syntheticGrantGetKeyEntryAccessVectorBlindnessValue(artifacts: TeeScanArtifacts): String {
+        val result = artifacts.syntheticGrantGetKeyEntryAccessVectorBlindness
+        return when {
+            result.anomalyKind ==
+                SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.GET_KEY_ENTRY_WITHOUT_GET_INFO_ALLOWED ->
+                buildString {
+                    append("Matched kind=GET_KEY_ENTRY_WITHOUT_GET_INFO_ALLOWED")
+                    result.granteeUid?.let { append(" uid=$it") }
+                    result.accessVector?.let { append(" accessVector=$it") }
+                    append(" granteeRead=true")
+                    result.detail.takeIf { it.isNotBlank() }?.let { append(" • $it") }
+                }
+            result.executed && result.available &&
+                result.anomalyKind == SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.NONE ->
+                buildString {
+                    append("Clean kind=NONE")
+                    result.granteeUid?.let { append(" uid=$it") }
+                    result.accessVector?.let { append(" accessVector=$it") }
+                    append(" granteeRead=PERMISSION_DENIED")
+                    result.detail.takeIf { it.isNotBlank() }?.let { append(" • $it") }
+                }
+            result.anomalyKind ==
+                SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.SKIPPED_AFTER_EXISTING_GRANT_DANGER ->
+                "Skipped • ${result.detail}"
+            else -> buildString {
+                append("Unavailable kind=")
+                append(result.anomalyKind.name)
+                result.granteeReadErrorKind?.let { append(" granteeRead=$it") }
+                result.accessVector?.let { append(" accessVector=$it") }
+                result.detail.takeIf { it.isNotBlank() }?.let { append(" • $it") }
+            }
+        }
+    }
+
     private fun grantSelfDomainFullChainSplitValue(artifacts: TeeScanArtifacts): String {
         val result = artifacts.grantSelfDomainFullChainSplit
         return when {
@@ -2024,6 +2083,18 @@ class TeeReportReducer(
                 if (result.executed && result.available) TeeSignalLevel.PASS else TeeSignalLevel.INFO
             SyntheticGrantGranteeBlindReadbackAnomalyKind.SKIPPED_AFTER_EXISTING_GRANT_DANGER,
             SyntheticGrantGranteeBlindReadbackAnomalyKind.UNAVAILABLE -> TeeSignalLevel.INFO
+        }
+    }
+
+    private fun syntheticGrantGetKeyEntryAccessVectorBlindnessLevel(artifacts: TeeScanArtifacts): TeeSignalLevel {
+        val result = artifacts.syntheticGrantGetKeyEntryAccessVectorBlindness
+        return when (result.anomalyKind) {
+            SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.GET_KEY_ENTRY_WITHOUT_GET_INFO_ALLOWED ->
+                TeeSignalLevel.FAIL
+            SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.NONE ->
+                if (result.executed && result.available) TeeSignalLevel.PASS else TeeSignalLevel.INFO
+            SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.SKIPPED_AFTER_EXISTING_GRANT_DANGER,
+            SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.UNAVAILABLE -> TeeSignalLevel.INFO
         }
     }
 

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeScanArtifacts.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeScanArtifacts.kt
@@ -36,6 +36,7 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystor
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyLifecycleResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitResult
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.LegacyKeystorePathResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesBatchedResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesConsistencyResult
@@ -72,6 +73,7 @@ data class TeeScanArtifacts(
     val keystore2Hook: Keystore2HookResult,
     val generateModeParcelFingerprint: Keystore2GenerateModeParcelFingerprintResult,
     val grantDomainFullChainSplit: GrantDomainFullChainSplitResult,
+    val syntheticGrantGranteeBlindReadback: SyntheticGrantGranteeBlindReadbackResult,
     val grantSelfDomainFullChainSplit: GrantSelfDomainFullChainSplitResult,
     val legacyKeystorePath: LegacyKeystorePathResult,
     val listEntriesConsistency: ListEntriesConsistencyResult,

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeScanArtifacts.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeScanArtifacts.kt
@@ -36,6 +36,7 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystor
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyLifecycleResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitResult
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGetKeyEntryAccessVectorBlindnessResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.LegacyKeystorePathResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesBatchedResult
@@ -74,6 +75,7 @@ data class TeeScanArtifacts(
     val generateModeParcelFingerprint: Keystore2GenerateModeParcelFingerprintResult,
     val grantDomainFullChainSplit: GrantDomainFullChainSplitResult,
     val syntheticGrantGranteeBlindReadback: SyntheticGrantGranteeBlindReadbackResult,
+    val syntheticGrantGetKeyEntryAccessVectorBlindness: SyntheticGrantGetKeyEntryAccessVectorBlindnessResult,
     val grantSelfDomainFullChainSplit: GrantSelfDomainFullChainSplitResult,
     val legacyKeystorePath: LegacyKeystorePathResult,
     val listEntriesConsistency: ListEntriesConsistencyResult,

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
@@ -45,7 +45,12 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyboxI
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2GenerateModeParcelFingerprintProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2HookProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitProbe
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainAnomalyKind
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitProbe
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainAnomalyKind
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitResult
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.LegacyKeystorePathProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesBatchedProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesConsistencyProbe
@@ -95,6 +100,7 @@ class TeeRepository(
     private val generateModeParcelFingerprintProbe = Keystore2GenerateModeParcelFingerprintProbe()
     private val grantDomainFullChainSplitProbe = GrantDomainFullChainSplitProbe(appContext)
     private val grantSelfDomainFullChainSplitProbe = GrantSelfDomainFullChainSplitProbe(appContext)
+    private val syntheticGrantGranteeBlindReadbackProbe = SyntheticGrantGranteeBlindReadbackProbe(appContext)
     private val legacyKeystorePathProbe = LegacyKeystorePathProbe()
     private val listEntriesConsistencyProbe = ListEntriesConsistencyProbe()
     private val listEntriesBatchedProbe = ListEntriesBatchedProbe()
@@ -161,6 +167,7 @@ class TeeRepository(
                     keystore2Hook = deepChecks.keystore2Hook,
                     generateModeParcelFingerprint = deepChecks.generateModeParcelFingerprint,
                     grantDomainFullChainSplit = deepChecks.grantDomainFullChainSplit,
+                    syntheticGrantGranteeBlindReadback = deepChecks.syntheticGrantGranteeBlindReadback,
                     grantSelfDomainFullChainSplit = deepChecks.grantSelfDomainFullChainSplit,
                     legacyKeystorePath = deepChecks.legacyKeystorePath,
                     listEntriesConsistency = deepChecks.listEntriesConsistency,
@@ -254,6 +261,12 @@ class TeeRepository(
         val generateModeParcelFingerprint = generateModeParcelFingerprintProbe.inspect()
         val grantDomainFullChainSplit = grantDomainFullChainSplitProbe.inspect(useStrongBox = useStrongBox)
         val grantSelfDomainFullChainSplit = grantSelfDomainFullChainSplitProbe.inspect(useStrongBox = useStrongBox)
+        val syntheticGrantGranteeBlindReadback =
+            if (grantDomainFullChainSplit.hasDanger() || grantSelfDomainFullChainSplit.hasDanger()) {
+                SyntheticGrantGranteeBlindReadbackProbe.skippedAfterExistingGrantDanger()
+            } else {
+                syntheticGrantGranteeBlindReadbackProbe.inspect(useStrongBox = useStrongBox)
+            }
         val legacyKeystorePath = legacyKeystorePathProbe.inspect()
         val binderHookBootstrap = binderHookBootstrapProbe.inspect()
         val binderPatchMode = binderPatchModeProbe.inspect()
@@ -275,6 +288,7 @@ class TeeRepository(
             keystore2Hook = keystore2HookResult,
             generateModeParcelFingerprint = generateModeParcelFingerprint,
             grantDomainFullChainSplit = grantDomainFullChainSplit,
+            syntheticGrantGranteeBlindReadback = syntheticGrantGranteeBlindReadback,
             grantSelfDomainFullChainSplit = grantSelfDomainFullChainSplit,
             legacyKeystorePath = legacyKeystorePath,
             listEntriesConsistency = listEntriesConsistencyResult,
@@ -299,6 +313,16 @@ class TeeRepository(
 
 }
 
+private fun GrantDomainFullChainSplitResult.hasDanger(): Boolean {
+    return anomalyKind == GrantDomainAnomalyKind.ISOLATED_CHAIN_SPLIT ||
+        anomalyKind == GrantDomainAnomalyKind.ISOLATED_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN
+}
+
+private fun GrantSelfDomainFullChainSplitResult.hasDanger(): Boolean {
+    return anomalyKind == GrantSelfDomainAnomalyKind.SELF_CHAIN_SPLIT ||
+        anomalyKind == GrantSelfDomainAnomalyKind.SELF_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN
+}
+
 private data class DeferredChecks(
     val pairConsistency: com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyPairConsistencyResult,
     val aesGcm: com.eltavine.duckdetector.features.tee.data.verification.keystore.AesGcmRoundTripResult,
@@ -311,6 +335,7 @@ private data class DeferredChecks(
     val keystore2Hook: com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2HookResult,
     val generateModeParcelFingerprint: com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2GenerateModeParcelFingerprintResult,
     val grantDomainFullChainSplit: com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult,
+    val syntheticGrantGranteeBlindReadback: com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackResult,
     val grantSelfDomainFullChainSplit: com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitResult,
     val legacyKeystorePath: com.eltavine.duckdetector.features.tee.data.verification.keystore.LegacyKeystorePathResult,
     val listEntriesConsistency: com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesConsistencyResult,
@@ -382,6 +407,9 @@ private data class DeferredChecks(
             ),
             grantDomainFullChainSplit = com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult(
                 detail = "Grant-domain full-chain split probe skipped.",
+            ),
+            syntheticGrantGranteeBlindReadback = com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackResult(
+                detail = "Grant caller-binding private binder probe skipped.",
             ),
             grantSelfDomainFullChainSplit = com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitResult(
                 detail = "Grant self-domain full-chain split probe skipped.",

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
@@ -50,7 +50,10 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDo
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitResult
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGetKeyEntryAccessVectorBlindnessProbe
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackProbe
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.LegacyKeystorePathProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesBatchedProbe
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesConsistencyProbe
@@ -101,6 +104,8 @@ class TeeRepository(
     private val grantDomainFullChainSplitProbe = GrantDomainFullChainSplitProbe(appContext)
     private val grantSelfDomainFullChainSplitProbe = GrantSelfDomainFullChainSplitProbe(appContext)
     private val syntheticGrantGranteeBlindReadbackProbe = SyntheticGrantGranteeBlindReadbackProbe(appContext)
+    private val syntheticGrantGetKeyEntryAccessVectorBlindnessProbe =
+        SyntheticGrantGetKeyEntryAccessVectorBlindnessProbe(appContext)
     private val legacyKeystorePathProbe = LegacyKeystorePathProbe()
     private val listEntriesConsistencyProbe = ListEntriesConsistencyProbe()
     private val listEntriesBatchedProbe = ListEntriesBatchedProbe()
@@ -168,6 +173,8 @@ class TeeRepository(
                     generateModeParcelFingerprint = deepChecks.generateModeParcelFingerprint,
                     grantDomainFullChainSplit = deepChecks.grantDomainFullChainSplit,
                     syntheticGrantGranteeBlindReadback = deepChecks.syntheticGrantGranteeBlindReadback,
+                    syntheticGrantGetKeyEntryAccessVectorBlindness =
+                        deepChecks.syntheticGrantGetKeyEntryAccessVectorBlindness,
                     grantSelfDomainFullChainSplit = deepChecks.grantSelfDomainFullChainSplit,
                     legacyKeystorePath = deepChecks.legacyKeystorePath,
                     listEntriesConsistency = deepChecks.listEntriesConsistency,
@@ -267,6 +274,16 @@ class TeeRepository(
             } else {
                 syntheticGrantGranteeBlindReadbackProbe.inspect(useStrongBox = useStrongBox)
             }
+        val syntheticGrantGetKeyEntryAccessVectorBlindness =
+            if (
+                grantDomainFullChainSplit.hasDanger() ||
+                grantSelfDomainFullChainSplit.hasDanger() ||
+                syntheticGrantGranteeBlindReadback.hasDanger()
+            ) {
+                SyntheticGrantGetKeyEntryAccessVectorBlindnessProbe.skippedAfterExistingGrantDanger()
+            } else {
+                syntheticGrantGetKeyEntryAccessVectorBlindnessProbe.inspect(useStrongBox = useStrongBox)
+            }
         val legacyKeystorePath = legacyKeystorePathProbe.inspect()
         val binderHookBootstrap = binderHookBootstrapProbe.inspect()
         val binderPatchMode = binderPatchModeProbe.inspect()
@@ -289,6 +306,7 @@ class TeeRepository(
             generateModeParcelFingerprint = generateModeParcelFingerprint,
             grantDomainFullChainSplit = grantDomainFullChainSplit,
             syntheticGrantGranteeBlindReadback = syntheticGrantGranteeBlindReadback,
+            syntheticGrantGetKeyEntryAccessVectorBlindness = syntheticGrantGetKeyEntryAccessVectorBlindness,
             grantSelfDomainFullChainSplit = grantSelfDomainFullChainSplit,
             legacyKeystorePath = legacyKeystorePath,
             listEntriesConsistency = listEntriesConsistencyResult,
@@ -323,6 +341,10 @@ private fun GrantSelfDomainFullChainSplitResult.hasDanger(): Boolean {
         anomalyKind == GrantSelfDomainAnomalyKind.SELF_GRANT_KEY_NOT_FOUND_AFTER_OWNER_CHAIN
 }
 
+private fun SyntheticGrantGranteeBlindReadbackResult.hasDanger(): Boolean {
+    return anomalyKind == SyntheticGrantGranteeBlindReadbackAnomalyKind.NON_GRANTEE_READBACK_ALLOWED
+}
+
 private data class DeferredChecks(
     val pairConsistency: com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyPairConsistencyResult,
     val aesGcm: com.eltavine.duckdetector.features.tee.data.verification.keystore.AesGcmRoundTripResult,
@@ -336,6 +358,7 @@ private data class DeferredChecks(
     val generateModeParcelFingerprint: com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2GenerateModeParcelFingerprintResult,
     val grantDomainFullChainSplit: com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult,
     val syntheticGrantGranteeBlindReadback: com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackResult,
+    val syntheticGrantGetKeyEntryAccessVectorBlindness: com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGetKeyEntryAccessVectorBlindnessResult,
     val grantSelfDomainFullChainSplit: com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitResult,
     val legacyKeystorePath: com.eltavine.duckdetector.features.tee.data.verification.keystore.LegacyKeystorePathResult,
     val listEntriesConsistency: com.eltavine.duckdetector.features.tee.data.verification.keystore.ListEntriesConsistencyResult,
@@ -411,6 +434,10 @@ private data class DeferredChecks(
             syntheticGrantGranteeBlindReadback = com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackResult(
                 detail = "Grant caller-binding private binder probe skipped.",
             ),
+            syntheticGrantGetKeyEntryAccessVectorBlindness =
+                com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                    detail = "Grant access-vector private binder probe skipped.",
+                ),
             grantSelfDomainFullChainSplit = com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitResult(
                 detail = "Grant self-domain full-chain split probe skipped.",
             ),

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/crl/CrlStatusService.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/crl/CrlStatusService.kt
@@ -167,7 +167,10 @@ class CrlStatusService(
         return withContext(Dispatchers.IO) {
             runCatching {
                 val json = embeddedStatusProvider.load()
-                val entries = parseStatusJson(json)
+                val entries = parseStatusJson(
+                    json = json,
+                    defaultSource = CrlEntrySource.EMBEDDED,
+                )
                 CrlSnapshotResult.Success(entries)
             }.getOrElse { throwable ->
                 CrlSnapshotResult.Failure(classifyEmbeddedFailure(throwable))
@@ -179,7 +182,10 @@ class CrlStatusService(
         return withContext(Dispatchers.IO) {
             runCatching {
                 val json = feedFetcher.fetch()
-                val entries = parseStatusJson(json)
+                val entries = parseStatusJson(
+                    json = json,
+                    defaultSource = CrlEntrySource.ONLINE,
+                )
                 CrlSnapshotResult.Success(entries)
             }.getOrElse { throwable ->
                 CrlSnapshotResult.Failure(classifyFailure(throwable))
@@ -199,7 +205,13 @@ class CrlStatusService(
         // 内置吊销是本地信任下限；在线数据可以追加条目，但不能降级仓库已标记吊销/暂停的序列号。
         return LinkedHashMap<String, CrlEntry>(embeddedEntries).apply {
             onlineEntries.forEach { (serial, entry) ->
-                putIfAbsent(serial, entry)
+                val existing = this[serial]
+                if (existing?.isLocalMassAbuseOverride(serial) == true && entry.isRevokedOrSuspended()) {
+                    // 临时例外：该本地硬编码序列号只是“大规模滥用”WARN，联网/构建增量命中时恢复标准 CRL 语义。
+                    this[serial] = entry
+                } else {
+                    putIfAbsent(serial, entry)
+                }
             }
         }
     }
@@ -212,17 +224,29 @@ class CrlStatusService(
         val revoked = chain.mapNotNull { cert ->
             val serialHex = cert.serialNumber.toString(16).lowercase()
             val serialDec = cert.serialNumber.toString()
-            val entry = entries[serialHex]
-                ?: entries[serialDec]
-                ?: entries[serialHex.trimStart('0').ifBlank { "0" }]
-                ?: entries[serialDec.trimStart('0').ifBlank { "0" }]
+            val candidates = listOfNotNull(
+                entries[serialHex],
+                entries[serialDec],
+                entries[serialHex.trimStart('0').ifBlank { "0" }],
+                entries[serialDec.trimStart('0').ifBlank { "0" }],
+            )
+            val entry = candidates.firstOrNull {
+                it.source == CrlEntrySource.ONLINE &&
+                    (it.status == STATUS_REVOKED || it.status == STATUS_SUSPENDED)
+            } ?: candidates.firstOrNull()
 
             entry
                 ?.takeIf { it.status == STATUS_REVOKED || it.status == STATUS_SUSPENDED }
                 ?.let { matched ->
+                    val evidenceKind = matched.evidenceKind(serialHex)
                     RevokedCertificate(
                         serial = "$serialHex / $serialDec",
-                        reason = matched.reason ?: matched.status,
+                        reason = if (evidenceKind == RevokedCertificateEvidenceKind.LOCAL_MASS_ABUSE) {
+                            "MASS_ABUSE"
+                        } else {
+                            matched.reason ?: matched.status
+                        },
+                        evidenceKind = evidenceKind,
                     )
                 }
         }
@@ -250,7 +274,10 @@ class CrlStatusService(
         return "$baseSummary $verdict"
     }
 
-    private fun parseStatusJson(json: String): Map<String, CrlEntry> {
+    private fun parseStatusJson(
+        json: String,
+        defaultSource: CrlEntrySource,
+    ): Map<String, CrlEntry> {
         val root = JSONObject(json)
         val entries = root.optJSONObject("entries")
             ?: throw JSONException("Attestation status feed is missing an entries object.")
@@ -264,6 +291,10 @@ class CrlStatusService(
                 result[serial] = CrlEntry(
                     status = entry.optString("status", "UNKNOWN"),
                     reason = entry.optString("reason").takeIf { it.isNotBlank() },
+                    source = entry.optString(DUCK_SOURCE_FIELD)
+                        .takeIf { it == DUCK_SOURCE_REMOTE }
+                        ?.let { CrlEntrySource.ONLINE }
+                        ?: defaultSource,
                 )
             }
         }
@@ -328,6 +359,24 @@ class CrlStatusService(
         }
     }
 
+    private fun CrlEntry.evidenceKind(serialHex: String): RevokedCertificateEvidenceKind {
+        return if (isLocalMassAbuseOverride(serialHex)) {
+            RevokedCertificateEvidenceKind.LOCAL_MASS_ABUSE
+        } else {
+            RevokedCertificateEvidenceKind.STANDARD_REVOCATION
+        }
+    }
+
+    private fun CrlEntry.isRevokedOrSuspended(): Boolean {
+        return status == STATUS_REVOKED || status == STATUS_SUSPENDED
+    }
+
+    private fun CrlEntry.isLocalMassAbuseOverride(serial: String): Boolean {
+        return source == CrlEntrySource.EMBEDDED &&
+            status == STATUS_REVOKED &&
+            serial.trimStart('0').ifBlank { "0" } == LOCAL_MASS_ABUSE_SERIAL
+    }
+
     private fun joinDetails(
         vararg parts: String?,
     ): String? {
@@ -349,6 +398,9 @@ class CrlStatusService(
         private const val NETWORK_TIMEOUT_MS = 5_000
         private const val STATUS_REVOKED = "REVOKED"
         private const val STATUS_SUSPENDED = "SUSPENDED"
+        private const val LOCAL_MASS_ABUSE_SERIAL = "8616ef30679ed43cc2b43e3c97a2319e"
+        private const val DUCK_SOURCE_FIELD = "_duckDetectorSource"
+        private const val DUCK_SOURCE_REMOTE = "REMOTE"
     }
 }
 
@@ -411,7 +463,13 @@ data class CrlStatusResult(
 data class RevokedCertificate(
     val serial: String,
     val reason: String,
+    val evidenceKind: RevokedCertificateEvidenceKind = RevokedCertificateEvidenceKind.STANDARD_REVOCATION,
 )
+
+enum class RevokedCertificateEvidenceKind {
+    STANDARD_REVOCATION,
+    LOCAL_MASS_ABUSE,
+}
 
 internal class AssetsCrlEmbeddedStatusProvider(
     private val context: Context,
@@ -458,7 +516,13 @@ private data class CrlFailure(
 private data class CrlEntry(
     val status: String,
     val reason: String?,
+    val source: CrlEntrySource,
 )
+
+private enum class CrlEntrySource {
+    EMBEDDED,
+    ONLINE,
+}
 
 private class HttpStatusException(
     val statusCode: Int,

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GenerateKeyReplyParcelParser.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GenerateKeyReplyParcelParser.kt
@@ -65,11 +65,14 @@ class GenerateKeyReplyParcelParser {
 
             val lastAuthorizationHasUnknownUnionTag = isUnknownKeyParameterValueUnionTag(lastAuthorization.unionTag)
             val matched =
-                modificationTimeMs == TARGET_MODIFICATION_TIME_MS &&
-                    lastAuthorization.secLevel in TARGET_LAST_AUTHORIZATION_SEC_LEVELS &&
-                    lastAuthorization.tag == TARGET_LAST_AUTHORIZATION_TAG &&
-                    lastAuthorization.unionTag == TARGET_LAST_AUTHORIZATION_UNION_TAG &&
-                    lastAuthorizationHasUnknownUnionTag
+                modificationTimeMs > TARGET_HIGH_MODIFICATION_TIME_MS_THRESHOLD ||
+                    (
+                        modificationTimeMs == TARGET_MODIFICATION_TIME_MS &&
+                            lastAuthorization.secLevel in TARGET_LAST_AUTHORIZATION_SEC_LEVELS &&
+                            lastAuthorization.tag == TARGET_LAST_AUTHORIZATION_TAG &&
+                            lastAuthorization.unionTag == TARGET_LAST_AUTHORIZATION_UNION_TAG &&
+                            lastAuthorizationHasUnknownUnionTag
+                        )
             GenerateKeyReplyParcelParseResult(
                 parseSucceeded = true,
                 authorizationCount = authorizationCount,
@@ -305,6 +308,7 @@ class GenerateKeyReplyParcelParser {
         const val AUTHORIZATION_TAG_OFFSET = 4
         const val AUTHORIZATION_UNION_TAG_OFFSET = 8
         const val TARGET_MODIFICATION_TIME_MS = 4294967297L
+        const val TARGET_HIGH_MODIFICATION_TIME_MS_THRESHOLD = 4_999_999_999L
         val TARGET_LAST_AUTHORIZATION_SEC_LEVELS = setOf(4L, 256L)
         const val TARGET_LAST_AUTHORIZATION_TAG = 0x00000001L
         const val TARGET_LAST_AUTHORIZATION_UNION_TAG = 32L

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/Keystore2PrivateBinderClient.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/Keystore2PrivateBinderClient.kt
@@ -414,11 +414,15 @@ class Keystore2PrivateBinderClient {
     }
 
     fun deleteKey(service: Any, keyDescriptor: Any) {
-        runCatching {
+        deleteKeyChecked(service, keyDescriptor)
+    }
+
+    fun deleteKeyChecked(service: Any, keyDescriptor: Any): Throwable? {
+        return runCatching {
             service.javaClass
                 .getMethod("deleteKey", keyDescriptor.javaClass)
                 .invoke(service, keyDescriptor)
-        }
+        }.exceptionOrNull()
     }
 
     fun listEntries(service: Any): Array<Any?> {

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/Keystore2PrivateGrantClient.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/Keystore2PrivateGrantClient.kt
@@ -41,32 +41,19 @@ class Keystore2PrivateGrantClient(
             failurePhase = Keystore2PrivateGrantPhase.PRIVATE_GRANT,
             failurePrefix = "private grant failed",
         ) { service, constants ->
-            val descriptor = createDescriptor(alias, constants.domainApp)
-            val grantDescriptor = service.javaClass.methods
-                .firstOrNull { method ->
-                    method.name == "grant" &&
-                        method.parameterTypes.size == 3 &&
-                        method.parameterTypes[1] == Int::class.javaPrimitiveType &&
-                        method.parameterTypes[2] == Int::class.javaPrimitiveType
-                }
-                ?.also { it.isAccessible = true }
-                ?.invoke(service, descriptor, uid, constants.grantAccessVector)
-                ?: return@withService Keystore2PrivateGrantResult.unavailable(
-                    phase = Keystore2PrivateGrantPhase.PRIVATE_GRANT,
-                    detail = "private grant failed: hidden grant() returned no descriptor.",
-                )
-            val grantId = readLongField(grantDescriptor, "nspace")
-            if (grantId == null) {
-                return@withService Keystore2PrivateGrantResult.unavailable(
-                    phase = Keystore2PrivateGrantPhase.PRIVATE_GRANT,
-                    detail = "private grant failed: hidden grant() returned invalid grant namespace.",
-                )
-            }
-            Keystore2PrivateGrantResult(
-                available = true,
+            grantAliasToUid(service, alias, uid, constants)
+        }
+    }
+
+    fun grantAliasToUid(service: Any, alias: String, uid: Int): Keystore2PrivateGrantResult {
+        return runCatching {
+            grantAliasToUid(service, alias, uid, resolveConstants())
+        }.getOrElse { throwable ->
+            grantFailureResult(
                 phase = Keystore2PrivateGrantPhase.PRIVATE_GRANT,
-                grantId = grantId,
-                detail = "private grant created grantId=$grantId unsignedGrantId=${java.lang.Long.toUnsignedString(grantId)} accessVector=${constants.grantAccessVector}",
+                detail = "private grant failed: ${describeThrowable(throwable)}",
+                errorKind = classifyFailure(throwable),
+                throwable = throwable,
             )
         }
     }
@@ -82,23 +69,19 @@ class Keystore2PrivateGrantClient(
             failurePhase = Keystore2PrivateGrantPhase.PRIVATE_UNGRANT,
             failurePrefix = "private ungrant failed",
         ) { service, constants ->
-            val descriptor = createDescriptor(alias, constants.domainApp)
-            val method = service.javaClass.methods
-                .firstOrNull { candidate ->
-                    candidate.name == "ungrant" &&
-                        candidate.parameterTypes.size == 2 &&
-                        candidate.parameterTypes[1] == Int::class.javaPrimitiveType
-                }
-                ?: return@withService Keystore2PrivateGrantResult.unavailable(
-                    phase = Keystore2PrivateGrantPhase.PRIVATE_UNGRANT,
-                    detail = "private ungrant failed: hidden ungrant() was unavailable.",
-                )
-            method.isAccessible = true
-            method.invoke(service, descriptor, uid)
-            Keystore2PrivateGrantResult(
-                available = true,
+            revokeAliasGrant(service, alias, uid, constants)
+        }
+    }
+
+    fun revokeAliasGrant(service: Any, alias: String, uid: Int): Keystore2PrivateGrantResult {
+        return runCatching {
+            revokeAliasGrant(service, alias, uid, resolveConstants())
+        }.getOrElse { throwable ->
+            grantFailureResult(
                 phase = Keystore2PrivateGrantPhase.PRIVATE_UNGRANT,
-                detail = "private ungrant completed uid=$uid",
+                detail = "private ungrant failed: ${describeThrowable(throwable)}",
+                errorKind = classifyFailure(throwable),
+                throwable = throwable,
             )
         }
     }
@@ -114,12 +97,19 @@ class Keystore2PrivateGrantClient(
             failurePhase = Keystore2PrivateGrantPhase.PRIVATE_GET_KEY_ENTRY_APP,
             failurePrefix = "private getKeyEntry(APP) failed",
         ) { service, constants ->
-            readChainFromDescriptor(
-                service = service,
-                descriptor = createDescriptor(alias, constants.domainApp),
+            readOwnerChain(service, alias, constants)
+        }
+    }
+
+    fun readOwnerChain(service: Any, alias: String): Keystore2PrivateGrantChainResult {
+        return runCatching {
+            readOwnerChain(service, alias, resolveConstants())
+        }.getOrElse { throwable ->
+            grantFailureResult(
                 phase = Keystore2PrivateGrantPhase.PRIVATE_GET_KEY_ENTRY_APP,
-                emptyDetail = "private getKeyEntry(APP) returned an empty certificate chain.",
-                successDetailPrefix = "private getKeyEntry(APP)",
+                detail = "private getKeyEntry(APP) failed: ${describeThrowable(throwable)}",
+                errorKind = classifyFailure(throwable),
+                throwable = throwable,
             )
         }
     }
@@ -135,12 +125,46 @@ class Keystore2PrivateGrantClient(
             failurePhase = Keystore2PrivateGrantPhase.PRIVATE_GET_KEY_ENTRY_GRANT,
             failurePrefix = "private getKeyEntry(GRANT) failed",
         ) { service, constants ->
-            readChainFromDescriptor(
-                service = service,
-                descriptor = createDescriptor(grantId, constants.domainGrant),
+            readGrantChain(service, grantId, constants)
+        }
+    }
+
+    fun readGrantChain(service: Any, grantId: Long): Keystore2PrivateGrantChainResult {
+        return runCatching {
+            readGrantChain(service, grantId, resolveConstants())
+        }.getOrElse { throwable ->
+            grantFailureResult(
                 phase = Keystore2PrivateGrantPhase.PRIVATE_GET_KEY_ENTRY_GRANT,
-                emptyDetail = "private getKeyEntry(GRANT) returned an empty certificate chain.",
-                successDetailPrefix = "private getKeyEntry(GRANT)",
+                detail = "private getKeyEntry(GRANT) failed: ${describeThrowable(throwable)}",
+                errorKind = classifyFailure(throwable),
+                throwable = throwable,
+            )
+        }
+    }
+
+    fun readGrantEntry(service: Any, grantId: Long): Keystore2PrivateGrantResult {
+        return runCatching {
+            val constants = resolveConstants()
+            val descriptor = createDescriptor(grantId, constants.domainGrant)
+            service.javaClass
+                .getMethod("getKeyEntry", descriptor.javaClass)
+                .also { it.isAccessible = true }
+                .invoke(service, descriptor)
+                ?: return@runCatching Keystore2PrivateGrantResult.unavailable(
+                    phase = Keystore2PrivateGrantPhase.PRIVATE_OWNER_REPLAY_GRANT,
+                    detail = "private owner replay getKeyEntry(GRANT) returned no KeyEntryResponse.",
+                )
+            Keystore2PrivateGrantResult(
+                available = true,
+                phase = Keystore2PrivateGrantPhase.PRIVATE_OWNER_REPLAY_GRANT,
+                detail = "private owner replay getKeyEntry(GRANT) returned a response.",
+            )
+        }.getOrElse { throwable ->
+            Keystore2PrivateGrantResult.unavailable(
+                phase = Keystore2PrivateGrantPhase.PRIVATE_OWNER_REPLAY_GRANT,
+                errorKind = classifyFailure(throwable),
+                detail = "private owner replay getKeyEntry(GRANT) failed: ${describeThrowable(throwable)}",
+                throwable = throwable,
             )
         }
     }
@@ -241,6 +265,95 @@ class Keystore2PrivateGrantClient(
             phase = phase,
             chain = chain,
             detail = "$successDetailPrefix chainLength=${chain.certificates.size}",
+        )
+    }
+
+    private fun grantAliasToUid(
+        service: Any,
+        alias: String,
+        uid: Int,
+        constants: Keystore2PrivateGrantConstants,
+    ): Keystore2PrivateGrantResult {
+        val descriptor = createDescriptor(alias, constants.domainApp)
+        val grantDescriptor = service.javaClass.methods
+            .firstOrNull { method ->
+                method.name == "grant" &&
+                    method.parameterTypes.size == 3 &&
+                    method.parameterTypes[1] == Int::class.javaPrimitiveType &&
+                    method.parameterTypes[2] == Int::class.javaPrimitiveType
+            }
+            ?.also { it.isAccessible = true }
+            ?.invoke(service, descriptor, uid, constants.grantAccessVector)
+            ?: return Keystore2PrivateGrantResult.unavailable(
+                phase = Keystore2PrivateGrantPhase.PRIVATE_GRANT,
+                detail = "private grant failed: hidden grant() returned no descriptor.",
+            )
+        val grantId = readLongField(grantDescriptor, "nspace")
+        if (grantId == null) {
+            return Keystore2PrivateGrantResult.unavailable(
+                phase = Keystore2PrivateGrantPhase.PRIVATE_GRANT,
+                detail = "private grant failed: hidden grant() returned invalid grant namespace.",
+            )
+        }
+        return Keystore2PrivateGrantResult(
+            available = true,
+            phase = Keystore2PrivateGrantPhase.PRIVATE_GRANT,
+            grantId = grantId,
+            detail = "private grant created grantId=$grantId unsignedGrantId=${java.lang.Long.toUnsignedString(grantId)} accessVector=${constants.grantAccessVector}",
+        )
+    }
+
+    private fun revokeAliasGrant(
+        service: Any,
+        alias: String,
+        uid: Int,
+        constants: Keystore2PrivateGrantConstants,
+    ): Keystore2PrivateGrantResult {
+        val descriptor = createDescriptor(alias, constants.domainApp)
+        val method = service.javaClass.methods
+            .firstOrNull { candidate ->
+                candidate.name == "ungrant" &&
+                    candidate.parameterTypes.size == 2 &&
+                    candidate.parameterTypes[1] == Int::class.javaPrimitiveType
+            }
+            ?: return Keystore2PrivateGrantResult.unavailable(
+                phase = Keystore2PrivateGrantPhase.PRIVATE_UNGRANT,
+                detail = "private ungrant failed: hidden ungrant() was unavailable.",
+            )
+        method.isAccessible = true
+        method.invoke(service, descriptor, uid)
+        return Keystore2PrivateGrantResult(
+            available = true,
+            phase = Keystore2PrivateGrantPhase.PRIVATE_UNGRANT,
+            detail = "private ungrant completed uid=$uid",
+        )
+    }
+
+    private fun readOwnerChain(
+        service: Any,
+        alias: String,
+        constants: Keystore2PrivateGrantConstants,
+    ): Keystore2PrivateGrantChainResult {
+        return readChainFromDescriptor(
+            service = service,
+            descriptor = createDescriptor(alias, constants.domainApp),
+            phase = Keystore2PrivateGrantPhase.PRIVATE_GET_KEY_ENTRY_APP,
+            emptyDetail = "private getKeyEntry(APP) returned an empty certificate chain.",
+            successDetailPrefix = "private getKeyEntry(APP)",
+        )
+    }
+
+    private fun readGrantChain(
+        service: Any,
+        grantId: Long,
+        constants: Keystore2PrivateGrantConstants,
+    ): Keystore2PrivateGrantChainResult {
+        return readChainFromDescriptor(
+            service = service,
+            descriptor = createDescriptor(grantId, constants.domainGrant),
+            phase = Keystore2PrivateGrantPhase.PRIVATE_GET_KEY_ENTRY_GRANT,
+            emptyDetail = "private getKeyEntry(GRANT) returned an empty certificate chain.",
+            successDetailPrefix = "private getKeyEntry(GRANT)",
         )
     }
 
@@ -570,6 +683,7 @@ enum class Keystore2PrivateGrantPhase {
     PRIVATE_GRANT,
     PRIVATE_GET_KEY_ENTRY_APP,
     PRIVATE_GET_KEY_ENTRY_GRANT,
+    PRIVATE_OWNER_REPLAY_GRANT,
     ISOLATED_BINDER_READBACK,
     PRIVATE_UNGRANT,
 }

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/Keystore2PrivateGrantClient.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/Keystore2PrivateGrantClient.kt
@@ -30,6 +30,10 @@ class Keystore2PrivateGrantClient(
 
     fun lookupBinder(): IBinder? = binderClient.lookupBinder()
 
+    fun constantsSnapshot(): Keystore2PrivateGrantConstants {
+        return resolveConstants()
+    }
+
     fun grantAliasToUid(alias: String, uid: Int): Keystore2PrivateGrantResult {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             return Keystore2PrivateGrantResult.unavailable(
@@ -47,7 +51,33 @@ class Keystore2PrivateGrantClient(
 
     fun grantAliasToUid(service: Any, alias: String, uid: Int): Keystore2PrivateGrantResult {
         return runCatching {
-            grantAliasToUid(service, alias, uid, resolveConstants())
+            val constants = resolveConstants()
+            grantAliasToUid(
+                service = service,
+                alias = alias,
+                uid = uid,
+                accessVector = constants.grantAccessVector,
+                constants = constants,
+            )
+        }.getOrElse { throwable ->
+            grantFailureResult(
+                phase = Keystore2PrivateGrantPhase.PRIVATE_GRANT,
+                detail = "private grant failed: ${describeThrowable(throwable)}",
+                errorKind = classifyFailure(throwable),
+                throwable = throwable,
+            )
+        }
+    }
+
+    fun grantAliasToUid(
+        service: Any,
+        alias: String,
+        uid: Int,
+        accessVector: Int,
+    ): Keystore2PrivateGrantResult {
+        return runCatching {
+            val constants = resolveConstants()
+            grantAliasToUid(service, alias, uid, accessVector, constants)
         }.getOrElse { throwable ->
             grantFailureResult(
                 phase = Keystore2PrivateGrantPhase.PRIVATE_GRANT,
@@ -274,6 +304,22 @@ class Keystore2PrivateGrantClient(
         uid: Int,
         constants: Keystore2PrivateGrantConstants,
     ): Keystore2PrivateGrantResult {
+        return grantAliasToUid(
+            service = service,
+            alias = alias,
+            uid = uid,
+            accessVector = constants.grantAccessVector,
+            constants = constants,
+        )
+    }
+
+    private fun grantAliasToUid(
+        service: Any,
+        alias: String,
+        uid: Int,
+        accessVector: Int,
+        constants: Keystore2PrivateGrantConstants,
+    ): Keystore2PrivateGrantResult {
         val descriptor = createDescriptor(alias, constants.domainApp)
         val grantDescriptor = service.javaClass.methods
             .firstOrNull { method ->
@@ -283,7 +329,7 @@ class Keystore2PrivateGrantClient(
                     method.parameterTypes[2] == Int::class.javaPrimitiveType
             }
             ?.also { it.isAccessible = true }
-            ?.invoke(service, descriptor, uid, constants.grantAccessVector)
+            ?.invoke(service, descriptor, uid, accessVector)
             ?: return Keystore2PrivateGrantResult.unavailable(
                 phase = Keystore2PrivateGrantPhase.PRIVATE_GRANT,
                 detail = "private grant failed: hidden grant() returned no descriptor.",
@@ -299,7 +345,7 @@ class Keystore2PrivateGrantClient(
             available = true,
             phase = Keystore2PrivateGrantPhase.PRIVATE_GRANT,
             grantId = grantId,
-            detail = "private grant created grantId=$grantId unsignedGrantId=${java.lang.Long.toUnsignedString(grantId)} accessVector=${constants.grantAccessVector}",
+            detail = "private grant created grantId=$grantId unsignedGrantId=${java.lang.Long.toUnsignedString(grantId)} accessVector=$accessVector",
         )
     }
 

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/SyntheticGrantGetKeyEntryAccessVectorBlindnessProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/SyntheticGrantGetKeyEntryAccessVectorBlindnessProbe.kt
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.verification.keystore
+
+import android.content.Context
+import android.os.Build
+
+class SyntheticGrantGetKeyEntryAccessVectorBlindnessProbe(
+    context: Context,
+    private val granteeManager: TeeGrantDomainGranteeManager = TeeGrantDomainGranteeManager(context),
+    private val binderClient: Keystore2PrivateBinderClient = Keystore2PrivateBinderClient(),
+    private val privateGrantClient: Keystore2PrivateGrantClient = Keystore2PrivateGrantClient(),
+) {
+
+    suspend fun inspect(useStrongBox: Boolean): SyntheticGrantGetKeyEntryAccessVectorBlindnessResult {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                detail = "Grant access-vector private binder probe requires Android 12 or newer.",
+            )
+        }
+        val alias = "duck_grant_access_vector_${System.nanoTime()}"
+        val diagnostics = GrantDetectionDiagnosticLog(
+            title = "Grant access-vector diagnostic alias=$alias",
+        )
+        val granteeResult = granteeManager.openSession()
+        if (!granteeResult.available || granteeResult.session == null) {
+            diagnostics.add("isolated-session", granteeResult.detail)
+            return SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                detail = "Private: isolated grantee unavailable.",
+                diagnosticCopyText = diagnostics.text(),
+            )
+        }
+
+        return granteeResult.session.use { granteeSession ->
+            val privateSessionResult = binderClient.openSession(useStrongBox = useStrongBox)
+            val privateSession = privateSessionResult.session ?: return@use SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                granteeUid = granteeSession.uid,
+                detail = privateSessionResult.failureReason
+                    ?: "Private: owner Keystore2 binder session unavailable.",
+                diagnosticCopyText = diagnostics.text(),
+            )
+            val requestedDescriptor = binderClient.createKeyDescriptor(alias)
+            var followUpDescriptor: Any = requestedDescriptor
+            var grantCreated = false
+            var result = SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                granteeUid = granteeSession.uid,
+                detail = "Private: grant access-vector probe did not complete.",
+            )
+            try {
+                result = run privateCycle@{
+                    val generated = runCatching {
+                        binderClient.generateSigningKey(
+                            securityLevel = privateSession.securityLevel,
+                            keyDescriptor = requestedDescriptor,
+                            attestationKeyDescriptor = null,
+                            attest = true,
+                        )
+                    }.getOrElse { throwable ->
+                        diagnostics.addThrowable("private-generate", throwable)
+                        return@privateCycle SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                            granteeUid = granteeSession.uid,
+                            detail = "Private: owner key generation failed (${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}).",
+                        )
+                    }
+                    followUpDescriptor = binderClient.resolveFollowUpDescriptor(requestedDescriptor, generated)
+
+                    val ownerResult = privateGrantClient.readOwnerChain(privateSession.service, alias)
+                    ownerResult.throwable?.let { diagnostics.addThrowable("private-owner-chain", it) }
+                    if (!ownerResult.available) {
+                        return@privateCycle SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                            granteeUid = granteeSession.uid,
+                            detail = ownerResult.detail,
+                        )
+                    }
+
+                    val accessVector = privateGrantClient.constantsSnapshot().permissionUse
+                    val grantResult = privateGrantClient.grantAliasToUid(
+                        service = privateSession.service,
+                        alias = alias,
+                        uid = granteeSession.uid,
+                        accessVector = accessVector,
+                    )
+                    grantResult.throwable?.let { diagnostics.addThrowable("private-grant-use-only", it) }
+                    val grantId = grantResult.grantId
+                    if (!grantResult.available || grantId == null) {
+                        return@privateCycle SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                            granteeUid = granteeSession.uid,
+                            accessVector = accessVector,
+                            detail = grantResult.detail,
+                        )
+                    }
+                    grantCreated = true
+
+                    val granteeRead = granteeSession.readGrantedCertificateChain(grantId, privateSession.binder)
+                    granteeRead.diagnosticCopyText.takeIf { it.isNotBlank() }?.let(diagnostics::addRaw)
+                    evaluateGranteeReadback(
+                        granteeUid = granteeSession.uid,
+                        accessVector = accessVector,
+                        granteeRead = granteeRead,
+                    )
+                }
+            } catch (throwable: Throwable) {
+                diagnostics.addThrowable("probe-failure", throwable)
+                result = SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                    executed = grantCreated,
+                    grantCreated = grantCreated,
+                    granteeUid = granteeSession.uid,
+                    detail = "Grant access-vector private binder probe failed: ${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}",
+                )
+            } finally {
+                if (grantCreated) {
+                    val revoke = privateGrantClient.revokeAliasGrant(
+                        service = privateSession.service,
+                        alias = alias,
+                        uid = granteeSession.uid,
+                    )
+                    revoke.throwable?.let { diagnostics.addThrowable("private-revoke", it) }
+                    if (!revoke.available) {
+                        result = result.copy(
+                            detail = appendGrantDetail(result.detail, revoke.detail),
+                        )
+                    }
+                }
+                binderClient.deleteKeyChecked(privateSession.service, followUpDescriptor)?.let { throwable ->
+                    diagnostics.addThrowable("private-delete", throwable)
+                    result = result.copy(
+                        detail = appendGrantDetail(
+                            result.detail,
+                            "Private cleanup deleteKey failed (${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}).",
+                        ),
+                    )
+                }
+                binderClient.closeSession(privateSession)
+            }
+            result.copy(diagnosticCopyText = diagnostics.text())
+        }
+    }
+
+    companion object {
+        fun skippedAfterExistingGrantDanger(): SyntheticGrantGetKeyEntryAccessVectorBlindnessResult {
+            return SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                anomalyKind = SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.SKIPPED_AFTER_EXISTING_GRANT_DANGER,
+                detail = "Skipped because an existing grant detector already reported danger.",
+            )
+        }
+
+        internal fun evaluateGranteeReadback(
+            granteeUid: Int,
+            accessVector: Int,
+            granteeRead: TeeGrantDomainGranteeChainResult,
+        ): SyntheticGrantGetKeyEntryAccessVectorBlindnessResult {
+            return when {
+                granteeRead.available -> SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                    executed = true,
+                    available = true,
+                    grantCreated = true,
+                    granteeUid = granteeUid,
+                    accessVector = accessVector,
+                    granteeReadSucceeded = true,
+                    granteeReadErrorKind = Keystore2PrivateGrantErrorKind.NONE,
+                    anomalyKind = SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.GET_KEY_ENTRY_WITHOUT_GET_INFO_ALLOWED,
+                    detail = "Private: grantee getKeyEntry(GRANT) succeeded without GET_INFO.",
+                )
+                granteeRead.errorKind == Keystore2PrivateGrantErrorKind.PERMISSION_DENIED ->
+                    SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                        executed = true,
+                        available = true,
+                        grantCreated = true,
+                        granteeUid = granteeUid,
+                        accessVector = accessVector,
+                        granteeReadErrorKind = granteeRead.errorKind,
+                        anomalyKind = SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.NONE,
+                        detail = "Private: grantee getKeyEntry(GRANT) rejected with PERMISSION_DENIED.",
+                    )
+                else -> SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                    executed = true,
+                    grantCreated = true,
+                    granteeUid = granteeUid,
+                    accessVector = accessVector,
+                    granteeReadErrorKind = granteeRead.errorKind,
+                    detail = "Private: grantee readback unavailable (${visibleGrantDetail(granteeRead.detail)}).",
+                )
+            }
+        }
+    }
+}
+
+data class SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+    val executed: Boolean = false,
+    val available: Boolean = false,
+    val grantCreated: Boolean = false,
+    val granteeUid: Int? = null,
+    val accessVector: Int? = null,
+    val granteeReadSucceeded: Boolean = false,
+    val granteeReadErrorKind: Keystore2PrivateGrantErrorKind? = null,
+    val anomalyKind: SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind =
+        SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.UNAVAILABLE,
+    val detail: String = "",
+    val diagnosticCopyText: String = "",
+)
+
+enum class SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind {
+    NONE,
+    GET_KEY_ENTRY_WITHOUT_GET_INFO_ALLOWED,
+    SKIPPED_AFTER_EXISTING_GRANT_DANGER,
+    UNAVAILABLE,
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/SyntheticGrantGranteeBlindReadbackProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/SyntheticGrantGranteeBlindReadbackProbe.kt
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.verification.keystore
+
+import android.content.Context
+import android.os.Build
+
+class SyntheticGrantGranteeBlindReadbackProbe(
+    context: Context,
+    private val granteeManager: TeeGrantDomainGranteeManager = TeeGrantDomainGranteeManager(context),
+    private val binderClient: Keystore2PrivateBinderClient = Keystore2PrivateBinderClient(),
+    private val privateGrantClient: Keystore2PrivateGrantClient = Keystore2PrivateGrantClient(),
+) {
+
+    suspend fun inspect(useStrongBox: Boolean): SyntheticGrantGranteeBlindReadbackResult {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return SyntheticGrantGranteeBlindReadbackResult(
+                detail = "Grant caller-binding private binder probe requires Android 12 or newer.",
+            )
+        }
+        val alias = "duck_grant_binding_${System.nanoTime()}"
+        val diagnostics = GrantDetectionDiagnosticLog(
+            title = "Grant caller-binding diagnostic alias=$alias",
+        )
+        val granteeResult = granteeManager.openSession()
+        if (!granteeResult.available || granteeResult.session == null) {
+            diagnostics.add("isolated-session", granteeResult.detail)
+            return SyntheticGrantGranteeBlindReadbackResult(
+                detail = "Private: isolated grantee unavailable.",
+                diagnosticCopyText = diagnostics.text(),
+            )
+        }
+
+        return granteeResult.session.use { granteeSession ->
+            val privateSessionResult = binderClient.openSession(useStrongBox = useStrongBox)
+            val privateSession = privateSessionResult.session ?: return@use SyntheticGrantGranteeBlindReadbackResult(
+                granteeUid = granteeSession.uid,
+                detail = privateSessionResult.failureReason
+                    ?: "Private: owner Keystore2 binder session unavailable.",
+                diagnosticCopyText = diagnostics.text(),
+            )
+            val requestedDescriptor = binderClient.createKeyDescriptor(alias)
+            var followUpDescriptor: Any = requestedDescriptor
+            var grantCreated = false
+            var result = SyntheticGrantGranteeBlindReadbackResult(
+                granteeUid = granteeSession.uid,
+                detail = "Private: grant caller-binding probe did not complete.",
+            )
+            try {
+                result = run privateCycle@{
+                    val generated = runCatching {
+                        binderClient.generateSigningKey(
+                            securityLevel = privateSession.securityLevel,
+                            keyDescriptor = requestedDescriptor,
+                            attestationKeyDescriptor = null,
+                            attest = true,
+                        )
+                    }.getOrElse { throwable ->
+                        diagnostics.addThrowable("private-generate", throwable)
+                        return@privateCycle SyntheticGrantGranteeBlindReadbackResult(
+                            granteeUid = granteeSession.uid,
+                            detail = "Private: owner key generation failed (${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}).",
+                        )
+                    }
+                    followUpDescriptor = binderClient.resolveFollowUpDescriptor(requestedDescriptor, generated)
+
+                    val ownerResult = privateGrantClient.readOwnerChain(privateSession.service, alias)
+                    ownerResult.throwable?.let { diagnostics.addThrowable("private-owner-chain", it) }
+                    if (!ownerResult.available) {
+                        return@privateCycle SyntheticGrantGranteeBlindReadbackResult(
+                            granteeUid = granteeSession.uid,
+                            detail = ownerResult.detail,
+                        )
+                    }
+
+                    val grantResult = privateGrantClient.grantAliasToUid(
+                        service = privateSession.service,
+                        alias = alias,
+                        uid = granteeSession.uid,
+                    )
+                    grantResult.throwable?.let { diagnostics.addThrowable("private-grant", it) }
+                    val grantId = grantResult.grantId
+                    if (!grantResult.available || grantId == null) {
+                        return@privateCycle SyntheticGrantGranteeBlindReadbackResult(
+                            granteeUid = granteeSession.uid,
+                            detail = grantResult.detail,
+                        )
+                    }
+                    grantCreated = true
+
+                    val allowedRead = granteeSession.readGrantedCertificateChain(grantId, privateSession.binder)
+                    allowedRead.diagnosticCopyText.takeIf { it.isNotBlank() }?.let(diagnostics::addRaw)
+                    if (!allowedRead.available) {
+                        return@privateCycle SyntheticGrantGranteeBlindReadbackResult(
+                            executed = true,
+                            grantCreated = true,
+                            granteeUid = granteeSession.uid,
+                            detail = "Private: grantee readback unavailable (${visibleGrantDetail(allowedRead.detail)}).",
+                        )
+                    }
+
+                    val ownerReplay = privateGrantClient.readGrantEntry(privateSession.service, grantId)
+                    ownerReplay.throwable?.let { diagnostics.addThrowable("private-owner-replay", it) }
+                    evaluateOwnerReplay(
+                        granteeUid = granteeSession.uid,
+                        ownerReplay = ownerReplay,
+                    )
+                }
+            } catch (throwable: Throwable) {
+                diagnostics.addThrowable("probe-failure", throwable)
+                result = SyntheticGrantGranteeBlindReadbackResult(
+                    executed = grantCreated,
+                    grantCreated = grantCreated,
+                    granteeUid = granteeSession.uid,
+                    detail = "Grant caller-binding private binder probe failed: ${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}",
+                )
+            } finally {
+                if (grantCreated) {
+                    val revoke = privateGrantClient.revokeAliasGrant(
+                        service = privateSession.service,
+                        alias = alias,
+                        uid = granteeSession.uid,
+                    )
+                    revoke.throwable?.let { diagnostics.addThrowable("private-revoke", it) }
+                    if (!revoke.available) {
+                        result = result.copy(
+                            detail = appendGrantDetail(result.detail, revoke.detail),
+                        )
+                    }
+                }
+                binderClient.deleteKeyChecked(privateSession.service, followUpDescriptor)?.let { throwable ->
+                    diagnostics.addThrowable("private-delete", throwable)
+                    result = result.copy(
+                        detail = appendGrantDetail(
+                            result.detail,
+                            "Private cleanup deleteKey failed (${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}).",
+                        ),
+                    )
+                }
+                binderClient.closeSession(privateSession)
+            }
+            result.copy(diagnosticCopyText = diagnostics.text())
+        }
+    }
+
+    companion object {
+        fun skippedAfterExistingGrantDanger(): SyntheticGrantGranteeBlindReadbackResult {
+            return SyntheticGrantGranteeBlindReadbackResult(
+                anomalyKind = SyntheticGrantGranteeBlindReadbackAnomalyKind.SKIPPED_AFTER_EXISTING_GRANT_DANGER,
+                detail = "Skipped because an existing grant detector already reported danger.",
+            )
+        }
+
+        internal fun evaluateOwnerReplay(
+            granteeUid: Int,
+            ownerReplay: Keystore2PrivateGrantResult,
+        ): SyntheticGrantGranteeBlindReadbackResult {
+            return when {
+                ownerReplay.available -> SyntheticGrantGranteeBlindReadbackResult(
+                    executed = true,
+                    available = true,
+                    grantCreated = true,
+                    granteeUid = granteeUid,
+                    granteeReadSucceeded = true,
+                    ownerReplaySucceeded = true,
+                    ownerReplayErrorKind = Keystore2PrivateGrantErrorKind.NONE,
+                    anomalyKind = SyntheticGrantGranteeBlindReadbackAnomalyKind.NON_GRANTEE_READBACK_ALLOWED,
+                    detail = "Private: non-grantee owner replay succeeded for isolated grant handle.",
+                )
+                ownerReplay.errorKind == Keystore2PrivateGrantErrorKind.KEY_NOT_FOUND ->
+                    SyntheticGrantGranteeBlindReadbackResult(
+                        executed = true,
+                        available = true,
+                        grantCreated = true,
+                        granteeUid = granteeUid,
+                        granteeReadSucceeded = true,
+                        ownerReplayErrorKind = ownerReplay.errorKind,
+                        anomalyKind = SyntheticGrantGranteeBlindReadbackAnomalyKind.NONE,
+                        detail = "Private: owner replay rejected with KEY_NOT_FOUND.",
+                    )
+                else -> SyntheticGrantGranteeBlindReadbackResult(
+                    executed = true,
+                    grantCreated = true,
+                    granteeUid = granteeUid,
+                    granteeReadSucceeded = true,
+                    ownerReplayErrorKind = ownerReplay.errorKind,
+                    detail = "Private: owner replay unavailable (${ownerReplay.detail}).",
+                )
+            }
+        }
+    }
+}
+
+data class SyntheticGrantGranteeBlindReadbackResult(
+    val executed: Boolean = false,
+    val available: Boolean = false,
+    val grantCreated: Boolean = false,
+    val granteeUid: Int? = null,
+    val granteeReadSucceeded: Boolean = false,
+    val ownerReplaySucceeded: Boolean = false,
+    val ownerReplayErrorKind: Keystore2PrivateGrantErrorKind? = null,
+    val anomalyKind: SyntheticGrantGranteeBlindReadbackAnomalyKind =
+        SyntheticGrantGranteeBlindReadbackAnomalyKind.UNAVAILABLE,
+    val detail: String = "",
+    val diagnosticCopyText: String = "",
+)
+
+enum class SyntheticGrantGranteeBlindReadbackAnomalyKind {
+    NONE,
+    NON_GRANTEE_READBACK_ALLOWED,
+    SKIPPED_AFTER_EXISTING_GRANT_DANGER,
+    UNAVAILABLE,
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/TeeGrantDomainGranteeService.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/TeeGrantDomainGranteeService.kt
@@ -97,6 +97,7 @@ class TeeGrantDomainGranteeService : Service() {
             val result = Keystore2PrivateGrantClient().readGrantChain(keystore2Binder, grantId)
             TeeGrantDomainGranteeChainResult(
                 available = result.available,
+                errorKind = result.errorKind,
                 chain = result.chain,
                 detail = result.detail.ifBlank { "isolated private binder readback blocked." },
                 diagnosticCopyText = result.throwable
@@ -107,6 +108,11 @@ class TeeGrantDomainGranteeService : Service() {
         }.getOrElse { throwable ->
             TeeGrantDomainGranteeChainResult(
                 available = false,
+                errorKind = classifyKeystore2PrivateGrantFailure(
+                    throwableClassName = throwable.rootCauseClassName(),
+                    message = throwable.rootCauseMessage(),
+                    serviceSpecificErrorCode = throwable.serviceSpecificErrorCode(),
+                ),
                 detail = "isolated binder call blocked: ${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}",
                 diagnosticCopyText = throwable.stackTraceToString().trim(),
             )
@@ -147,11 +153,43 @@ class TeeGrantDomainGranteeService : Service() {
         }.getOrElse { throwable ->
             TeeGrantDomainGranteeChainResult(
                 available = false,
+                errorKind = classifyKeystore2PrivateGrantFailure(
+                    throwableClassName = throwable.rootCauseClassName(),
+                    message = throwable.rootCauseMessage(),
+                    serviceSpecificErrorCode = throwable.serviceSpecificErrorCode(),
+                ),
                 detail = "$stage isolated readback failed: ${GrantDomainFullChainSplitProbe.describeThrowable(throwable)}",
                 diagnosticCopyText = throwable.stackTraceToString().trim(),
             )
         }
     }
+}
+
+private fun Throwable.rootCause(): Throwable {
+    var current = this
+    while (current.cause != null && current.cause !== current) {
+        current = current.cause!!
+    }
+    return current
+}
+
+private fun Throwable.rootCauseClassName(): String = rootCause().javaClass.name
+
+private fun Throwable.rootCauseMessage(): String? = rootCause().message
+
+private fun Throwable.serviceSpecificErrorCode(): Int? {
+    var current: Throwable? = this
+    while (current != null) {
+        if (current.javaClass.name == "android.os.ServiceSpecificException") {
+            return runCatching {
+                val field = current.javaClass.getField("errorCode")
+                field.isAccessible = true
+                field.get(current) as? Int
+            }.getOrNull()
+        }
+        current = current.cause
+    }
+    return null
 }
 
 object TeeGrantDomainGranteeProtocol {
@@ -164,6 +202,7 @@ object TeeGrantDomainGranteeProtocol {
 
 data class TeeGrantDomainGranteeChainResult(
     val available: Boolean = false,
+    val errorKind: Keystore2PrivateGrantErrorKind = Keystore2PrivateGrantErrorKind.NONE,
     val chain: GrantDomainCertificateChain = GrantDomainCertificateChain(),
     val detail: String = "",
     val diagnosticCopyText: String = "",
@@ -171,6 +210,7 @@ data class TeeGrantDomainGranteeChainResult(
     fun writeToParcel(reply: Parcel?) {
         reply ?: return
         reply.writeInt(if (available) 1 else 0)
+        reply.writeString(errorKind.name)
         reply.writeInt(chain.certificates.size)
         chain.certificates.forEach { certificate ->
             reply.writeInt(certificate.derLength)
@@ -183,6 +223,9 @@ data class TeeGrantDomainGranteeChainResult(
     companion object {
         fun readFromParcel(reply: Parcel): TeeGrantDomainGranteeChainResult {
             val available = reply.readInt() != 0
+            val errorKind = runCatching {
+                Keystore2PrivateGrantErrorKind.valueOf(reply.readString().orEmpty())
+            }.getOrDefault(Keystore2PrivateGrantErrorKind.SERVICE_UNAVAILABLE)
             val size = reply.readInt().coerceAtLeast(0)
             val certificates = buildList {
                 repeat(size) {
@@ -196,6 +239,7 @@ data class TeeGrantDomainGranteeChainResult(
             }
             return TeeGrantDomainGranteeChainResult(
                 available = available,
+                errorKind = errorKind,
                 chain = GrantDomainCertificateChain(certificates),
                 detail = reply.readString().orEmpty(),
                 diagnosticCopyText = reply.readString().orEmpty(),

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapper.kt
@@ -149,7 +149,11 @@ class TeeCardModelMapper {
         }
 
     private fun TeeReport.topFindingDetail(): String? {
-        if (!summary.contains("Grant self-domain") && !summary.contains("Grant isolated-domain")) {
+        if (
+            !summary.contains("Grant self-domain") &&
+            !summary.contains("Grant isolated-domain") &&
+            !summary.contains("Grant handle")
+        ) {
             return null
         }
         // Grant stage details can include Java/hidden/private summaries. Keep that audit text inside
@@ -160,14 +164,22 @@ class TeeCardModelMapper {
             .flatMap { section -> section.items.asSequence() }
             .firstOrNull { item ->
                 item.level == TeeSignalLevel.FAIL &&
-                    (item.title == "Grant self-domain" || item.title == "Grant isolated-domain")
+                    (
+                        item.title == "Grant self-domain" ||
+                            item.title == "Grant isolated-domain" ||
+                            item.title == "Grant caller binding"
+                        )
             }
             ?: sections
                 .asSequence()
                 .flatMap { section -> section.items.asSequence() }
                 .firstOrNull { item ->
                     item.level == TeeSignalLevel.WARN &&
-                        (item.title == "Grant self-domain" || item.title == "Grant isolated-domain")
+                        (
+                            item.title == "Grant self-domain" ||
+                                item.title == "Grant isolated-domain" ||
+                                item.title == "Grant caller binding"
+                            )
                 }
                 ?: return null
 
@@ -188,6 +200,8 @@ class TeeCardModelMapper {
             } else {
                 "Grant isolated-domain certificate chain diverged; open TEE details for stage diagnostics."
             }
+            "Grant caller binding" ->
+                "Grant handle caller binding failed; open TEE details for stage diagnostics."
             else -> null
         }
     }

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
@@ -27,6 +27,8 @@ import com.eltavine.duckdetector.features.tee.data.verification.certificate.Chai
 import com.eltavine.duckdetector.features.tee.data.verification.certificate.CertificateTrustResult
 import com.eltavine.duckdetector.features.tee.data.verification.certificate.DualAlgorithmChainResult
 import com.eltavine.duckdetector.features.tee.data.verification.crl.CrlStatusResult
+import com.eltavine.duckdetector.features.tee.data.verification.crl.RevokedCertificate
+import com.eltavine.duckdetector.features.tee.data.verification.crl.RevokedCertificateEvidenceKind
 import com.eltavine.duckdetector.features.tee.data.verification.boot.BootConsistencyResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.IdAttestationResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.AesGcmRoundTripResult
@@ -1814,6 +1816,66 @@ class TeeReportReducerTest {
     }
 
     @Test
+    fun `local mass abuse revocation is warning not tampered`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                networkState = TeeNetworkState(
+                    mode = TeeNetworkMode.SKIPPED,
+                    summary = "Built-in revocation snapshot is active; online refresh is disabled in Settings.",
+                    cacheEntries = 1,
+                    usedCache = true,
+                ),
+                crlRevokedCertificates = listOf(
+                    RevokedCertificate(
+                        serial = "8616ef30679ed43cc2b43e3c97a2319e / 178194732304493...",
+                        reason = "MASS_ABUSE",
+                        evidenceKind = RevokedCertificateEvidenceKind.LOCAL_MASS_ABUSE,
+                    )
+                ),
+            ),
+        )
+
+        assertEquals(TeeVerdict.SUSPICIOUS, report.verdict)
+        assertTrue(report.summary.contains("mass abuse", ignoreCase = true))
+        assertTrue(report.sections.single { it.title == "Trust" }.items.any {
+            it.title == "CRL" &&
+                    it.body.contains("mass abuse", ignoreCase = true) &&
+                    it.level == TeeSignalLevel.WARN
+        })
+        assertTrue(report.signals.any {
+            it.label == "CRL" && it.value == "Mass abuse" && it.level == TeeSignalLevel.WARN
+        })
+    }
+
+    @Test
+    fun `standard crl revocation remains tampered`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                networkState = TeeNetworkState(
+                    mode = TeeNetworkMode.ACTIVE,
+                    summary = "Online revocation data refreshed successfully.",
+                ),
+                crlRevokedCertificates = listOf(
+                    RevokedCertificate(
+                        serial = "8616ef30679ed43cc2b43e3c97a2319e / 178194732304493...",
+                        reason = "KEY_COMPROMISE",
+                    )
+                ),
+            ),
+        )
+
+        assertEquals(TeeVerdict.TAMPERED, report.verdict)
+        assertTrue(report.sections.single { it.title == "Trust" }.items.any {
+            it.title == "CRL" &&
+                    it.body.contains("revoked", ignoreCase = true) &&
+                    it.level == TeeSignalLevel.FAIL
+        })
+        assertTrue(report.signals.any {
+            it.label == "CRL" && it.value == "Revoked" && it.level == TeeSignalLevel.FAIL
+        })
+    }
+
+    @Test
     fun `refresh failed crl state is surfaced as degraded`() {
         val report = reducer.reduce(
             baseArtifacts(
@@ -2033,6 +2095,7 @@ class TeeReportReducerTest {
             mode = TeeNetworkMode.INACTIVE,
             summary = "Offline-only verification",
         ),
+        crlRevokedCertificates: List<RevokedCertificate> = emptyList(),
         trust: CertificateTrustResult = CertificateTrustResult(
             trustRoot = TeeTrustRoot.GOOGLE,
             chainLength = 3,
@@ -2148,6 +2211,7 @@ class TeeReportReducerTest {
             rkp = rkp,
             crl = CrlStatusResult(
                 networkState = networkState,
+                revokedCertificates = crlRevokedCertificates,
             ),
             pairConsistency = KeyPairConsistencyResult(
                 keyMatchesCertificate = true,

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
@@ -40,6 +40,8 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDo
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitResult
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGetKeyEntryAccessVectorBlindnessResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationAnomalyKind
@@ -471,6 +473,64 @@ class TeeReportReducerTest {
             it.title == "Grant caller binding" &&
                 it.level == TeeSignalLevel.PASS &&
                 it.body.contains("ownerReplay=KEY_NOT_FOUND")
+        })
+    }
+
+    @Test
+    fun `grant access vector missing get info readback becomes supplementary danger`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                syntheticGrantGetKeyEntryAccessVectorBlindness =
+                    SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                        executed = true,
+                        available = true,
+                        grantCreated = true,
+                        granteeUid = 99001,
+                        accessVector = 0x100,
+                        granteeReadSucceeded = true,
+                        anomalyKind =
+                            SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.GET_KEY_ENTRY_WITHOUT_GET_INFO_ALLOWED,
+                        detail = "Private: grantee getKeyEntry(GRANT) succeeded without GET_INFO.",
+                        diagnosticCopyText = "grant access-vector diagnostic",
+                    ),
+            ),
+        )
+
+        assertEquals(TeeVerdict.CONSISTENT, report.verdict)
+        assertEquals(1, report.supplementaryIndicatorCount)
+        assertEquals(TeeSignalLevel.FAIL, report.supplementaryReviewLevel)
+        assertTrue(report.summary.contains("without GET_INFO", ignoreCase = true))
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "Grant access vector" &&
+                it.level == TeeSignalLevel.FAIL &&
+                it.body.contains("GET_KEY_ENTRY_WITHOUT_GET_INFO_ALLOWED") &&
+                it.body.contains("accessVector=256") &&
+                it.hiddenCopyText == "grant access-vector diagnostic"
+        })
+    }
+
+    @Test
+    fun `grant access vector permission denied readback stays clean`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                syntheticGrantGetKeyEntryAccessVectorBlindness =
+                    SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                        executed = true,
+                        available = true,
+                        grantCreated = true,
+                        granteeUid = 99001,
+                        accessVector = 0x100,
+                        anomalyKind = SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.NONE,
+                        detail = "Private: grantee getKeyEntry(GRANT) rejected with PERMISSION_DENIED.",
+                    ),
+            ),
+        )
+
+        assertEquals(0, report.supplementaryIndicatorCount)
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "Grant access vector" &&
+                it.level == TeeSignalLevel.PASS &&
+                it.body.contains("granteeRead=PERMISSION_DENIED")
         })
     }
 
@@ -2132,6 +2192,10 @@ class TeeReportReducerTest {
             SyntheticGrantGranteeBlindReadbackResult(
                 detail = "skipped",
             ),
+        syntheticGrantGetKeyEntryAccessVectorBlindness: SyntheticGrantGetKeyEntryAccessVectorBlindnessResult =
+            SyntheticGrantGetKeyEntryAccessVectorBlindnessResult(
+                detail = "skipped",
+            ),
         grantSelfDomainFullChainSplit: GrantSelfDomainFullChainSplitResult = GrantSelfDomainFullChainSplitResult(
             detail = "skipped",
         ),
@@ -2239,6 +2303,7 @@ class TeeReportReducerTest {
             generateModeParcelFingerprint = generateModeParcelFingerprint,
             grantDomainFullChainSplit = grantDomainFullChainSplit,
             syntheticGrantGranteeBlindReadback = syntheticGrantGranteeBlindReadback,
+            syntheticGrantGetKeyEntryAccessVectorBlindness = syntheticGrantGetKeyEntryAccessVectorBlindness,
             grantSelfDomainFullChainSplit = grantSelfDomainFullChainSplit,
             legacyKeystorePath = legacyKeystorePath,
             listEntriesConsistency = listEntriesConsistency,

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
@@ -38,6 +38,8 @@ import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDo
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantDomainFullChainSplitResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.GrantSelfDomainFullChainSplitResult
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackAnomalyKind
+import com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationAnomalyKind
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.ImportKeyRetainedAttestationNarrativeResult
 import com.eltavine.duckdetector.features.tee.data.verification.keystore.KeyLifecycleResult
@@ -412,6 +414,61 @@ class TeeReportReducerTest {
             it.title == "Grant isolated-domain" &&
                 it.level == TeeSignalLevel.INFO &&
                 it.body.contains("Unavailable", ignoreCase = true)
+        })
+    }
+
+    @Test
+    fun `grant caller binding non grantee readback becomes supplementary danger`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                syntheticGrantGranteeBlindReadback = SyntheticGrantGranteeBlindReadbackResult(
+                    executed = true,
+                    available = true,
+                    grantCreated = true,
+                    granteeUid = 99001,
+                    granteeReadSucceeded = true,
+                    ownerReplaySucceeded = true,
+                    anomalyKind = SyntheticGrantGranteeBlindReadbackAnomalyKind.NON_GRANTEE_READBACK_ALLOWED,
+                    detail = "Private: non-grantee owner replay succeeded for isolated grant handle.",
+                    diagnosticCopyText = "grant caller binding diagnostic",
+                ),
+            ),
+        )
+
+        assertEquals(TeeVerdict.CONSISTENT, report.verdict)
+        assertEquals(1, report.supplementaryIndicatorCount)
+        assertEquals(TeeSignalLevel.FAIL, report.supplementaryReviewLevel)
+        assertTrue(report.summary.contains("Grant handle remained readable", ignoreCase = true))
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "Grant caller binding" &&
+                it.level == TeeSignalLevel.FAIL &&
+                it.body.contains("NON_GRANTEE_READBACK_ALLOWED") &&
+                it.body.contains("ownerReplay=true") &&
+                it.hiddenCopyText == "grant caller binding diagnostic"
+        })
+    }
+
+    @Test
+    fun `grant caller binding rejected owner replay stays clean`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                syntheticGrantGranteeBlindReadback = SyntheticGrantGranteeBlindReadbackResult(
+                    executed = true,
+                    available = true,
+                    grantCreated = true,
+                    granteeUid = 99001,
+                    granteeReadSucceeded = true,
+                    anomalyKind = SyntheticGrantGranteeBlindReadbackAnomalyKind.NONE,
+                    detail = "Private: owner replay rejected with KEY_NOT_FOUND.",
+                ),
+            ),
+        )
+
+        assertEquals(0, report.supplementaryIndicatorCount)
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "Grant caller binding" &&
+                it.level == TeeSignalLevel.PASS &&
+                it.body.contains("ownerReplay=KEY_NOT_FOUND")
         })
     }
 
@@ -2008,6 +2065,10 @@ class TeeReportReducerTest {
         grantDomainFullChainSplit: GrantDomainFullChainSplitResult = GrantDomainFullChainSplitResult(
             detail = "skipped",
         ),
+        syntheticGrantGranteeBlindReadback: SyntheticGrantGranteeBlindReadbackResult =
+            SyntheticGrantGranteeBlindReadbackResult(
+                detail = "skipped",
+            ),
         grantSelfDomainFullChainSplit: GrantSelfDomainFullChainSplitResult = GrantSelfDomainFullChainSplitResult(
             detail = "skipped",
         ),
@@ -2113,6 +2174,7 @@ class TeeReportReducerTest {
             keystore2Hook = keystore2Hook,
             generateModeParcelFingerprint = generateModeParcelFingerprint,
             grantDomainFullChainSplit = grantDomainFullChainSplit,
+            syntheticGrantGranteeBlindReadback = syntheticGrantGranteeBlindReadback,
             grantSelfDomainFullChainSplit = grantSelfDomainFullChainSplit,
             legacyKeystorePath = legacyKeystorePath,
             listEntriesConsistency = listEntriesConsistency,

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/crl/CrlStatusServiceTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/crl/CrlStatusServiceTest.kt
@@ -172,6 +172,126 @@ class CrlStatusServiceTest {
     }
 
     @Test
+    fun `local hardcoded abuse serial is classified as mass abuse warning evidence`() = runBlocking {
+        val store = FakeTeeNetworkPrefsStore(
+            TeeNetworkPrefs(
+                consentAsked = true,
+                consentGranted = false,
+                crlCacheJson = null,
+                crlFetchedAt = 0L,
+            ),
+        )
+        val service = CrlStatusService(
+            consentStore = store,
+            networkStatusProvider = CrlNetworkStatusProvider { true },
+            feedFetcher = CrlFeedFetcher { """{"entries":{}}""" },
+            embeddedStatusProvider = embeddedStatusProvider(
+                """{"entries":{"8616ef30679ed43cc2b43e3c97a2319e":{"status":"REVOKED","reason":"KEY_COMPROMISE"}}}"""
+            ),
+        )
+
+        val result = service.inspect(listOf(FakeX509Certificate(LOCAL_MASS_ABUSE_SERIAL)))
+
+        assertEquals(1, result.revokedCertificates.size)
+        assertEquals("MASS_ABUSE", result.revokedCertificates.single().reason)
+        assertEquals(
+            RevokedCertificateEvidenceKind.LOCAL_MASS_ABUSE,
+            result.revokedCertificates.single().evidenceKind,
+        )
+    }
+
+    @Test
+    fun `online hardcoded abuse serial remains standard revocation evidence`() = runBlocking {
+        val store = FakeTeeNetworkPrefsStore(
+            TeeNetworkPrefs(
+                consentAsked = true,
+                consentGranted = true,
+                crlCacheJson = null,
+                crlFetchedAt = 0L,
+            ),
+        )
+        val service = CrlStatusService(
+            consentStore = store,
+            networkStatusProvider = CrlNetworkStatusProvider { true },
+            feedFetcher = CrlFeedFetcher {
+                """{"entries":{"8616ef30679ed43cc2b43e3c97a2319e":{"status":"REVOKED","reason":"KEY_COMPROMISE"}}}"""
+            },
+            embeddedStatusProvider = embeddedStatusProvider("""{"entries":{}}"""),
+        )
+
+        val result = service.inspect(listOf(FakeX509Certificate(LOCAL_MASS_ABUSE_SERIAL)))
+
+        assertEquals(1, result.revokedCertificates.size)
+        assertEquals("KEY_COMPROMISE", result.revokedCertificates.single().reason)
+        assertEquals(
+            RevokedCertificateEvidenceKind.STANDARD_REVOCATION,
+            result.revokedCertificates.single().evidenceKind,
+        )
+    }
+
+    @Test
+    fun `online decimal hardcoded abuse serial overrides local hex warning evidence`() = runBlocking {
+        val store = FakeTeeNetworkPrefsStore(
+            TeeNetworkPrefs(
+                consentAsked = true,
+                consentGranted = true,
+                crlCacheJson = null,
+                crlFetchedAt = 0L,
+            ),
+        )
+        val service = CrlStatusService(
+            consentStore = store,
+            networkStatusProvider = CrlNetworkStatusProvider { true },
+            feedFetcher = CrlFeedFetcher {
+                """{"entries":{"${LOCAL_MASS_ABUSE_SERIAL_DEC}":{"status":"REVOKED","reason":"KEY_COMPROMISE"}}}"""
+            },
+            embeddedStatusProvider = embeddedStatusProvider(
+                """{"entries":{"8616ef30679ed43cc2b43e3c97a2319e":{"status":"REVOKED","reason":"KEY_COMPROMISE"}}}"""
+            ),
+        )
+
+        val result = service.inspect(listOf(FakeX509Certificate(LOCAL_MASS_ABUSE_SERIAL)))
+
+        assertEquals(1, result.revokedCertificates.size)
+        assertEquals("KEY_COMPROMISE", result.revokedCertificates.single().reason)
+        assertEquals(
+            RevokedCertificateEvidenceKind.STANDARD_REVOCATION,
+            result.revokedCertificates.single().evidenceKind,
+        )
+    }
+
+    @Test
+    fun `online good status does not suppress local mass abuse warning evidence`() = runBlocking {
+        val store = FakeTeeNetworkPrefsStore(
+            TeeNetworkPrefs(
+                consentAsked = true,
+                consentGranted = true,
+                crlCacheJson = null,
+                crlFetchedAt = 0L,
+            ),
+        )
+        val service = CrlStatusService(
+            consentStore = store,
+            networkStatusProvider = CrlNetworkStatusProvider { true },
+            feedFetcher = CrlFeedFetcher {
+                """{"entries":{"8616ef30679ed43cc2b43e3c97a2319e":{"status":"GOOD"}}}"""
+            },
+            embeddedStatusProvider = embeddedStatusProvider(
+                """{"entries":{"8616ef30679ed43cc2b43e3c97a2319e":{"status":"REVOKED","reason":"KEY_COMPROMISE"}}}"""
+            ),
+        )
+
+        val result = service.inspect(listOf(FakeX509Certificate(LOCAL_MASS_ABUSE_SERIAL)))
+
+        assertEquals(1, result.revokedCertificates.size)
+        assertEquals("MASS_ABUSE", result.revokedCertificates.single().reason)
+        assertEquals(
+            RevokedCertificateEvidenceKind.LOCAL_MASS_ABUSE,
+            result.revokedCertificates.single().evidenceKind,
+        )
+    }
+
+    @Test
     fun `matches revoked certificate when feed key is decimal`() = runBlocking {
         val store = FakeTeeNetworkPrefsStore(
             TeeNetworkPrefs(
@@ -468,5 +588,8 @@ class CrlStatusServiceTest {
 
     private companion object {
         private const val NOW = 1_900_000_000_000L
+        private const val LOCAL_MASS_ABUSE_SERIAL = "8616ef30679ed43cc2b43e3c97a2319e"
+        private const val LOCAL_MASS_ABUSE_SERIAL_DEC =
+            "178235633296982535164483918324719301022"
     }
 }

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GenerateKeyReplyParcelParserTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/GenerateKeyReplyParcelParserTest.kt
@@ -118,6 +118,38 @@ class GenerateKeyReplyParcelParserTest {
     }
 
     @Test
+    fun `fingerprint matches when modification time is above high threshold`() {
+        val result = parser.parse(
+            rawReply = variableCountGenerateModeReply(
+                lastSecLevel = 20,
+                lastTag = 0x00000020,
+                lastUnionTag = 1,
+                modificationTimeMs = 5_000_000_000L,
+            ),
+        )
+
+        assertTrue(result.parseSucceeded)
+        assertEquals(5_000_000_000L, result.modificationTimeMs)
+        assertTrue(result.matched)
+    }
+
+    @Test
+    fun `fingerprint does not match at high threshold boundary without stable tuple`() {
+        val result = parser.parse(
+            rawReply = variableCountGenerateModeReply(
+                lastSecLevel = 20,
+                lastTag = 0x00000020,
+                lastUnionTag = 1,
+                modificationTimeMs = 4_999_999_999L,
+            ),
+        )
+
+        assertTrue(result.parseSucceeded)
+        assertEquals(4_999_999_999L, result.modificationTimeMs)
+        assertFalse(result.matched)
+    }
+
+    @Test
     fun `fingerprint does not match when last authorization security level differs`() {
         val result = parser.parse(rawReply = variableCountGenerateModeReply(lastSecLevel = 20))
 

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/Keystore2PrivateBinderClientTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/Keystore2PrivateBinderClientTest.kt
@@ -175,4 +175,21 @@ class Keystore2PrivateBinderClientTest {
         assertEquals(1, records.size)
         assertEquals(2, records.single().occurrenceCount)
     }
+
+    @Test
+    fun `delete key checked exposes cleanup failures`() {
+        val failure = client.deleteKeyChecked(FailingDeleteService(), FakeDescriptor())
+
+        assertNotNull(failure)
+        assertEquals("cleanup failed", failure!!.cause?.message)
+    }
+
+    class FakeDescriptor
+
+    class FailingDeleteService {
+        fun deleteKey(descriptor: FakeDescriptor) {
+            check(descriptor.javaClass == FakeDescriptor::class.java)
+            error("cleanup failed")
+        }
+    }
 }

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/Keystore2PrivateGrantClientTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/Keystore2PrivateGrantClientTest.kt
@@ -31,6 +31,7 @@ class Keystore2PrivateGrantClientTest {
         assertEquals(0x100, constants.permissionUse)
         assertEquals(0x4, constants.permissionGetInfo)
         assertEquals(0x104, constants.grantAccessVector)
+        assertEquals(0x100, constants.permissionUse)
         assertEquals(2, constants.transactionGetKeyEntry)
         assertEquals(7, constants.transactionGrant)
         assertEquals(8, constants.transactionUngrant)

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/Keystore2PrivateGrantClientTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/Keystore2PrivateGrantClientTest.kt
@@ -140,4 +140,16 @@ class Keystore2PrivateGrantClientTest {
         assertEquals(Keystore2PrivateGrantPhase.PRIVATE_UNGRANT, result.phase)
         assertEquals(Keystore2PrivateGrantErrorKind.UNGRANT_FAILED, result.errorKind)
     }
+
+    @Test
+    fun `owner replay phase is distinct from certificate chain readback`() {
+        val result = Keystore2PrivateGrantResult.unavailable(
+            phase = Keystore2PrivateGrantPhase.PRIVATE_OWNER_REPLAY_GRANT,
+            errorKind = Keystore2PrivateGrantErrorKind.KEY_NOT_FOUND,
+            detail = "private owner replay getKeyEntry(GRANT) failed: KEY_NOT_FOUND",
+        )
+
+        assertEquals(Keystore2PrivateGrantPhase.PRIVATE_OWNER_REPLAY_GRANT, result.phase)
+        assertEquals(Keystore2PrivateGrantErrorKind.KEY_NOT_FOUND, result.errorKind)
+    }
 }

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/SyntheticGrantGetKeyEntryAccessVectorBlindnessProbeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/SyntheticGrantGetKeyEntryAccessVectorBlindnessProbeTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.verification.keystore
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SyntheticGrantGetKeyEntryAccessVectorBlindnessProbeTest {
+
+    @Test
+    fun `successful grantee readback without get info is an access vector anomaly`() {
+        val result = SyntheticGrantGetKeyEntryAccessVectorBlindnessProbe.evaluateGranteeReadback(
+            granteeUid = 99001,
+            accessVector = Keystore2PrivateGrantClient.KEY_PERMISSION_USE_FALLBACK,
+            granteeRead = TeeGrantDomainGranteeChainResult(
+                available = true,
+                chain = GrantDomainCertificateChain(
+                    certificates = listOf(
+                        GrantDomainCertificateFingerprint(derLength = 3, sha256 = "abc"),
+                    ),
+                ),
+            ),
+        )
+
+        assertTrue(result.executed)
+        assertTrue(result.available)
+        assertTrue(result.granteeReadSucceeded)
+        assertEquals(
+            SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.GET_KEY_ENTRY_WITHOUT_GET_INFO_ALLOWED,
+            result.anomalyKind,
+        )
+    }
+
+    @Test
+    fun `permission denied grantee readback is the clean contract result`() {
+        val result = SyntheticGrantGetKeyEntryAccessVectorBlindnessProbe.evaluateGranteeReadback(
+            granteeUid = 99001,
+            accessVector = Keystore2PrivateGrantClient.KEY_PERMISSION_USE_FALLBACK,
+            granteeRead = TeeGrantDomainGranteeChainResult(
+                available = false,
+                errorKind = Keystore2PrivateGrantErrorKind.PERMISSION_DENIED,
+                detail = "isolated binder call blocked: PERMISSION_DENIED",
+            ),
+        )
+
+        assertTrue(result.executed)
+        assertTrue(result.available)
+        assertFalse(result.granteeReadSucceeded)
+        assertEquals(SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.NONE, result.anomalyKind)
+    }
+
+    @Test
+    fun `key not found grantee readback stays unavailable rather than reporting clean`() {
+        val result = SyntheticGrantGetKeyEntryAccessVectorBlindnessProbe.evaluateGranteeReadback(
+            granteeUid = 99001,
+            accessVector = Keystore2PrivateGrantClient.KEY_PERMISSION_USE_FALLBACK,
+            granteeRead = TeeGrantDomainGranteeChainResult(
+                available = false,
+                errorKind = Keystore2PrivateGrantErrorKind.KEY_NOT_FOUND,
+                detail = "isolated binder call blocked: KEY_NOT_FOUND",
+            ),
+        )
+
+        assertTrue(result.executed)
+        assertFalse(result.available)
+        assertEquals(SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.UNAVAILABLE, result.anomalyKind)
+        assertEquals(Keystore2PrivateGrantErrorKind.KEY_NOT_FOUND, result.granteeReadErrorKind)
+    }
+
+    @Test
+    fun `existing grant danger produces an explicit skipped result`() {
+        val result = SyntheticGrantGetKeyEntryAccessVectorBlindnessProbe.skippedAfterExistingGrantDanger()
+
+        assertFalse(result.executed)
+        assertEquals(
+            SyntheticGrantGetKeyEntryAccessVectorBlindnessAnomalyKind.SKIPPED_AFTER_EXISTING_GRANT_DANGER,
+            result.anomalyKind,
+        )
+    }
+}

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/SyntheticGrantGranteeBlindReadbackProbeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/SyntheticGrantGranteeBlindReadbackProbeTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.verification.keystore
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SyntheticGrantGranteeBlindReadbackProbeTest {
+
+    @Test
+    fun `successful owner replay is a caller binding anomaly`() {
+        val result = SyntheticGrantGranteeBlindReadbackProbe.evaluateOwnerReplay(
+            granteeUid = 99001,
+            ownerReplay = Keystore2PrivateGrantResult(
+                available = true,
+                phase = Keystore2PrivateGrantPhase.PRIVATE_OWNER_REPLAY_GRANT,
+            ),
+        )
+
+        assertTrue(result.executed)
+        assertTrue(result.available)
+        assertTrue(result.ownerReplaySucceeded)
+        assertEquals(
+            SyntheticGrantGranteeBlindReadbackAnomalyKind.NON_GRANTEE_READBACK_ALLOWED,
+            result.anomalyKind,
+        )
+    }
+
+    @Test
+    fun `key not found owner replay is the clean contract result`() {
+        val result = SyntheticGrantGranteeBlindReadbackProbe.evaluateOwnerReplay(
+            granteeUid = 99001,
+            ownerReplay = Keystore2PrivateGrantResult.unavailable(
+                phase = Keystore2PrivateGrantPhase.PRIVATE_OWNER_REPLAY_GRANT,
+                errorKind = Keystore2PrivateGrantErrorKind.KEY_NOT_FOUND,
+                detail = "private getKeyEntry(GRANT) failed: KEY_NOT_FOUND",
+            ),
+        )
+
+        assertTrue(result.executed)
+        assertTrue(result.available)
+        assertFalse(result.ownerReplaySucceeded)
+        assertEquals(SyntheticGrantGranteeBlindReadbackAnomalyKind.NONE, result.anomalyKind)
+    }
+
+    @Test
+    fun `permission denied owner replay stays unavailable rather than reporting danger`() {
+        val result = SyntheticGrantGranteeBlindReadbackProbe.evaluateOwnerReplay(
+            granteeUid = 99001,
+            ownerReplay = Keystore2PrivateGrantResult.unavailable(
+                phase = Keystore2PrivateGrantPhase.PRIVATE_OWNER_REPLAY_GRANT,
+                errorKind = Keystore2PrivateGrantErrorKind.PERMISSION_DENIED,
+                detail = "private getKeyEntry(GRANT) failed: PERMISSION_DENIED",
+            ),
+        )
+
+        assertTrue(result.executed)
+        assertFalse(result.available)
+        assertEquals(SyntheticGrantGranteeBlindReadbackAnomalyKind.UNAVAILABLE, result.anomalyKind)
+        assertEquals(Keystore2PrivateGrantErrorKind.PERMISSION_DENIED, result.ownerReplayErrorKind)
+    }
+
+    @Test
+    fun `existing grant danger produces an explicit skipped result`() {
+        val result = SyntheticGrantGranteeBlindReadbackProbe.skippedAfterExistingGrantDanger()
+
+        assertFalse(result.executed)
+        assertEquals(
+            SyntheticGrantGranteeBlindReadbackAnomalyKind.SKIPPED_AFTER_EXISTING_GRANT_DANGER,
+            result.anomalyKind,
+        )
+    }
+}

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapperTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/presentation/TeeCardModelMapperTest.kt
@@ -482,6 +482,49 @@ class TeeCardModelMapperTest {
     }
 
     @Test
+    fun `grant caller binding failure escalates aligned tee card to danger`() {
+        val model = mapper.map(
+            report = TeeReport(
+                stage = TeeScanStage.READY,
+                verdict = TeeVerdict.CONSISTENT,
+                tier = TeeTier.TEE,
+                headline = "Attestation aligned; local probes need review",
+                summary = "Grant handle remained readable by its non-grantee owner. Attestation and trust-path checks still aligned.",
+                collapsedSummary = "Aligned • local review",
+                trustRoot = TeeTrustRoot.GOOGLE,
+                trustSummary = "Local trust path",
+                tamperScore = 10,
+                evidenceCount = 1,
+                supplementaryIndicatorCount = 1,
+                supplementaryReviewLevel = TeeSignalLevel.FAIL,
+                signals = listOf(
+                    TeeSignal("Grant caller binding", "Matched", TeeSignalLevel.FAIL),
+                ),
+                sections = listOf(
+                    TeeEvidenceSection(
+                        title = "Checks",
+                        items = listOf(
+                            TeeEvidenceItem(
+                                "Grant caller binding",
+                                "Matched kind=NON_GRANTEE_READBACK_ALLOWED uid=99001 ownerReplay=true",
+                                TeeSignalLevel.FAIL,
+                            ),
+                        ),
+                    ),
+                ),
+                certificates = emptyList(),
+            ),
+            isExpanded = false,
+        )
+
+        assertEquals(DetectorStatus.danger(), model.status)
+        assertEquals(
+            "Grant handle caller binding failed; open TEE details for stage diagnostics.",
+            model.findingDetail,
+        )
+    }
+
+    @Test
     fun `grant isolated-domain private readback crash shows warning card and compact finding detail`() {
         val model = mapper.map(
             report = TeeReport(

--- a/build-logic/src/main/kotlin/com/eltavine/duckdetector/buildlogic/GenerateTeeCrlAssetTask.kt
+++ b/build-logic/src/main/kotlin/com/eltavine/duckdetector/buildlogic/GenerateTeeCrlAssetTask.kt
@@ -31,6 +31,7 @@ import org.gradle.api.tasks.TaskAction
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.IOException
+import java.math.BigInteger
 import java.net.HttpURLConnection
 import java.net.URL
 
@@ -172,8 +173,17 @@ abstract class GenerateTeeCrlAssetTask : DefaultTask() {
         val remoteKeys = remoteEntries.keys()
         while (remoteKeys.hasNext()) {
             val key = remoteKeys.next()
-            if (!fallbackEntries.has(key)) {
-                fallbackEntries.put(key, remoteEntries.get(key))
+            val remoteEntry = remoteEntries.getJSONObject(key)
+            if (isLocalMassAbuseSerial(key) && remoteEntry.isRevokedOrSuspended()) {
+                // 临时例外：构建增量真的拉到该序列号时，标记为远端来源，运行时不再降级成本地“大规模滥用”WARN。
+                fallbackEntries.put(
+                    LOCAL_MASS_ABUSE_SERIAL,
+                    JSONObject(remoteEntry.toString()).put(DUCK_SOURCE_FIELD, DUCK_SOURCE_REMOTE),
+                )
+            } else if (fallbackEntries.has(key)) {
+                continue
+            } else {
+                fallbackEntries.put(key, remoteEntry)
             }
         }
         return fallbackRoot.toString(2)
@@ -195,3 +205,22 @@ abstract class GenerateTeeCrlAssetTask : DefaultTask() {
         return root
     }
 }
+
+private fun isLocalMassAbuseSerial(key: String): Boolean {
+    val normalized = key.lowercase().trimStart('0').ifBlank { "0" }
+    return normalized == LOCAL_MASS_ABUSE_SERIAL ||
+        runCatching {
+            BigInteger(key).toString(16).lowercase() == LOCAL_MASS_ABUSE_SERIAL
+        }.getOrDefault(false)
+}
+
+private fun JSONObject.isRevokedOrSuspended(): Boolean {
+    return when (optString("status")) {
+        "REVOKED", "SUSPENDED" -> true
+        else -> false
+    }
+}
+
+private const val LOCAL_MASS_ABUSE_SERIAL = "8616ef30679ed43cc2b43e3c97a2319e"
+private const val DUCK_SOURCE_FIELD = "_duckDetectorSource"
+private const val DUCK_SOURCE_REMOTE = "REMOTE"


### PR DESCRIPTION
## Summary
- add private-Binder Grant caller-binding and GET_INFO access-vector probes with structured report propagation
- extend TEE Simulator generate-mode fingerprint detection for abnormally high `modificationTimeMs`
- classify the embedded local mass-abuse revocation serial as warning while preserving normal CI/online CRL severity

## Test Plan
- `./gradlew.bat :app:testDebugUnitTest --tests "com.eltavine.duckdetector.features.tee.data.verification.keystore.GenerateKeyReplyParcelParserTest" --tests "com.eltavine.duckdetector.features.tee.data.verification.crl.CrlStatusServiceTest" --tests "com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2PrivateBinderClientTest" --tests "com.eltavine.duckdetector.features.tee.data.verification.keystore.Keystore2PrivateGrantClientTest" --tests "com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGranteeBlindReadbackProbeTest" --tests "com.eltavine.duckdetector.features.tee.data.verification.keystore.SyntheticGrantGetKeyEntryAccessVectorBlindnessProbeTest" --tests "com.eltavine.duckdetector.features.tee.data.report.TeeReportReducerTest" --tests "com.eltavine.duckdetector.features.tee.presentation.TeeCardModelMapperTest"`

## Notes
- Android device validation remains required for the private Binder grant behavior against stock Keystore2 and target interception modules.
