### PR TITLE
fix(tee): skip RSA OAEP MGF1 checks on legacy devices

### DIFF
--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
@@ -155,6 +155,7 @@ class TeeRepository(
                 nativeSnapshot = native,
             )
             val deepChecks = collectDeepChecks(
+                attestationVersion = snapshot.attestationVersion ?: 2,
                 useStrongBox = snapshot.tier == TeeTier.STRONGBOX,
                 deepChecksAllowed = snapshot.tier == TeeTier.TEE || snapshot.tier == TeeTier.STRONGBOX,
                 snapshot = snapshot,
@@ -217,6 +218,7 @@ class TeeRepository(
     }
 
     private suspend fun collectDeepChecks(
+        attestationVersion: Int,
         useStrongBox: Boolean,
         deepChecksAllowed: Boolean,
         snapshot: com.eltavine.duckdetector.features.tee.data.attestation.AttestationSnapshot,
@@ -229,7 +231,7 @@ class TeeRepository(
         val pairConsistency = async { pairConsistencyProbe.inspect(useStrongBox = useStrongBox) }
         val aesGcm = async { aesGcmProbe.inspect(useStrongBox = useStrongBox) }
         val lifecycle = async { lifecycleProbe.inspect(useStrongBox = useStrongBox) }
-        val keyMintCapability = async { keyMintCapabilityProbe.inspect(useStrongBox = useStrongBox) }
+        val keyMintCapability = async { keyMintCapabilityProbe.inspect(attestationVersion = attestationVersion, useStrongBox = useStrongBox) }
         val timing = async { timingProbe.inspect(useStrongBox = useStrongBox) }
         val oversizedChallenge = async { oversizedChallengeProbe.inspect(useStrongBox = useStrongBox) }
         val keyboxImport = async { keyboxImportProbe.inspect() }

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/KeyMintCapabilityProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/KeyMintCapabilityProbe.kt
@@ -46,7 +46,7 @@ import javax.crypto.spec.PSource
 import javax.security.auth.x500.X500Principal
 
 class KeyMintCapabilityProbe {
-    fun inspect(useStrongBox: Boolean = false): KeyMintCapabilityResult {
+    fun inspect(attestationVersion: Int = 2, useStrongBox: Boolean = false): KeyMintCapabilityResult {
         val hmac = hmacSha256(useStrongBox)
         val limitedUseEc = limitedUseEc(useStrongBox)
         val ecdh = ecdhP256(useStrongBox)
@@ -58,8 +58,8 @@ class KeyMintCapabilityProbe {
         val rsaPssPkcs1 = rsaPssPkcs1Rejected(useStrongBox)
         val rsaOaepPkcs1 = rsaOaepPkcs1Rejected(useStrongBox)
         val rsaPkcs1Oaep = rsaPkcs1OaepRejected(useStrongBox)
-        val rsaOaepMgf1 = rsaOaepMgf1Sha256(useStrongBox)
-        val rsaOaepMgf1Sha1 = rsaOaepMgf1Sha1Rejected(useStrongBox)
+        val rsaOaepMgf1 = rsaOaepMgf1Sha256(attestationVersion, useStrongBox)
+        val rsaOaepMgf1Sha1 = rsaOaepMgf1Sha1Rejected(attestationVersion, useStrongBox)
         val rsaOaepSha256 = rsaOaepSha256RoundTrip(useStrongBox)
         val rsaOaepSha1 = rsaOaepSha1Rejected(useStrongBox)
         val ecNone = ecNoneRejected(useStrongBox)
@@ -516,11 +516,18 @@ class KeyMintCapabilityProbe {
         }
     }
 
-    private fun rsaOaepMgf1Sha256(useStrongBox: Boolean): CheckResult {
+    private fun rsaOaepMgf1Sha256(attestationVersion: Int, useStrongBox: Boolean): CheckResult {
         if (Build.VERSION.SDK_INT < 35) {
             return CheckResult(
                 ok = true,
                 detail = "RSA-OAEP MGF1 digest probe requires Android 15 or newer.",
+                executed = false,
+            )
+        }
+        if (attestationVersion < 100) {
+            return CheckResult(
+                ok = true,
+                detail = "RSA-OAEP MGF1 digest probe requires KeyMint 1.0 or newer.",
                 executed = false,
             )
         }
@@ -559,11 +566,18 @@ class KeyMintCapabilityProbe {
         }
     }
 
-    private fun rsaOaepMgf1Sha1Rejected(useStrongBox: Boolean): CheckResult {
+    private fun rsaOaepMgf1Sha1Rejected(attestationVersion: Int, useStrongBox: Boolean): CheckResult {
         if (Build.VERSION.SDK_INT < 35) {
             return CheckResult(
                 ok = true,
                 detail = "RSA-OAEP MGF1 digest authorization probe requires Android 15 or newer.",
+                executed = false,
+            )
+        }
+        if (attestationVersion < 100) {
+            return CheckResult(
+                ok = true,
+                detail = "RSA-OAEP MGF1 digest authorization probe requires KeyMint 1.0 or newer.",
                 executed = false,
             )
         }


### PR DESCRIPTION
This PR fixes two false positive TEE integrity checks by adding a check for the attestationVersion field in both `rsaOaepMgf1Sha256` and `rsaOaepMgf1Sha1Rejected` in [KeyMintCapabilityProbe.kt](https://github.com/eltavine/Duck-Detector-Refactoring/blob/master/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/KeyMintCapabilityProbe.kt). RSA OAEP MGF1 digest is passed to TEE via the `KM_TAG_RSA_OAEP_MGF_DIGEST` tag, which was however only introduced in KeyMint 1.0. Devices with the legacy KeyMaster TEE only support SHA-1 MGF1, this caused `rsaOaepMgf1Sha256` to fail and `rsaOaepMgf1Sha1Rejected` to pass due to the fact TEE is not aware of the supported key digests.

More info here:
- https://source.android.com/docs/security/features/keystore/attestation#schema
- https://android.googlesource.com/platform/hardware/interfaces/+/android-17.0.0_r1/security/keymint/aidl/android/hardware/security/keymint/Tag.aidl#193
- https://android.googlesource.com/platform/frameworks/base/+/android-17.0.0_r1/keystore/java/android/security/keystore2/AndroidKeyStoreCipherSpiBase.java#75
- https://android.googlesource.com/platform/frameworks/base/+/android-17.0.0_r1/keystore/java/android/security/keystore2/AndroidKeyStoreKeyPairGeneratorSpi.java#443
- https://android.googlesource.com/platform/frameworks/base/+/android-17.0.0_r1/keystore/java/android/security/keystore2/AndroidKeyStoreRSACipherSpi.java#168
- https://android.googlesource.com/platform/frameworks/base/+/android-17.0.0_r1/keystore/java/android/security/keystore2/AndroidKeyStoreSpi.java#566