### PR TITLE
[codex] Preserve export row field names in release builds

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -30,3 +30,13 @@
 
 # Native preload launches MainActivity by explicit component name before Compose starts.
 -keepnames class com.eltavine.duckdetector.MainActivity
+
+# DashboardExportFormatter reflects over shared UI row models when building
+# exported reports. Keep the field names stable in release builds so R8 does
+# not strip detector card details from the text export.
+-keepclassmembers class com.eltavine.duckdetector.features.**.ui.model.** {
+    java.lang.String label;
+    java.lang.String value;
+    java.lang.String detail;
+    java.lang.String text;
+}


### PR DESCRIPTION
## Summary

- Preserve the UI row field names used by `DashboardExportFormatter` when R8 minification is enabled.
- Fix release text exports losing detector card details for rows read through reflection.

Fixes #84

## Change Type

- [ ] Feature / new detector capability
- [x] Bug fix / false positive or false negative reduction
- [ ] Refactor with no intended behavior change
- [ ] UI / copy / localization
- [x] Build / CI / release / versioning
- [ ] Documentation only

## Affected Areas

- [ ] Kotlin data/domain/presentation logic
- [ ] Compose UI
- [ ] Native / JNI / C++
- [ ] SELinux / app_zygote / `/proc` / mount / cgroup behavior
- [ ] AndroidKeyStore / TEE / StrongBox / Binder behavior
- [ ] Zygisk / LSPosed / root-runtime probes
- [x] Gradle / dependency / versioning / release workflow
- [ ] Notifications / Telegram / QQ / release publishing
- [ ] Strings / i18n / user-facing copy

## Detector Behavior Impact

- New signals: none.
- Changed verdict / severity rules: none.
- Expected false-positive impact: none; detection logic is unchanged.
- Expected false-negative impact: none; detection logic is unchanged.
- Compatibility notes by Android version / ROM / device class: release text exports should keep detector row details consistently after R8 minification.

## Architecture / Coupling Notes

- `DashboardExportFormatter` reads common row fields (`label`, `value`, `detail`, `text`) reflectively across multiple detector UI models.
- Release builds enable R8 minification/obfuscation, so those field names must stay stable for the existing export path.

## Validation

- [ ] Compilation passed:
  - Command: `gradle :app:assembleRelease`
  - Result: Not completed in local environment; the Gradle wrapper timed out downloading Gradle 9.6.1 and the system Gradle invocation timed out without producing an APK.
- [ ] Real test completed:
  - What was tested: N/A; build-rule-only change, no device available in this PR run.
  - Result: N/A.
- [ ] Unit tests:
  - N/A; this change targets release R8 member-name preservation rather than JVM logic.
- [ ] `:app:assembleDebug`:
  - N/A; debug builds do not exercise release R8 minification.
- [ ] Native build / JNI validation:
  - N/A.
- [x] Release / workflow validation, if build or CI changed:
  - Command: `git diff --check`
  - Result: Passed.
- [ ] Manual app smoke test:
  - N/A.

## Device / Runtime Testing

Tested on:

- Device / ROM / Android version: N/A.
- Root / module environment: N/A.
- Result: N/A.

Not tested on real device because:

- This PR only keeps release field names for the existing export formatter and does not change runtime detector logic.

Optional comparison testing:

- [ ] Unlocked / rooted / modified device tested:
  - Device / ROM / Android version:
  - Root / module environment:
  - Result:
- [ ] Stock / normal device tested:
  - Device / ROM / Android version:
  - Result:
- [x] Comparison testing not performed:
  - Reason: no detector behavior change.

## Documentation And Strings

- [ ] README / docs updated
- [ ] Strings updated where user-facing text changed
- [x] No documentation or string update needed

Reason:

- No user-facing copy changes.

## Revert / Rollback Plan

- Remove the added `-keepclassmembers` block from `app/proguard-rules.pro` if it causes release-build issues.