### PR TITLE
feat(systemproperties): treat sys.oem_unlock_allowed as dangerous on B and higher

### DIFF
--- a/app/src/main/java/com/eltavine/duckdetector/features/systemproperties/data/rules/SystemPropertiesCatalog.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/systemproperties/data/rules/SystemPropertiesCatalog.kt
@@ -16,6 +16,7 @@
 
 package com.eltavine.duckdetector.features.systemproperties.data.rules
 
+import android.os.Build
 import com.eltavine.duckdetector.features.systemproperties.domain.SystemPropertyCategory
 
 data class SystemPropertyRule(
@@ -192,13 +193,22 @@ object SystemPropertiesCatalog {
             dangerousValues = listOf("unencrypted"),
             expectedSafeValue = "encrypted",
         ),
-        SystemPropertyRule(
-            property = "sys.oem_unlock_allowed",
-            description = "OEM unlock allowed",
-            category = SystemPropertyCategory.VERIFIED_BOOT,
-            warningValues = listOf("1", "true"),
-            expectedSafeValue = "0",
-        ),
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
+            SystemPropertyRule(
+                property = "sys.oem_unlock_allowed",
+                description = "OEM unlock allowed",
+                category = SystemPropertyCategory.VERIFIED_BOOT,
+                dangerousValues = listOf("*"),
+            )
+        } else {
+            SystemPropertyRule(
+                property = "sys.oem_unlock_allowed",
+                description = "OEM unlock allowed",
+                category = SystemPropertyCategory.VERIFIED_BOOT,
+                warningValues = listOf("1", "true"),
+                expectedSafeValue = "0",
+            )
+        },
         SystemPropertyRule(
             property = "ro.oem_unlock_supported",
             description = "OEM unlock supported",


### PR DESCRIPTION
The `sys.oem_unlock_allowed` prop has been removed on Android 16.
https://android.googlesource.com/platform/frameworks/base/+/bab174bf0883cbc5039a2860a1af706a56fe6ca0%5E%21/#F0