### PR TITLE
chore: Downgrade pruning check to info level

### DIFF
--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
@@ -1099,7 +1099,7 @@ class TeeReportReducer(
                         fact(
                             "Pruning",
                             pruningValue(artifacts),
-                            if (artifacts.pruning.suspicious) TeeSignalLevel.WARN else TeeSignalLevel.INFO
+                            TeeSignalLevel.INFO
                         )
                     )
                     add(


### PR DESCRIPTION
This check does not depend on keystore but TA, and TA behavior various. For example, QTEE in SM8750 series can perfectly perform well with 16 handles.

https://cs.android.com/android/platform/superproject/+/android-latest-release:system/keymint/ta/src/lib.rs;l=82?q=MAX_OPERATIONS&ss=android%2Fplatform%2Fsuperproject:system%2Fkeymint%2F

