### PR TITLE
WIP: enhance SELinux app-zygote seqno oracle detection（正在开发中...）

### DIFF
--- a/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/probes/SelinuxPolicyloadSeqnoProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/probes/SelinuxPolicyloadSeqnoProbe.kt
@@ -19,6 +19,7 @@ package com.eltavine.duckdetector.features.selinux.data.probes
 import java.io.FileInputStream
 import java.io.IOException
 import java.io.RandomAccessFile
+import java.util.concurrent.TimeUnit
 
 enum class SelinuxPolicyloadSeqnoState {
     CLEAN,
@@ -26,6 +27,25 @@ enum class SelinuxPolicyloadSeqnoState {
     INCONCLUSIVE,
     UNAVAILABLE,
 }
+
+data class SelinuxPathMetadata(
+    val path: String,
+    val exists: Boolean,
+    val uid: Int? = null,
+    val mode: String? = null,
+    val rawMode: Long? = null,
+    val fileType: String? = null,
+    val failureReason: String? = null,
+)
+
+data class SelinuxPolicyloadSeqnoMetadataResult(
+    val available: Boolean,
+    val probeAttempted: Boolean,
+    val statusMetadata: SelinuxPathMetadata,
+    val accessMetadata: SelinuxPathMetadata,
+    val failureReason: String? = null,
+    val unavailableReason: String? = null,
+)
 
 data class SelinuxPolicyloadSeqnoResult(
     val state: SelinuxPolicyloadSeqnoState,
@@ -39,12 +59,37 @@ data class SelinuxPolicyloadSeqnoResult(
     val notes: List<String> = emptyList(),
 )
 
+internal fun interface SelinuxStatCommandRunner {
+    fun run(
+        command: List<String>,
+        timeoutSeconds: Long,
+    ): SelinuxStatCommandResult
+}
+
+internal data class SelinuxStatCommandResult(
+    val exitCode: Int?,
+    val stdout: String,
+    val stderr: String,
+    val timedOut: Boolean = false,
+    val failureReason: String? = null,
+)
+
 class SelinuxPolicyloadSeqnoProbe {
 
     fun inspect(): SelinuxPolicyloadSeqnoResult {
+        return inspect(
+            statusReader = ::readStatusStable,
+            accessDecisionReader = ::queryAccessDecision,
+        )
+    }
+
+    internal fun inspect(
+        statusReader: () -> SelinuxStatus,
+        accessDecisionReader: () -> AccessDecision,
+    ): SelinuxPolicyloadSeqnoResult {
         return runCatching {
-            val status = readStatusStable()
-            val access = queryAccessDecision()
+            val status = statusReader()
+            val access = accessDecisionReader()
             interpret(status, access)
         }.getOrElse { throwable ->
             SelinuxPolicyloadSeqnoResult(
@@ -99,7 +144,7 @@ class SelinuxPolicyloadSeqnoProbe {
     }
 
     private fun readStatusOnce(): SelinuxStatus {
-        val bytes = FileInputStream(SELINUX_STATUS).use { input ->
+        val bytes = FileInputStream(SELINUX_STATUS_PATH).use { input ->
             val buffer = ByteArray(STATUS_SIZE_BYTES)
             val count = input.read(buffer)
             if (count < STATUS_SIZE_BYTES) {
@@ -119,7 +164,7 @@ class SelinuxPolicyloadSeqnoProbe {
     private fun queryAccessDecision(): AccessDecision {
         val processClass = readProcessClass()
         val query = "$APP_ZYGOTE_CONTEXT $ISOLATED_APP_CONTEXT $processClass"
-        RandomAccessFile(SELINUX_ACCESS, "rw").use { file ->
+        RandomAccessFile(SELINUX_ACCESS_PATH, "rw").use { file ->
             file.write(query.toByteArray(Charsets.US_ASCII))
             file.seek(0L)
             val buffer = ByteArray(ACCESS_RESPONSE_MAX_BYTES)
@@ -169,11 +214,13 @@ class SelinuxPolicyloadSeqnoProbe {
         const val METHOD_LABEL = "App-zygote seqno oracle"
         const val STATUS_CLEAN = "Clean"
         const val STATUS_SUSPICIOUS = "Seqno split"
+        const val STATUS_METADATA_MISMATCH = "Metadata mismatch"
         const val STATUS_INCONCLUSIVE = "Info"
         const val STATUS_UNAVAILABLE = "Unavailable"
 
-        private const val SELINUX_STATUS = "/sys/fs/selinux/status"
-        private const val SELINUX_ACCESS = "/sys/fs/selinux/access"
+        const val SELINUX_STATUS_PATH = "/sys/fs/selinux/status"
+        const val SELINUX_ACCESS_PATH = "/sys/fs/selinux/access"
+
         private const val SELINUX_PROCESS_CLASS = "/sys/fs/selinux/class/process/index"
         private const val APP_ZYGOTE_CONTEXT = "u:r:app_zygote:s0"
         private const val ISOLATED_APP_CONTEXT = "u:r:isolated_app:s0"
@@ -182,5 +229,236 @@ class SelinuxPolicyloadSeqnoProbe {
         private const val ACCESS_RESPONSE_MAX_BYTES = 256
         private const val ZYGOTE_PRELOAD_NOTE =
             "This oracle is trusted only when produced by android:zygotePreloadName inside the dedicated app_zygote carrier."
+    }
+}
+
+class SelinuxPolicyloadSeqnoMetadataProbe internal constructor(
+    private val statCommandRunner: SelinuxStatCommandRunner = ProcessSelinuxStatCommandRunner(),
+) {
+
+    fun inspect(): SelinuxPolicyloadSeqnoMetadataResult {
+        val command = listOf(
+            STAT_BINARY,
+            "-c",
+            STAT_FORMAT,
+            SelinuxPolicyloadSeqnoProbe.SELINUX_STATUS_PATH,
+            SelinuxPolicyloadSeqnoProbe.SELINUX_ACCESS_PATH,
+        )
+        val result = statCommandRunner.run(command, STAT_TIMEOUT_SECONDS)
+        return parseStatMetadata(result)
+    }
+
+    private fun parseStatMetadata(result: SelinuxStatCommandResult): SelinuxPolicyloadSeqnoMetadataResult {
+        val parsed = linkedMapOf<String, SelinuxPathMetadata>()
+        result.stdout
+            .lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .forEach { line ->
+                val fields = line.split('\t')
+                if (fields.size < STAT_FIELD_COUNT) {
+                    return@forEach
+                }
+                val path = fields[0].trim()
+                if (path !in EXPECTED_METADATA_PATHS) {
+                    return@forEach
+                }
+                val uidText = fields[1].trim()
+                val rawModeText = fields[2].trim()
+                val uid = uidText.toIntOrNull()
+                val rawMode = rawModeText.toLongOrNull(radix = 16)
+                parsed[path] = SelinuxPathMetadata(
+                    path = path,
+                    exists = true,
+                    uid = uid,
+                    mode = rawMode?.let(::permissionMode),
+                    rawMode = rawMode,
+                    fileType = rawMode?.let(::fileType),
+                    failureReason = when {
+                        uid == null -> "stat uid was not numeric: $uidText"
+                        rawMode == null -> "stat raw mode was not hex: $rawModeText"
+                        else -> null
+                    },
+                )
+            }
+
+        val commandFailureReason = result.commandFailureReason()
+        val status = parsed[SelinuxPolicyloadSeqnoProbe.SELINUX_STATUS_PATH] ?: SelinuxPathMetadata(
+            path = SelinuxPolicyloadSeqnoProbe.SELINUX_STATUS_PATH,
+            exists = false,
+        )
+        val access = parsed[SelinuxPolicyloadSeqnoProbe.SELINUX_ACCESS_PATH] ?: SelinuxPathMetadata(
+            path = SelinuxPolicyloadSeqnoProbe.SELINUX_ACCESS_PATH,
+            exists = false,
+        )
+        val parsedMetadataCount = parsed.size
+        val unavailableReason = unavailableReason(
+            status = status,
+            access = access,
+            commandFailureReason = commandFailureReason,
+            parsedMetadataCount = parsedMetadataCount,
+        )
+        val failureReason = if (unavailableReason == null) {
+            failureReason(status, access)
+        } else {
+            null
+        }
+        return SelinuxPolicyloadSeqnoMetadataResult(
+            available = unavailableReason == null,
+            probeAttempted = true,
+            statusMetadata = status,
+            accessMetadata = access,
+            failureReason = failureReason,
+            unavailableReason = unavailableReason,
+        )
+    }
+
+    private fun SelinuxStatCommandResult.commandFailureReason(): String? {
+        val reasons = buildList {
+            failureReason?.takeIf { it.isNotBlank() }?.let(::add)
+            if (timedOut) {
+                add("stat command timed out")
+            }
+            exitCode?.takeIf { it != 0 }?.let { add("stat exit=$it") }
+            if (stdout.isBlank()) {
+                add("stat produced no output")
+            }
+            stderr.takeIf { it.isNotBlank() }?.let { add("stderr=${it.take(MAX_STAT_DIAGNOSTIC_CHARS)}") }
+        }
+        return reasons.takeIf { it.isNotEmpty() }?.joinToString("; ")
+    }
+
+    private fun unavailableReason(
+        status: SelinuxPathMetadata,
+        access: SelinuxPathMetadata,
+        commandFailureReason: String?,
+        parsedMetadataCount: Int,
+    ): String? {
+        if (parsedMetadataCount == 0) {
+            return commandFailureReason ?: "stat returned no SELinux metadata"
+        }
+        val parseFailures = listOf(status, access)
+            .filter { it.exists }
+            .mapNotNull { metadata ->
+                metadata.failureReason?.let { "${metadata.path}: $it" }
+            }
+        return parseFailures.takeIf { it.isNotEmpty() }?.joinToString(
+            prefix = "stat metadata parse failed: ",
+            separator = "; ",
+        )
+    }
+
+    private fun failureReason(
+        status: SelinuxPathMetadata,
+        access: SelinuxPathMetadata,
+    ): String? {
+        val failures = buildList {
+            listOf(status, access).forEach { metadata ->
+                if (!metadata.exists) {
+                    add("${metadata.path} missing")
+                    return@forEach
+                }
+                if (metadata.uid != EXPECTED_METADATA_UID) {
+                    add("${metadata.path} uid=${metadata.uid ?: "unreadable"} expected=$EXPECTED_METADATA_UID")
+                }
+                val expectedMode = expectedPermissionMode(metadata.path)
+                if (metadata.mode != expectedMode) {
+                    add("${metadata.path} mode=${metadata.mode ?: "unreadable"} expected=$expectedMode")
+                }
+                if (metadata.fileType != EXPECTED_METADATA_FILE_TYPE) {
+                    add(
+                        "${metadata.path} type=${metadata.fileType ?: "unreadable"} " +
+                            "expected=$EXPECTED_METADATA_FILE_TYPE",
+                    )
+                }
+            }
+        }.distinct()
+        return failures.takeIf { it.isNotEmpty() }?.joinToString(
+            prefix = "metadata mismatch: ",
+            separator = "; ",
+        )
+    }
+
+    private fun permissionMode(rawMode: Long): String {
+        return (rawMode and PERMISSION_BITS_MASK).toString(radix = 8).padStart(3, '0')
+    }
+
+    private fun fileType(rawMode: Long): String {
+        return when (rawMode and FILE_TYPE_BITS_MASK) {
+            REGULAR_FILE_BITS -> "regular"
+            DIRECTORY_BITS -> "directory"
+            CHARACTER_DEVICE_BITS -> "character"
+            BLOCK_DEVICE_BITS -> "block"
+            SYMLINK_BITS -> "symlink"
+            SOCKET_BITS -> "socket"
+            FIFO_BITS -> "fifo"
+            else -> "unknown"
+        }
+    }
+
+    private fun expectedPermissionMode(path: String): String {
+        return when (path) {
+            SelinuxPolicyloadSeqnoProbe.SELINUX_ACCESS_PATH -> EXPECTED_ACCESS_METADATA_MODE
+            else -> EXPECTED_STATUS_METADATA_MODE
+        }
+    }
+
+    private companion object {
+        private const val STAT_BINARY = "/system/bin/stat"
+        private const val STAT_FORMAT = "%n\t%u\t%f"
+        private const val STAT_TIMEOUT_SECONDS = 2L
+        private const val STAT_FIELD_COUNT = 3
+        private const val EXPECTED_METADATA_UID = 0
+        private const val EXPECTED_STATUS_METADATA_MODE = "444"
+        private const val EXPECTED_ACCESS_METADATA_MODE = "666"
+        private const val EXPECTED_METADATA_FILE_TYPE = "regular"
+        private const val PERMISSION_BITS_MASK = 0x1FFL
+        private const val FILE_TYPE_BITS_MASK = 0xF000L
+        private const val FIFO_BITS = 0x1000L
+        private const val CHARACTER_DEVICE_BITS = 0x2000L
+        private const val DIRECTORY_BITS = 0x4000L
+        private const val BLOCK_DEVICE_BITS = 0x6000L
+        private const val REGULAR_FILE_BITS = 0x8000L
+        private const val SYMLINK_BITS = 0xA000L
+        private const val SOCKET_BITS = 0xC000L
+        private const val MAX_STAT_DIAGNOSTIC_CHARS = 160
+        private val EXPECTED_METADATA_PATHS = setOf(
+            SelinuxPolicyloadSeqnoProbe.SELINUX_STATUS_PATH,
+            SelinuxPolicyloadSeqnoProbe.SELINUX_ACCESS_PATH,
+        )
+    }
+}
+
+private class ProcessSelinuxStatCommandRunner : SelinuxStatCommandRunner {
+
+    override fun run(
+        command: List<String>,
+        timeoutSeconds: Long,
+    ): SelinuxStatCommandResult {
+        return runCatching {
+            val process = ProcessBuilder(command).start()
+            val completed = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+            if (!completed) {
+                process.destroyForcibly()
+                return@runCatching SelinuxStatCommandResult(
+                    exitCode = null,
+                    stdout = "",
+                    stderr = "",
+                    timedOut = true,
+                )
+            }
+            SelinuxStatCommandResult(
+                exitCode = process.exitValue(),
+                stdout = process.inputStream.bufferedReader().use { it.readText().trim() },
+                stderr = process.errorStream.bufferedReader().use { it.readText().trim() },
+            )
+        }.getOrElse { throwable ->
+            SelinuxStatCommandResult(
+                exitCode = null,
+                stdout = "",
+                stderr = "",
+                failureReason = throwable.message ?: throwable.javaClass.simpleName,
+            )
+        }
     }
 }

--- a/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/repository/SelinuxRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/selinux/data/repository/SelinuxRepository.kt
@@ -23,6 +23,9 @@ import com.eltavine.duckdetector.features.selinux.data.probes.DedicatedCarrierSt
 import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxContextValidityProbe
 import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxContextValidityProbeResult
 import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxContextValidityState
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxPathMetadata
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxPolicyloadSeqnoMetadataProbe
+import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxPolicyloadSeqnoMetadataResult
 import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxPolicyloadSeqnoProbe
 import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxPolicyloadSeqnoState
 import com.eltavine.duckdetector.features.selinux.data.probes.SelinuxProcAttrCurrentProbe
@@ -47,6 +50,8 @@ class SelinuxRepository(
     context: Context? = null,
     private val auditRuntimeProbe: SelinuxAuditRuntimeProbe = SelinuxAuditRuntimeProbe(),
     private val contextValidityProbe: SelinuxContextValidityProbe = SelinuxContextValidityProbe(),
+    private val policyloadSeqnoMetadataProbe: SelinuxPolicyloadSeqnoMetadataProbe =
+        SelinuxPolicyloadSeqnoMetadataProbe(),
     private val contextValidityCarrierManager: SelinuxContextValidityCarrierManager =
         SelinuxContextValidityCarrierManager(context?.applicationContext),
 ) {
@@ -95,8 +100,9 @@ class SelinuxRepository(
         val carrierSnapshot = contextValidityCarrierManager.collectSnapshot()
         val carrierResult = contextValidityProbe.interpret(carrierSnapshot)
         val contextValidityResult = carrierResult
+        val policyloadSeqnoMetadata = policyloadSeqnoMetadataProbe.inspect()
         methods += buildContextValidityMethod(contextValidityResult)
-        methods += buildPolicyloadSeqnoMethod(contextValidityResult)
+        methods += buildPolicyloadSeqnoMethod(contextValidityResult, policyloadSeqnoMetadata)
         methods += buildProcAttrCurrentMethod(carrierResult, EvidenceSource.DEDICATED_CARRIER)
         methods += buildDirtyPolicyMethods(carrierSnapshot)
 
@@ -383,13 +389,23 @@ class SelinuxRepository(
 
     private fun buildPolicyloadSeqnoMethod(
         result: SelinuxContextValidityProbeResult,
+        metadata: SelinuxPolicyloadSeqnoMetadataResult,
     ): SelinuxCheckResult {
-        val state = runCatching {
+        val carrierState = runCatching {
             SelinuxPolicyloadSeqnoState.valueOf(result.policyloadSeqnoState.orEmpty())
         }.getOrDefault(SelinuxPolicyloadSeqnoState.UNAVAILABLE)
+        val state = when {
+            metadata.failureReason != null -> SelinuxPolicyloadSeqnoState.SUSPICIOUS
+            else -> carrierState
+        }
         val status = when (state) {
             SelinuxPolicyloadSeqnoState.CLEAN -> SelinuxPolicyloadSeqnoProbe.STATUS_CLEAN
-            SelinuxPolicyloadSeqnoState.SUSPICIOUS -> SelinuxPolicyloadSeqnoProbe.STATUS_SUSPICIOUS
+            SelinuxPolicyloadSeqnoState.SUSPICIOUS ->
+                if (metadata.failureReason != null) {
+                    SelinuxPolicyloadSeqnoProbe.STATUS_METADATA_MISMATCH
+                } else {
+                    SelinuxPolicyloadSeqnoProbe.STATUS_SUSPICIOUS
+                }
             SelinuxPolicyloadSeqnoState.INCONCLUSIVE -> SelinuxPolicyloadSeqnoProbe.STATUS_INCONCLUSIVE
             SelinuxPolicyloadSeqnoState.UNAVAILABLE -> SelinuxPolicyloadSeqnoProbe.STATUS_UNAVAILABLE
         }
@@ -402,7 +418,16 @@ class SelinuxRepository(
             result.policyloadSeqnoStatusPolicyload?.let { add("status.policyload=$it") }
             result.policyloadSeqnoAccessSeqno?.let { add("access.avd.seqno=$it") }
             result.policyloadSeqnoProcessClass?.let { add("process class=$it") }
-            (result.policyloadSeqnoFailureReason ?: result.failureReason)
+            policyloadSeqnoMetadataDetail(
+                label = "status metadata",
+                metadata = metadata.statusMetadata,
+            )?.let(::add)
+            policyloadSeqnoMetadataDetail(
+                label = "access metadata",
+                metadata = metadata.accessMetadata,
+            )?.let(::add)
+            metadata.unavailableReason?.let { add("Metadata unavailable=$it") }
+            (metadata.failureReason ?: result.policyloadSeqnoFailureReason ?: result.failureReason)
                 ?.let { add("Failure=$it") }
             result.policyloadSeqnoNotes.forEach(::add)
         }.joinToString(" | ")
@@ -419,6 +444,49 @@ class SelinuxRepository(
             permissionDenied = false,
             details = detail,
         )
+    }
+
+    private fun policyloadSeqnoMetadataDetail(
+        label: String,
+        metadata: SelinuxPathMetadata,
+    ): String? {
+        if (
+            !metadata.exists &&
+            metadata.uid == null &&
+            metadata.mode == null &&
+            metadata.rawMode == null &&
+            metadata.fileType == null &&
+            metadata.failureReason == null
+        ) {
+            return null
+        }
+        return buildString {
+            append(label)
+            append(" path=")
+            append(metadata.path)
+            append(" exists=")
+            append(if (metadata.exists) "yes" else "no")
+            metadata.uid?.let {
+                append(" uid=")
+                append(it)
+            }
+            metadata.mode?.let {
+                append(" mode=")
+                append(it)
+            }
+            metadata.rawMode?.let {
+                append(" rawMode=0x")
+                append(it.toString(radix = 16))
+            }
+            metadata.fileType?.let {
+                append(" type=")
+                append(it)
+            }
+            metadata.failureReason?.takeIf { it.isNotBlank() }?.let {
+                append(" failure=")
+                append(it)
+            }
+        }
     }
 
     private fun buildProcAttrCurrentMethod(

--- a/app/src/main/java/com/eltavine/duckdetector/features/selinux/presentation/SelinuxCardModelMapper.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/selinux/presentation/SelinuxCardModelMapper.kt
@@ -88,7 +88,7 @@ class SelinuxCardModelMapper {
                     report.auditIntegrity?.state == SelinuxAuditIntegrityState.TAMPERED -> "Enforcing with audit rewrite"
                     contextValidity?.status == SelinuxContextValidityProbe.BITPAIR_KSU_PRESENT ->
                         "Enforcing with KSU context materialized"
-                    policyloadSeqno?.isSecure == false -> "Enforcing with app_zygote seqno split"
+                    policyloadSeqno?.isSecure == false -> "Enforcing with app_zygote seqno oracle anomaly"
                     procAttrCurrent?.isSecure == false -> "Enforcing with app_zygote attr-write anomaly"
                     dirtyPolicyHit != null -> trustedPolicyRuleVerdict()
                     appZygoteCarrierState == AppZygoteCarrierSupportState.UNTRUSTED ->
@@ -164,7 +164,7 @@ class SelinuxCardModelMapper {
                             )
                         }
                         if (policyloadSeqno?.isSecure == false) {
-                            add("The zygotePreload app_zygote carrier observed a policyload/access seqno split; treat this as KernelSU-specific evidence bounded to the preload carrier.")
+                            add("The zygotePreload app_zygote carrier observed a seqno oracle anomaly; treat this as KernelSU-specific evidence bounded to the preload carrier.")
                         }
                         if (dirtyPolicyHit != null) {
                             add(trustedPolicyRuleSummary(dirtyPolicyHit))
@@ -483,7 +483,7 @@ class SelinuxCardModelMapper {
         }
         when {
             policyloadSeqno?.isSecure == false -> items += SelinuxImpactItemModel(
-                "The zygotePreload app_zygote carrier observed a policyload/access seqno split.",
+                "The zygotePreload app_zygote carrier observed a seqno oracle anomaly.",
                 DetectorStatus.danger(),
             )
 

--- a/app/src/test/java/com/eltavine/duckdetector/features/selinux/data/probes/SelinuxPolicyloadSeqnoProbeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/selinux/data/probes/SelinuxPolicyloadSeqnoProbeTest.kt
@@ -94,6 +94,133 @@ class SelinuxPolicyloadSeqnoProbeTest {
         assertEquals(9L, result.accessSeqno)
     }
 
+    @Test
+    fun `metadata probe parses regular root readable selinuxfs files`() {
+        val result = metadataProbe(
+            stdout = """
+                /sys/fs/selinux/status	0	8124
+                /sys/fs/selinux/access	0	81b6
+            """.trimIndent(),
+        ).inspect()
+
+        assertTrue(result.available)
+        assertEquals(0, result.statusMetadata.uid)
+        assertEquals("444", result.statusMetadata.mode)
+        assertEquals(0x8124L, result.statusMetadata.rawMode)
+        assertEquals("regular", result.statusMetadata.fileType)
+        assertEquals(0, result.accessMetadata.uid)
+        assertEquals("666", result.accessMetadata.mode)
+        assertEquals(0x81b6L, result.accessMetadata.rawMode)
+        assertEquals("regular", result.accessMetadata.fileType)
+    }
+
+    @Test
+    fun `missing status metadata is a fail condition when access metadata parsed`() {
+        val result = metadataProbe(
+            stdout = "/sys/fs/selinux/access\t0\t81b6",
+        ).inspect()
+
+        assertTrue(result.available)
+        assertEquals(false, result.statusMetadata.exists)
+        assertTrue(result.failureReason.orEmpty().contains("/sys/fs/selinux/status missing"))
+    }
+
+    @Test
+    fun `missing access metadata is a fail condition when status metadata parsed`() {
+        val result = metadataProbe(
+            stdout = "/sys/fs/selinux/status\t0\t8124",
+        ).inspect()
+
+        assertTrue(result.available)
+        assertEquals(false, result.accessMetadata.exists)
+        assertTrue(result.failureReason.orEmpty().contains("/sys/fs/selinux/access missing"))
+    }
+
+    @Test
+    fun `non root selinux status owner is a fail condition`() {
+        val result = metadataProbe(
+            stdout = """
+                /sys/fs/selinux/status	2000	8124
+                /sys/fs/selinux/access	0	81b6
+            """.trimIndent(),
+        ).inspect()
+
+        assertTrue(result.available)
+        assertEquals(2000, result.statusMetadata.uid)
+        assertTrue(result.failureReason.orEmpty().contains("uid=2000 expected=0"))
+    }
+
+    @Test
+    fun `non 666 selinux access mode is a fail condition`() {
+        val result = metadataProbe(
+            stdout = """
+                /sys/fs/selinux/status	0	8124
+                /sys/fs/selinux/access	0	8124
+            """.trimIndent(),
+        ).inspect()
+
+        assertTrue(result.available)
+        assertEquals("444", result.accessMetadata.mode)
+        assertEquals(0x8124L, result.accessMetadata.rawMode)
+        assertTrue(result.failureReason.orEmpty().contains("mode=444 expected=666"))
+    }
+
+    @Test
+    fun `non regular selinux status path is a fail condition`() {
+        val result = metadataProbe(
+            stdout = """
+                /sys/fs/selinux/status	0	4124
+                /sys/fs/selinux/access	0	81b6
+            """.trimIndent(),
+        ).inspect()
+
+        assertTrue(result.available)
+        assertEquals("directory", result.statusMetadata.fileType)
+        assertTrue(result.failureReason.orEmpty().contains("type=directory expected=regular"))
+    }
+
+    @Test
+    fun `stat timeout is unavailable not a metadata fail`() {
+        val result = metadataProbe(
+            stdout = "",
+            timedOut = true,
+        ).inspect()
+
+        assertEquals(false, result.available)
+        assertEquals(null, result.failureReason)
+        assertTrue(result.unavailableReason.orEmpty().contains("stat command timed out"))
+    }
+
+    @Test
+    fun `stat nonzero exit with parsed metadata still evaluates parsed metadata`() {
+        val result = metadataProbe(
+            stdout = """
+                /sys/fs/selinux/status	0	8124
+                /sys/fs/selinux/access	0	81b6
+            """.trimIndent(),
+            exitCode = 1,
+            stderr = "No such file",
+        ).inspect()
+
+        assertTrue(result.available)
+        assertEquals(null, result.failureReason)
+        assertEquals(null, result.unavailableReason)
+    }
+
+    @Test
+    fun `stat unparsable uid is unavailable not a metadata fail`() {
+        val result = metadataProbe(
+            stdout = """
+                /sys/fs/selinux/status	root	8124
+                /sys/fs/selinux/access	0	81b6
+            """.trimIndent(),
+        ).inspect()
+
+        assertEquals(false, result.available)
+        assertEquals(null, result.failureReason)
+        assertTrue(result.unavailableReason.orEmpty().contains("stat uid was not numeric"))
+    }
+
     private fun status(
         sequence: Long,
         policyload: Long,
@@ -111,4 +238,33 @@ class SelinuxPolicyloadSeqnoProbeTest {
         processClass = 2,
         seqno = seqno,
     )
+
+    private fun metadataProbe(
+        stdout: String,
+        exitCode: Int? = 0,
+        stderr: String = "",
+        timedOut: Boolean = false,
+    ): SelinuxPolicyloadSeqnoMetadataProbe {
+        return SelinuxPolicyloadSeqnoMetadataProbe(
+            statCommandRunner = SelinuxStatCommandRunner { command, timeoutSeconds ->
+                assertEquals(
+                    listOf(
+                        "/system/bin/stat",
+                        "-c",
+                        "%n\t%u\t%f",
+                        "/sys/fs/selinux/status",
+                        "/sys/fs/selinux/access",
+                    ),
+                    command,
+                )
+                assertEquals(2L, timeoutSeconds)
+                SelinuxStatCommandResult(
+                    exitCode = exitCode,
+                    stdout = stdout,
+                    stderr = stderr,
+                    timedOut = timedOut,
+                )
+            },
+        )
+    }
 }

--- a/app/src/test/java/com/eltavine/duckdetector/features/selinux/presentation/SelinuxCardModelMapperContextValidityTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/selinux/presentation/SelinuxCardModelMapperContextValidityTest.kt
@@ -280,12 +280,48 @@ class SelinuxCardModelMapperContextValidityTest {
         )
 
         assertEquals(DetectorStatus.danger(), model.status)
-        assertEquals("Enforcing with app_zygote seqno split", model.verdict)
-        assertTrue(model.summary.contains("policyload/access seqno split"))
+        assertEquals("Enforcing with app_zygote seqno oracle anomaly", model.verdict)
+        assertTrue(model.summary.contains("seqno oracle anomaly"))
         assertTrue(
             model.methodRows.any {
                 it.label == SelinuxPolicyloadSeqnoProbe.METHOD_LABEL &&
                     it.status == DetectorStatus.danger()
+            },
+        )
+    }
+
+    @Test
+    fun `app zygote seqno metadata mismatch maps to danger after support rows`() {
+        val model = mapper.map(
+            baseReport(
+                SelinuxCheckResult(
+                    method = SelinuxContextValidityProbe.METHOD_LABEL,
+                    status = SelinuxContextValidityProbe.BITPAIR_UNSUPPORTED,
+                    isSecure = null,
+                    permissionDenied = false,
+                    details = "Carrier=<unreadable> | Carrier state=failed",
+                ),
+                SelinuxCheckResult(
+                    method = SelinuxPolicyloadSeqnoProbe.METHOD_LABEL,
+                    status = SelinuxPolicyloadSeqnoProbe.STATUS_METADATA_MISMATCH,
+                    isSecure = false,
+                    permissionDenied = false,
+                    details = "status metadata path=/sys/fs/selinux/status exists=yes uid=0 mode=444 | " +
+                        "access metadata path=/sys/fs/selinux/access exists=yes uid=0 mode=444 | " +
+                        "Failure=metadata mismatch: /sys/fs/selinux/access mode=444 expected=666",
+                ),
+            ),
+        )
+
+        assertEquals(DetectorStatus.danger(), model.status)
+        assertEquals("Enforcing with app_zygote seqno oracle anomaly", model.verdict)
+        assertTrue(model.summary.contains("seqno oracle anomaly"))
+        assertTrue(
+            model.methodRows.any {
+                it.label == SelinuxPolicyloadSeqnoProbe.METHOD_LABEL &&
+                    it.value == SelinuxPolicyloadSeqnoProbe.STATUS_METADATA_MISMATCH &&
+                    it.status == DetectorStatus.danger() &&
+                    it.detail.orEmpty().contains("metadata mismatch")
             },
         )
     }


### PR DESCRIPTION
## Summary

This is still in development.

Enhances the SELinux App-zygote seqno oracle with a main-process metadata check for the selinuxfs seqno paths before mapping the oracle result into the SELinux detector card.

Current behavior:
- Keeps the seqno oracle itself inside the dedicated app_zygote carrier.
- Runs `/system/bin/stat -c "%n\t%u\t%f"` from the normal app process for `/sys/fs/selinux/status` and `/sys/fs/selinux/access`.
- Parses raw `st_mode` metadata and checks path-specific uid/mode/type expectations.
- Treats confirmed metadata mismatch as danger-level SELinux evidence.
- Treats stat execution/no-output/parse availability failures as metadata unavailable detail instead of an immediate red card, to avoid false positives from process/device restrictions.

## TODO before ready for review

- Adapt SI2 device behavior.
- Expose and highlight the concrete numeric mode bits in the UI/details.
- Run real-device validation.

## Validation

- Ran focused unit test before the final access-mode adjustment:
  `./gradlew.bat :app:testDebugUnitTest --tests "com.eltavine.duckdetector.features.selinux.data.probes.SelinuxPolicyloadSeqnoProbeTest"`
- Confirmed Kotlin compile locally after the implementation according to local verification, but no full build was run.
- Real-device validation is still pending.