### PR TITLE
fix(tee): harden KeyMint identity, VINTF validation, and MGF1 probing

### DIFF
--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducer.kt
@@ -287,11 +287,22 @@ class TeeReportReducer(
                 )
             }
             if (artifacts.vintfKeyMintVersion.anomalyKind == VintfKeyMintVersionAnomalyKind.MISMATCH) {
+                // This is reported separately from the crypto capability row. A version/tier
+                // identity mismatch means the target backend cannot be selected unambiguously;
+                // it is evidence about identity, not evidence that an MGF1 operation executed.
+                // 这里必须与 crypto capability 分开报告。版本/tier 身份冲突表示无法唯一选中
+                // backend，它是“身份不一致”证据，不是“MGF1 已执行且失败”证据。
+                val runtimeIdentityMismatch = keyMintRuntimeIdentityMismatch(artifacts)
                 add(
                     fact(
-                        "KeyMint VINTF",
-                        "VINTF KeyMint version diverged from attestation. " +
-                            vintfKeyMintVersionValue(artifacts),
+                        if (runtimeIdentityMismatch) "KeyMint runtime identity" else "KeyMint VINTF",
+                        if (runtimeIdentityMismatch) {
+                            "Attestation and keymaster versions violate the AOSP single-runtime mapping. " +
+                                vintfKeyMintVersionValue(artifacts)
+                        } else {
+                            "VINTF KeyMint version diverged from attestation. " +
+                                vintfKeyMintVersionValue(artifacts)
+                        },
                         TeeSignalLevel.FAIL,
                         hiddenCopyText = artifacts.vintfKeyMintVersion.diagnosticCopyText,
                     )
@@ -1071,7 +1082,11 @@ class TeeReportReducer(
                     )
                     add(
                         fact(
-                            "KeyMint VINTF",
+                            if (keyMintRuntimeIdentityMismatch(artifacts)) {
+                                "KeyMint runtime identity"
+                            } else {
+                                "KeyMint VINTF"
+                            },
                             vintfKeyMintVersionValue(artifacts),
                             vintfKeyMintVersionLevel(artifacts),
                             hiddenCopyText = artifacts.vintfKeyMintVersion.diagnosticCopyText,
@@ -2940,11 +2955,22 @@ class TeeReportReducer(
         VintfKeyMintVersionAnomalyKind.NO_ATTESTED_VERSION -> TeeSignalLevel.INFO
     }
 
+    private fun keyMintRuntimeIdentityMismatch(artifacts: TeeScanArtifacts): Boolean {
+        val attestationVersion = artifacts.vintfKeyMintVersion.attestationVersion ?: return false
+        val keymasterVersion = artifacts.vintfKeyMintVersion.keymasterVersion ?: return false
+        return attestationVersion >= 100 &&
+            keymasterVersion >= 100 &&
+            attestationVersion != keymasterVersion
+    }
+
     private fun vintfKeyMintVersionValue(artifacts: TeeScanArtifacts): String {
         val result = artifacts.vintfKeyMintVersion
         return when (result.anomalyKind) {
-            VintfKeyMintVersionAnomalyKind.MISMATCH ->
+            VintfKeyMintVersionAnomalyKind.MISMATCH -> if (keyMintRuntimeIdentityMismatch(artifacts)) {
+                "Attestation and keymaster versions violate the AOSP single-runtime mapping. ${result.detail}"
+            } else {
                 "VINTF declaration did not match attested version. ${result.detail}"
+            }
             VintfKeyMintVersionAnomalyKind.NONE ->
                 "VINTF declaration matched attested KeyMint version. ${result.detail}"
             VintfKeyMintVersionAnomalyKind.UNREADABLE ->

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepository.kt
@@ -266,10 +266,30 @@ class TeeRepository(
         val aesGcm = async { aesGcmProbe.inspect(useStrongBox = useStrongBox) }
         val lifecycle = async { lifecycleProbe.inspect(useStrongBox = useStrongBox) }
         val keyMintCapability = async {
+            // KeyMint operations are obtained from one explicit IKeystoreSecurityLevel (TEE or
+            // StrongBox). If the attestation record names different security levels for the two
+            // version fields, testing either binder instance would test the wrong identity.
+            // KeyMint 操作来自一个明确的 IKeystoreSecurityLevel（TEE 或 StrongBox）。如果
+            // attestation record 的两个版本字段属于不同 security level，选择任一 binder
+            // 实例都会测错对象，因此 MGF1 子探针必须 skip，由独立一致性证据报 FAIL。
+            //
+            // AOSP references:
+            // system/hardware/interfaces/keystore2/aidl/android/system/keystore2/IKeystoreService.aidl
+            // https://android.googlesource.com/platform/system/hardware/interfaces/+/refs/heads/main/keystore2/aidl/android/system/keystore2/IKeystoreService.aidl
+            // system/hardware/interfaces/keystore2/aidl/android/system/keystore2/IKeystoreSecurityLevel.aidl
+            // https://android.googlesource.com/platform/system/hardware/interfaces/+/refs/heads/main/keystore2/aidl/android/system/keystore2/IKeystoreSecurityLevel.aidl
             val tierConsistent = snapshot.attestationTier == null || snapshot.keymasterTier == null ||
                 snapshot.attestationTier == snapshot.keymasterTier
             val nativeKeyMintObserved = listOfNotNull(snapshot.attestationVersion, snapshot.keymasterVersion)
                 .any { it >= 100 }
+            // AIDL KeyMint projects both attestation fields from the same interface version, while
+            // legacy Keymaster uses the explicit 2->1, 3->2, 4->3, 41->4 mapping below.
+            // AIDL KeyMint 的两个 attestation 字段来自同一个接口版本；legacy Keymaster 则使用
+            // 下方 AOSP 明确定义的 2->1、3->2、4->3、41->4 映射。
+            val runtimeIdentityConsistent = keyMintRuntimeIdentityConsistent(
+                attestationVersion = snapshot.attestationVersion,
+                keymasterVersion = snapshot.keymasterVersion,
+            )
             keyMintCapabilityProbe.inspect(
                 attestationVersion = snapshot.attestationVersion,
                 keymasterVersion = snapshot.keymasterVersion,
@@ -287,6 +307,7 @@ class TeeRepository(
                         it.instance == if (useStrongBox) "strongbox" else "default"
                 },
                 securityLevelsConsistent = tierConsistent,
+                runtimeIdentityConsistent = runtimeIdentityConsistent,
                 useStrongBox = useStrongBox,
             )
         }
@@ -404,6 +425,43 @@ class TeeRepository(
     }
 
 }
+
+internal fun keyMintRuntimeIdentityConsistent(
+    attestationVersion: Int?,
+    keymasterVersion: Int?,
+): Boolean {
+    if (attestationVersion == null || keymasterVersion == null) {
+        return true
+    }
+    val attestationIsKeyMint = attestationVersion >= KEYMINT_VERSION_FAMILY_BASE
+    val keymasterIsKeyMint = keymasterVersion >= KEYMINT_VERSION_FAMILY_BASE
+    if (attestationIsKeyMint != keymasterIsKeyMint) {
+        return false
+    }
+    if (attestationIsKeyMint) {
+        return attestationVersion == keymasterVersion
+    }
+    // keymasterVersion keeps the legacy Keymaster encoding (2, 3, 4, 41).
+    // attestationVersion is a separate attestation-record semantic (1, 2, 3, 4);
+    // this table is an AOSP-defined cross-field relationship, not linear arithmetic.
+    // keymasterVersion 保留旧 Keymaster 编码（2、3、4、41），attestationVersion 是独立的
+    // attestation record 语义（1、2、3、4）；这里是 AOSP 定义的跨字段映射，不是线性换算。
+    //
+    // AOSP references:
+    // system/keymaster/include/keymaster/km_openssl/attestation_record.h
+    // https://android.googlesource.com/platform/system/keymaster/+/refs/heads/main/include/keymaster/km_openssl/attestation_record.h
+    // hardware/interfaces/keymaster/4.0/vts/functional/keymaster_hidl_hal_test.cpp
+    // https://android.googlesource.com/platform/hardware/interfaces/+/refs/heads/main/keymaster/4.0/vts/functional/keymaster_hidl_hal_test.cpp
+    return LEGACY_KEYMASTER_TO_ATTESTATION_VERSION[keymasterVersion] == attestationVersion
+}
+
+private const val KEYMINT_VERSION_FAMILY_BASE = 100
+private val LEGACY_KEYMASTER_TO_ATTESTATION_VERSION = mapOf(
+    2 to 1,
+    3 to 2,
+    4 to 3,
+    41 to 4,
+)
 
 private fun GrantDomainFullChainSplitResult.hasDanger(): Boolean {
     return anomalyKind == GrantDomainAnomalyKind.ISOLATED_CHAIN_SPLIT ||

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/KeyMintCapabilityProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/KeyMintCapabilityProbe.kt
@@ -56,6 +56,7 @@ class KeyMintCapabilityProbe(
         declaredKeyMintVersion: Int? = null,
         legacyKeymasterDeclared: Boolean = false,
         securityLevelsConsistent: Boolean = true,
+        runtimeIdentityConsistent: Boolean = true,
         useStrongBox: Boolean = false,
     ): KeyMintCapabilityResult {
         val hmac = hmacSha256(useStrongBox)
@@ -69,20 +70,21 @@ class KeyMintCapabilityProbe(
         val rsaPssPkcs1 = rsaPssPkcs1Rejected(useStrongBox)
         val rsaOaepPkcs1 = rsaOaepPkcs1Rejected(useStrongBox)
         val rsaPkcs1Oaep = rsaPkcs1OaepRejected(useStrongBox)
+        val backend = classifyKeyMintBackend(
+            attestationVersion = attestationVersion,
+            keymasterVersion = keymasterVersion,
+            declaredKeyMintVersion = declaredKeyMintVersion,
+            legacyKeymasterDeclared = legacyKeymasterDeclared,
+            runtimeIdentityConsistent = runtimeIdentityConsistent,
+        )
         val rsaOaepMgf1 = rsaOaepMgf1Sha256(
-            attestationVersion,
-            keymasterVersion,
-            declaredKeyMintVersion,
-            legacyKeymasterDeclared,
-            securityLevelsConsistent,
+            backend = backend,
+            securityLevelsConsistent = securityLevelsConsistent,
             useStrongBox,
         )
         val rsaOaepMgf1Sha1 = rsaOaepMgf1Sha1Rejected(
-            attestationVersion,
-            keymasterVersion,
-            declaredKeyMintVersion,
-            legacyKeymasterDeclared,
-            securityLevelsConsistent,
+            backend = backend,
+            securityLevelsConsistent = securityLevelsConsistent,
             useStrongBox,
         )
         val rsaOaepSha256 = rsaOaepSha256RoundTrip(useStrongBox)
@@ -159,6 +161,7 @@ class KeyMintCapabilityProbe(
                 declaredKeyMintVersion = declaredKeyMintVersion,
                 legacyKeymasterDeclared = legacyKeymasterDeclared,
                 securityLevelsConsistent = securityLevelsConsistent,
+                runtimeIdentityConsistent = runtimeIdentityConsistent,
                 checks = listOf(
                     KeyMintDiagnosticEntry("HMAC-SHA256", hmac.executed, hmac.ok, hmac.detail, hmac.diagnostic),
                     KeyMintDiagnosticEntry("Single-use EC", limitedUseEc.executed, limitedUseEc.ok, limitedUseEc.detail, limitedUseEc.diagnostic),
@@ -573,15 +576,17 @@ class KeyMintCapabilityProbe(
     }
 
     private fun rsaOaepMgf1Sha256(
-        attestationVersion: Int?,
-        keymasterVersion: Int?,
-        declaredKeyMintVersion: Int?,
-        legacyKeymasterDeclared: Boolean,
+        backend: KeyMintBackendDecision,
         securityLevelsConsistent: Boolean,
         useStrongBox: Boolean,
     ): CheckResult {
-        if (!securityLevelsConsistent) {
-            return CheckResult(false, "Attestation and keymaster security levels disagree.")
+        val plan = resolveMgf1ProbePlan(backend, securityLevelsConsistent)
+        if (plan.mode == Mgf1ProbeMode.SKIP) {
+            return CheckResult(
+                ok = true,
+                detail = plan.detail,
+                executed = false,
+            )
         }
         // We intentionally do not trust UI/API level alone here.
         // AndroidKeyStore only exposes MGF-digest configuration from newer framework APIs, but the
@@ -594,15 +599,7 @@ class KeyMintCapabilityProbe(
         // https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/keystore/java/android/security/keystore2/AndroidKeyStoreRSACipherSpi.java
         // hardware/interfaces/security/keymint/aidl/vts/functional/KeyMintTest.cpp
         // https://android.googlesource.com/platform/hardware/interfaces/+/refs/heads/main/security/keymint/aidl/vts/functional/KeyMintTest.cpp
-        val keyMintVersion = deriveObservedKeyMintVersion(
-            attestationVersion,
-            keymasterVersion,
-            declaredKeyMintVersion,
-        ) ?: KEYMINT_VERSION_1
-        if (
-            Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
-            legacyKeymasterDeclared
-        ) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             return CheckResult(
                 ok = true,
                 detail = "RSA-OAEP MGF1 digest probe requires a native KeyMint 1+ backend.",
@@ -618,11 +615,12 @@ class KeyMintCapabilityProbe(
         ) { rawKey ->
             val capability = evaluateRsaOaepMgf1Capability(
                 authorizations = rawKey.authorizations,
-                attestationVersion,
-                keymasterVersion,
-                keyMintVersion,
+                attestationVersion = backend.attestationVersion,
+                keymasterVersion = backend.keymasterVersion,
+                declaredKeyMintVersion = backend.version,
                 expectedSecurityLevel = rawKey.expectedSecurityLevel,
                 returnedSecurityLevel = rawKey.returnedSecurityLevel,
+                probeMode = plan.mode,
             )
             if (!capability.shouldExecute) {
                 CheckResult(
@@ -652,25 +650,19 @@ class KeyMintCapabilityProbe(
     }
 
     private fun rsaOaepMgf1Sha1Rejected(
-        attestationVersion: Int?,
-        keymasterVersion: Int?,
-        declaredKeyMintVersion: Int?,
-        legacyKeymasterDeclared: Boolean,
+        backend: KeyMintBackendDecision,
         securityLevelsConsistent: Boolean,
         useStrongBox: Boolean,
     ): CheckResult {
-        if (!securityLevelsConsistent) {
-            return CheckResult(false, "Attestation and keymaster security levels disagree.")
+        val plan = resolveMgf1ProbePlan(backend, securityLevelsConsistent)
+        if (plan.mode == Mgf1ProbeMode.SKIP) {
+            return CheckResult(
+                ok = true,
+                detail = plan.detail,
+                executed = false,
+            )
         }
-        val keyMintVersion = deriveObservedKeyMintVersion(
-            attestationVersion,
-            keymasterVersion,
-            declaredKeyMintVersion,
-        ) ?: KEYMINT_VERSION_1
-        if (
-            Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
-            legacyKeymasterDeclared
-        ) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             return CheckResult(
                 ok = true,
                 detail = "RSA-OAEP MGF1 authorization probe requires a native KeyMint 1+ backend.",
@@ -686,11 +678,12 @@ class KeyMintCapabilityProbe(
         ) { rawKey ->
             val capability = evaluateRsaOaepMgf1Capability(
                 authorizations = rawKey.authorizations,
-                attestationVersion,
-                keymasterVersion,
-                keyMintVersion,
+                attestationVersion = backend.attestationVersion,
+                keymasterVersion = backend.keymasterVersion,
+                declaredKeyMintVersion = backend.version,
                 expectedSecurityLevel = rawKey.expectedSecurityLevel,
                 returnedSecurityLevel = rawKey.returnedSecurityLevel,
+                probeMode = plan.mode,
             )
             if (!capability.shouldExecute) {
                 CheckResult(
@@ -1128,6 +1121,7 @@ class KeyMintCapabilityProbe(
         declaredKeyMintVersion: Int?,
         legacyKeymasterDeclared: Boolean,
         securityLevelsConsistent: Boolean,
+        runtimeIdentityConsistent: Boolean,
         checks: List<KeyMintDiagnosticEntry>,
     ): String = buildString {
         appendLine("keymint-capability-diagnostic=v1")
@@ -1138,6 +1132,7 @@ class KeyMintCapabilityProbe(
         appendLine("declaredKeyMintVersion=${declaredKeyMintVersion ?: "null"}")
         appendLine("legacyKeymasterDeclared=$legacyKeymasterDeclared")
         appendLine("securityLevelsConsistent=$securityLevelsConsistent")
+        appendLine("runtimeIdentityConsistent=$runtimeIdentityConsistent")
         appendLine("checks:")
         checks.forEach { check ->
             appendLine("- ${check.name}: executed=${check.executed}, ok=${check.ok}, detail=${check.detail}")
@@ -1291,6 +1286,139 @@ internal data class AuthorizationSummary(
     val securityLevel: Int?,
 )
 
+internal enum class KeyMintBackendFamily {
+    LEGACY_KEYMASTER,
+    KEYMINT,
+    UNKNOWN,
+    CONFLICT,
+}
+
+internal data class KeyMintBackendDecision(
+    val family: KeyMintBackendFamily,
+    val version: Int?,
+    val attestationVersion: Int?,
+    val keymasterVersion: Int?,
+    val skipDetail: String,
+)
+
+internal enum class Mgf1ProbeMode {
+    // No operation is attempted when the target backend cannot be identified unambiguously.
+    // 无法唯一识别目标 backend 时不发起操作，避免把“没测”伪装成“密码学失败”。
+    SKIP,
+    // KeyMint 1/2: VTS validates begin/finish behavior but does not require the MGF digest
+    // authorization to be echoed in key characteristics.
+    // KeyMint 1/2：VTS 验证 begin/finish 行为，但不要求 key characteristics 回显 MGF digest。
+    OPERATION_ONLY,
+    // KeyMint 3+: VTS additionally requires the exact hardware-enforced MGF digest set.
+    // KeyMint 3+：VTS 额外要求精确的、由硬件层强制的 MGF digest 集合。
+    CHARACTERISTICS_AND_OPERATION,
+}
+
+internal data class Mgf1ProbePlan(
+    val mode: Mgf1ProbeMode,
+    val detail: String,
+)
+
+internal fun resolveMgf1ProbePlan(
+    backend: KeyMintBackendDecision,
+    securityLevelsConsistent: Boolean,
+): Mgf1ProbePlan {
+    if (backend.family != KeyMintBackendFamily.KEYMINT) {
+        return Mgf1ProbePlan(Mgf1ProbeMode.SKIP, backend.skipDetail)
+    }
+    if (!securityLevelsConsistent) {
+        // IKeystoreSecurityLevel operations are scoped to one selected TEE/StrongBox instance.
+        // If attestation and keymaster tiers disagree, running against either instance cannot
+        // establish the MGF1 behavior of the identity described by the certificate.
+        // IKeystoreSecurityLevel 操作绑定到一个明确的 TEE/StrongBox 实例。若 attestation 与
+        // keymaster tier 冲突，无论选择哪个实例，都不能证明证书所描述身份的 MGF1 行为。
+        return Mgf1ProbePlan(
+            Mgf1ProbeMode.SKIP,
+            "RSA-OAEP MGF1 skipped because attestation and keymaster security levels disagree.",
+        )
+    }
+    val version = backend.version ?: return Mgf1ProbePlan(
+        Mgf1ProbeMode.SKIP,
+        "RSA-OAEP MGF1 skipped because the native KeyMint version was unavailable.",
+    )
+    // AOSP references for the version split and exact characteristics expectation:
+    // hardware/interfaces/security/keymint/aidl/vts/functional/KeyMintTest.cpp
+    // https://android.googlesource.com/platform/hardware/interfaces/+/refs/heads/main/security/keymint/aidl/vts/functional/KeyMintTest.cpp
+    // hardware/interfaces/security/keymint/aidl/android/hardware/security/keymint/Tag.aidl
+    // https://android.googlesource.com/platform/hardware/interfaces/+/refs/heads/main/security/keymint/aidl/android/hardware/security/keymint/Tag.aidl
+    return if (version < KEYMINT_VERSION_3) {
+        Mgf1ProbePlan(
+            Mgf1ProbeMode.OPERATION_ONLY,
+            "KeyMint 1/2 uses raw keystore2 operation checks.",
+        )
+    } else {
+        Mgf1ProbePlan(
+            Mgf1ProbeMode.CHARACTERISTICS_AND_OPERATION,
+            "KeyMint 3+ requires exact MGF1 characteristics and raw operation checks.",
+        )
+    }
+}
+
+internal fun classifyKeyMintBackend(
+    attestationVersion: Int?,
+    keymasterVersion: Int?,
+    declaredKeyMintVersion: Int?,
+    legacyKeymasterDeclared: Boolean,
+    runtimeIdentityConsistent: Boolean,
+): KeyMintBackendDecision {
+    // The 100-based values are native KeyMint attestation encodings. Legacy values use a
+    // different Keymaster family, and VINTF is only a declaration fallback. Conflicting signals
+    // therefore produce CONFLICT/SKIP instead of choosing whichever value is numerically larger.
+    // 100-based 数值属于原生 KeyMint attestation 编码；legacy 数值属于另一套 Keymaster 家族，
+    // VINTF 也只是声明兜底。信号冲突时必须 CONFLICT/SKIP，不能随意取数值更大的那个。
+    val actualVersions = listOfNotNull(attestationVersion, keymasterVersion)
+    val nativeVersions = actualVersions.filter { it >= KEYMINT_VERSION_1 }
+    val legacyVersions = actualVersions.filter { it in 0 until KEYMINT_VERSION_1 }
+    val hasIdentityConflict = !runtimeIdentityConsistent ||
+        (nativeVersions.isNotEmpty() && legacyVersions.isNotEmpty()) ||
+        (declaredKeyMintVersion != null && legacyVersions.isNotEmpty()) ||
+        (legacyKeymasterDeclared && nativeVersions.isNotEmpty())
+    if (hasIdentityConflict) {
+        return KeyMintBackendDecision(
+            family = KeyMintBackendFamily.CONFLICT,
+            version = nativeVersions.maxOrNull() ?: declaredKeyMintVersion,
+            attestationVersion = attestationVersion,
+            keymasterVersion = keymasterVersion,
+            skipDetail = "RSA-OAEP MGF1 skipped because runtime identity signals conflict.",
+        )
+    }
+    if (nativeVersions.isNotEmpty() || declaredKeyMintVersion != null) {
+        return KeyMintBackendDecision(
+            family = KeyMintBackendFamily.KEYMINT,
+            // VINTF is a declaration, not the observed implementation version. Prefer the
+            // attested/keymaster value whenever one exists; use VINTF only as a family/version
+            // fallback when the runtime did not expose any version at all.
+            // VINTF 是声明，不是实际运行时版本。只要运行时有版本，就优先使用 attestation/
+            // keymaster 的真实值；只有完全没有运行时版本时才使用 VINTF 作为兜底。
+            version = nativeVersions.maxOrNull() ?: declaredKeyMintVersion,
+            attestationVersion = attestationVersion,
+            keymasterVersion = keymasterVersion,
+            skipDetail = "",
+        )
+    }
+    if (legacyVersions.isNotEmpty() || legacyKeymasterDeclared) {
+        return KeyMintBackendDecision(
+            family = KeyMintBackendFamily.LEGACY_KEYMASTER,
+            version = null,
+            attestationVersion = attestationVersion,
+            keymasterVersion = keymasterVersion,
+            skipDetail = "RSA-OAEP MGF1 skipped for legacy Keymaster/km_compat.",
+        )
+    }
+    return KeyMintBackendDecision(
+        family = KeyMintBackendFamily.UNKNOWN,
+        version = null,
+        attestationVersion = attestationVersion,
+        keymasterVersion = keymasterVersion,
+        skipDetail = "RSA-OAEP MGF1 skipped because the backend family could not be established.",
+    )
+}
+
 internal fun evaluateRsaOaepMgf1Capability(
     authorizations: List<AuthorizationSummary>,
     attestationVersion: Int?,
@@ -1298,6 +1426,7 @@ internal fun evaluateRsaOaepMgf1Capability(
     declaredKeyMintVersion: Int? = null,
     expectedSecurityLevel: Int = KEYMINT_SECURITY_LEVEL_TRUSTED_ENVIRONMENT,
     returnedSecurityLevel: Int = expectedSecurityLevel,
+    probeMode: Mgf1ProbeMode? = null,
 ): RsaOaepMgf1Capability {
     // KeyMint 3+ tightened the contract: the allowed MGF digests must be surfaced back through
     // hardware-enforced key characteristics, and VTS compares the exact set.
@@ -1331,7 +1460,12 @@ internal fun evaluateRsaOaepMgf1Capability(
         keymasterVersion,
         declaredKeyMintVersion,
     )
-    if (keyMintVersion == null || keyMintVersion < 100) {
+    val validationMode = probeMode ?: when {
+        keyMintVersion == null || keyMintVersion < KEYMINT_VERSION_1 -> Mgf1ProbeMode.SKIP
+        keyMintVersion < KEYMINT_VERSION_3 -> Mgf1ProbeMode.OPERATION_ONLY
+        else -> Mgf1ProbeMode.CHARACTERISTICS_AND_OPERATION
+    }
+    if (validationMode == Mgf1ProbeMode.SKIP) {
         return RsaOaepMgf1Capability(
             supported = false,
             shouldExecute = false,
@@ -1347,7 +1481,7 @@ internal fun evaluateRsaOaepMgf1Capability(
             diagnostic = diagnostic,
         )
     }
-    if (keyMintVersion < 300) {
+    if (validationMode == Mgf1ProbeMode.OPERATION_ONLY) {
         return RsaOaepMgf1Capability(
             supported = true,
             shouldExecute = true,
@@ -1433,18 +1567,19 @@ internal fun deriveObservedKeyMintVersion(
     keymasterVersion: Int?,
     declaredKeyMintVersion: Int? = null,
 ): Int? {
-    // We take the highest native-KeyMint-family signal we have, because the device can lie in one
-    // channel (attestation blob, framework wrapper, or VINTF) while still exposing a newer backend in
-    // another. Using the max avoids downgrading a KeyMint 3 device into the looser KeyMint 1/2 path.
-    // 这里取“最高的 KeyMint 家族版本信号”，是为了防止单一信号源被篡改或过旧时，把本应走严格
-    // KeyMint 3+ 语义的设备误降级到 KeyMint 1/2 的宽松路径。
-    return listOfNotNull(attestationVersion, keymasterVersion, declaredKeyMintVersion)
-        .filter { it >= 100 }
-        .maxOrNull()
+    // Runtime attestation/keymaster values describe the selected backend. VINTF is only a
+    // fallback when both runtime values are absent; it must not upgrade a real KeyMint 2
+    // implementation into a stricter KeyMint 3 path just because the declaration is newer.
+    // 运行时 attestation/keymaster 值描述当前选中的 backend。只有两个运行时值都缺失时才用
+    // VINTF 兜底；不能因为声明较新，就把真实 KeyMint 2 升级到更严格的 KeyMint 3 路径。
+    return listOfNotNull(attestationVersion, keymasterVersion)
+        .firstOrNull { it >= KEYMINT_VERSION_1 }
+        ?: declaredKeyMintVersion?.takeIf { it >= KEYMINT_VERSION_1 }
 }
 
 private const val KEYMINT_DIGEST_NONE = 0
 private const val KEYMINT_VERSION_1 = 100
+private const val KEYMINT_VERSION_3 = 300
 private const val KEYMINT_DIGEST_SHA_256 = 4
 private const val KEYMINT_DIGEST_SHA_224 = 3
 private const val KEYMINT_ERROR_INCOMPATIBLE_MGF_DIGEST = -78

--- a/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/VintfKeyMintVersionProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/VintfKeyMintVersionProbe.kt
@@ -27,6 +27,7 @@ import org.xml.sax.InputSource
 class VintfKeyMintVersionProbe(
     private val manifestDirs: List<String> = VINTF_MANIFEST_DIRS,
     private val manifestFiles: List<String> = VINTF_MANIFEST_FILES,
+    private val vendorApiLevelReader: VendorApiLevelReader = ReflectionVendorApiLevelReader(),
 ) {
 
     fun inspect(snapshot: AttestationSnapshot): VintfKeyMintVersionResult {
@@ -39,6 +40,11 @@ class VintfKeyMintVersionProbe(
         // StrongBox、或者 Keymaster 和 KeyMint 交叉比较，最后得出一个“看起来匹配、其实对象错了”的结论。
         val versionFamilyMismatch = actualKeymasterVersion != null && actualAttestationVersion != null &&
             (actualKeymasterVersion >= 100) != (actualAttestationVersion >= 100)
+        val keyMintRuntimeIdentityMismatch = actualKeymasterVersion != null &&
+            actualAttestationVersion != null &&
+            actualKeymasterVersion >= 100 &&
+            actualAttestationVersion >= 100 &&
+            actualKeymasterVersion != actualAttestationVersion
         val tierMismatch = snapshot.attestationTier != null && snapshot.keymasterTier != null &&
             snapshot.attestationTier != snapshot.keymasterTier
         val keyMintAttestation = maxOf(actualKeymasterVersion ?: 0, actualAttestationVersion ?: 0) >= 100
@@ -62,30 +68,54 @@ class VintfKeyMintVersionProbe(
             }
         }
         val hasActualVersion = actualKeymasterVersion != null || actualAttestationVersion != null
-        val mismatch = comparedDeclarations.isNotEmpty() &&
+        val requiresVendorApiLevel = hasActualVersion && comparedDeclarations.any {
+            it.family == VintfKeyMintVersionFamily.KEYMINT_AIDL
+        }
+        val vendorApiLevel = if (requiresVendorApiLevel) {
+            vendorApiLevelReader.read()
+        } else {
+            VendorApiLevelResult.unused()
+        }
+        val vendorApiUnavailable = requiresVendorApiLevel && vendorApiLevel.level == null
+        val mismatch = !vendorApiUnavailable &&
+            comparedDeclarations.isNotEmpty() &&
             hasActualVersion &&
-            comparedDeclarations.none { it.matches(actualKeymasterVersion, actualAttestationVersion) }
+            comparedDeclarations.none {
+                it.matches(
+                    keymasterVersion = actualKeymasterVersion,
+                    attestationVersion = actualAttestationVersion,
+                    vendorApiLevel = vendorApiLevel.level,
+                )
+            }
         val anomalyKind = when {
-            tierMismatch || versionFamilyMismatch || mismatch -> VintfKeyMintVersionAnomalyKind.MISMATCH
-            manifest.unreadablePaths.isNotEmpty() -> VintfKeyMintVersionAnomalyKind.UNREADABLE
+            tierMismatch || versionFamilyMismatch || keyMintRuntimeIdentityMismatch || mismatch ->
+                VintfKeyMintVersionAnomalyKind.MISMATCH
+            manifest.unreadablePaths.isNotEmpty() || vendorApiUnavailable ->
+                VintfKeyMintVersionAnomalyKind.UNREADABLE
             comparedDeclarations.isEmpty() -> VintfKeyMintVersionAnomalyKind.NO_DECLARATION
             !hasActualVersion -> VintfKeyMintVersionAnomalyKind.NO_ATTESTED_VERSION
             else -> VintfKeyMintVersionAnomalyKind.NONE
         }
 
         return VintfKeyMintVersionResult(
-            readable = manifest.unreadablePaths.isEmpty(),
+            readable = manifest.unreadablePaths.isEmpty() && !vendorApiUnavailable,
             anomalyKind = anomalyKind,
             declarations = manifest.declarations,
             comparedDeclarations = comparedDeclarations,
             unreadablePaths = manifest.unreadablePaths,
             attestationVersion = actualAttestationVersion,
             keymasterVersion = actualKeymasterVersion,
+            vendorApiLevel = vendorApiLevel.level,
+            vendorApiDetail = vendorApiLevel.detail,
             detail = when {
                 tierMismatch -> "Attestation and keymaster security levels disagree: " +
                     "attestation=${snapshot.attestationTier}, keymaster=${snapshot.keymasterTier}."
                 versionFamilyMismatch -> "Attestation and keymaster versions disagree on HAL family: " +
                     "attestation=$actualAttestationVersion, keymaster=$actualKeymasterVersion."
+                keyMintRuntimeIdentityMismatch -> "Attestation and keymaster versions disagree on KeyMint " +
+                    "runtime identity: attestation=$actualAttestationVersion, keymaster=$actualKeymasterVersion."
+                vendorApiUnavailable -> "KeyMint AIDL version comparison was incomplete because the " +
+                    "vendor API level could not be determined. ${vendorApiLevel.detail}"
                 else -> detailFor(
                     anomalyKind = anomalyKind,
                     comparedDeclarations = comparedDeclarations,
@@ -126,9 +156,21 @@ class VintfKeyMintVersionProbe(
         val declarations = mutableListOf<VintfKeyMintVersionDeclaration>()
         files.values.forEach { file ->
             val xml = runCatching { file.readText() }.getOrElse { throwable ->
-                unreadablePaths += "${file.absolutePath}: ${describe(throwable)}"
+                if (isPotentialKeyMintManifestPath(file.absolutePath, includeAggregateManifest = true)) {
+                    unreadablePaths += "${file.absolutePath}: ${describe(throwable)}"
+                }
                 null
             } ?: return@forEach
+            // Vendor VINTF directories sometimes contain non-XML fragments for unrelated HALs.
+            // Parsing every *.xml file lets those malformed fragments poison an otherwise complete
+            // KeyMint result. Only target-bearing fragments participate in this focused probe;
+            // malformed KeyMint/Keymaster fragments still fail closed as UNREADABLE.
+            // 部分厂商会把其他 HAL 的非 XML 碎片放进 VINTF 目录。若无差别解析全部 *.xml，
+            // 无关文件的语法错误会污染已经完整匹配的 KeyMint 结果。这里只解析带目标标识的片段；
+            // 真正属于 KeyMint/Keymaster 的损坏片段仍按 UNREADABLE 处理。
+            if (!isPotentialKeyMintManifest(file.absolutePath, xml)) {
+                return@forEach
+            }
             declarations += runCatching { parseManifest(file.absolutePath, xml) }.getOrElse { throwable ->
                 unreadablePaths += "${file.absolutePath}: ${describe(throwable)}"
                 emptyList()
@@ -210,6 +252,21 @@ class VintfKeyMintVersionProbe(
 
     private fun describe(throwable: Throwable): String {
         return "${throwable.javaClass.simpleName}: ${throwable.message ?: "no message"}"
+    }
+
+    private fun isPotentialKeyMintManifest(path: String, xml: String): Boolean {
+        return isPotentialKeyMintManifestPath(path, includeAggregateManifest = false) ||
+            KEYSTORE_HAL_MARKERS.any { marker -> xml.contains(marker, ignoreCase = true) }
+    }
+
+    private fun isPotentialKeyMintManifestPath(
+        path: String,
+        includeAggregateManifest: Boolean,
+    ): Boolean {
+        val name = File(path).name
+        return name.contains("keymint", ignoreCase = true) ||
+            name.contains("keymaster", ignoreCase = true) ||
+            (includeAggregateManifest && name.equals("manifest.xml", ignoreCase = true))
     }
 
     private data class ManifestReadResult(
@@ -350,6 +407,13 @@ class VintfKeyMintVersionProbe(
         private const val DEFAULT_INSTANCE = "default"
         private const val STRONGBOX_INSTANCE = "strongbox"
         private const val DEFAULT_AIDL_VERSION = "1"
+        internal const val STRICT_KEYMINT_VENDOR_API_THRESHOLD = 202504
+        private val KEYSTORE_HAL_MARKERS = listOf(
+            KEYMINT_HAL_NAME,
+            KEYMASTER_HAL_NAME,
+            KEYMINT_INTERFACE_NAME,
+            KEYMASTER_INTERFACE_NAME,
+        )
         private val HIDL_FQNAME_REGEX = Regex("^@([0-9]+(?:\\.[0-9]+)?)::([^/]+)/(.+)$")
 
         private fun expectedLegacyVersions(version: String): Pair<Int, Int>? {
@@ -407,9 +471,40 @@ data class VintfKeyMintVersionDeclaration(
         get() = "$halName/$interfaceName/$instance@$vintfVersion -> " +
             "keymaster=$expectedKeymasterVersion,attestation=$expectedAttestationVersion"
 
-    fun matches(keymasterVersion: Int?, attestationVersion: Int?): Boolean {
-        return (keymasterVersion == null || keymasterVersion == expectedKeymasterVersion) &&
-            (attestationVersion == null || attestationVersion == expectedAttestationVersion)
+    fun matches(
+        keymasterVersion: Int?,
+        attestationVersion: Int?,
+        vendorApiLevel: Int?,
+    ): Boolean {
+        return when (family) {
+            VintfKeyMintVersionFamily.KEYMINT_AIDL -> {
+                vendorApiLevel ?: return false
+                if (keymasterVersion == null || attestationVersion == null) {
+                    return false
+                }
+                val versions = listOf(keymasterVersion, attestationVersion)
+                if (vendorApiLevel > VintfKeyMintVersionProbe.STRICT_KEYMINT_VENDOR_API_THRESHOLD) {
+                    versions.all { version -> version == expectedKeymasterVersion }
+                } else {
+                    // This mirrors KeyMint VTS check_attestation_version() for both fields.
+                    // Both attestationVersion and keymasterVersion may lag the AIDL declaration
+                    // only on vendor API <= 36, and must remain 100-based and <= aidlVersion * 100.
+                    // 这里对两个字段复刻 VTS 的同一套规则：只有 vendor API <= 36 才允许实现版本
+                    // 低于 AIDL 声明，且版本必须是 100 的倍数并且不超过 aidlVersion * 100。
+                    //
+                    // AOSP references:
+                    // hardware/interfaces/security/keymint/aidl/vts/functional/KeyMintAidlTestBase.cpp
+                    // https://android.googlesource.com/platform/hardware/interfaces/+/refs/heads/main/security/keymint/aidl/vts/functional/KeyMintAidlTestBase.cpp
+                    versions.all { version ->
+                        version >= 100 && version % 100 == 0 && version <= expectedKeymasterVersion
+                    }
+                }
+            }
+            VintfKeyMintVersionFamily.KEYMASTER_HIDL -> {
+                (keymasterVersion == null || keymasterVersion == expectedKeymasterVersion) &&
+                    (attestationVersion == null || attestationVersion == expectedAttestationVersion)
+            }
+        }
     }
 }
 
@@ -421,6 +516,8 @@ data class VintfKeyMintVersionResult(
     val unreadablePaths: List<String> = emptyList(),
     val attestationVersion: Int? = null,
     val keymasterVersion: Int? = null,
+    val vendorApiLevel: Int? = null,
+    val vendorApiDetail: String = "Vendor API level was not required.",
     val detail: String,
 ) {
     val diagnosticCopyText: String
@@ -437,6 +534,12 @@ data class VintfKeyMintVersionResult(
             append("keymasterVersion=")
             append(keymasterVersion ?: "null")
             append('\n')
+            append("vendorApiLevel=")
+            append(vendorApiLevel ?: "null")
+            append('\n')
+            append("vendorApiDetail=")
+            append(vendorApiDetail)
+            append('\n')
             append("comparedDeclarations=")
             append(comparedDeclarations.joinToString { it.summary }.ifBlank { "none" })
             append('\n')
@@ -448,4 +551,80 @@ data class VintfKeyMintVersionResult(
             append('\n')
             append(detail)
         }
+}
+
+fun interface VendorApiLevelReader {
+    fun read(): VendorApiLevelResult
+}
+
+data class VendorApiLevelResult(
+    val level: Int?,
+    val detail: String,
+) {
+    companion object {
+        fun unused(): VendorApiLevelResult = VendorApiLevelResult(
+            level = null,
+            detail = "Vendor API level was not required.",
+        )
+    }
+}
+
+internal fun resolveVendorApiLevel(readProperty: (String) -> String?): VendorApiLevelResult {
+    // This intentionally mirrors KeyMint VTS get_vendor_api_level(), rather than using
+    // Build.VERSION.SDK_INT or a different init/libvendorsupport interpretation:
+    //   ro.vendor.api_level
+    //   else ro.board.api_level
+    //   else ro.board.first_api_level
+    //   productApi = ro.product.first_api_level ?: ro.build.version.sdk
+    //   if boardApi is absent, return productApi; otherwise return min(productApi, boardApi).
+    // 这里刻意复刻 KeyMint VTS 的 get_vendor_api_level()，不能用 Build.VERSION.SDK_INT 或另一套
+    // init/libvendorsupport 语义替代：vendor 属性优先；board 两个属性缺失时直接返回 product；
+    // board 存在时返回 min(productApi, boardApi)。
+    //
+    // AOSP reference:
+    // hardware/interfaces/security/keymint/aidl/vts/functional/KeyMintAidlTestBase.cpp
+    // https://android.googlesource.com/platform/hardware/interfaces/+/refs/heads/main/security/keymint/aidl/vts/functional/KeyMintAidlTestBase.cpp
+    fun property(name: String): Int? = readProperty(name)
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+        ?.toIntOrNull()
+        ?.takeIf { it >= 0 }
+
+    property("ro.vendor.api_level")?.let { level ->
+        return VendorApiLevelResult(level, "source=ro.vendor.api_level")
+    }
+
+    val boardApiLevel = property("ro.board.api_level")
+        ?: property("ro.board.first_api_level")
+    val productApiLevel = property("ro.product.first_api_level")
+        ?: property("ro.build.version.sdk")
+        ?: return VendorApiLevelResult(
+            level = null,
+            detail = "Missing ro.product.first_api_level and ro.build.version.sdk.",
+        )
+
+    return if (boardApiLevel == null) {
+        VendorApiLevelResult(productApiLevel, "source=productApi, boardApi=absent")
+    } else {
+        VendorApiLevelResult(
+            level = minOf(productApiLevel, boardApiLevel),
+            detail = "source=min(productApi=$productApiLevel, boardApi=$boardApiLevel)",
+        )
+    }
+}
+
+private class ReflectionVendorApiLevelReader : VendorApiLevelReader {
+    override fun read(): VendorApiLevelResult {
+        return runCatching {
+            val clazz = Class.forName("android.os.SystemProperties")
+            val method = clazz.getMethod("get", String::class.java)
+            resolveVendorApiLevel { name -> method.invoke(null, name) as? String }
+        }.getOrElse { throwable ->
+            VendorApiLevelResult(
+                level = null,
+                detail = "SystemProperties unavailable: ${throwable.javaClass.simpleName}: " +
+                    (throwable.message ?: "no message"),
+            )
+        }
+    }
 }

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/report/TeeReportReducerTest.kt
@@ -140,6 +140,30 @@ class TeeReportReducerTest {
     }
 
     @Test
+    fun `skipped mgf1 checks do not become crypto failures`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                keyMintCapability = KeyMintCapabilityResult(
+                    executed = true,
+                    crypto = KeyMintCryptoCapabilityResult(
+                        rsaOaepMgf1Executed = false,
+                        rsaOaepMgf1Ok = false,
+                        rsaOaepMgf1Detail = "Skipped because security levels disagree.",
+                        rsaOaepMgf1Sha1Executed = false,
+                        rsaOaepMgf1Sha1Ok = false,
+                        rsaOaepMgf1Sha1Detail = "Skipped because security levels disagree.",
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals(0, report.supplementaryIndicatorCount)
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "KeyMint crypto" && it.level == TeeSignalLevel.INFO
+        })
+    }
+
+    @Test
     fun `keymint crypto row hides full diagnostic behind copy payload`() {
         val report = reducer.reduce(
             baseArtifacts(
@@ -323,6 +347,29 @@ class TeeReportReducerTest {
             it.title == "KeyMint VINTF" &&
                 it.level == TeeSignalLevel.FAIL &&
                 it.body.contains("did not match", ignoreCase = true)
+        })
+    }
+
+    @Test
+    fun `keymint runtime identity mismatch becomes explicit supplementary failure`() {
+        val report = reducer.reduce(
+            baseArtifacts(
+                vintfKeyMintVersion = VintfKeyMintVersionResult(
+                    readable = true,
+                    anomalyKind = VintfKeyMintVersionAnomalyKind.MISMATCH,
+                    attestationVersion = 100,
+                    keymasterVersion = 300,
+                    detail = "Attestation and keymaster versions disagree on KeyMint runtime identity.",
+                ),
+            ),
+        )
+
+        assertEquals(1, report.supplementaryIndicatorCount)
+        assertEquals(TeeSignalLevel.FAIL, report.supplementaryReviewLevel)
+        assertTrue(report.sections.single { it.title == "Checks" }.items.any {
+            it.title == "KeyMint runtime identity" &&
+                it.level == TeeSignalLevel.FAIL &&
+                it.body.contains("AOSP single-runtime mapping")
         })
     }
 

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepositoryKeyMintVersionTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/repository/TeeRepositoryKeyMintVersionTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.repository
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TeeRepositoryKeyMintVersionTest {
+
+    @Test
+    fun `keymint runtime identity requires equal projected versions`() {
+        assertTrue(keyMintRuntimeIdentityConsistent(100, 100))
+        assertTrue(keyMintRuntimeIdentityConsistent(300, 300))
+        assertFalse(keyMintRuntimeIdentityConsistent(100, 300))
+        assertFalse(keyMintRuntimeIdentityConsistent(300, 100))
+    }
+
+    @Test
+    fun `legacy keymaster runtime identity follows aosp conversion table`() {
+        assertTrue(keyMintRuntimeIdentityConsistent(1, 2))
+        assertTrue(keyMintRuntimeIdentityConsistent(2, 3))
+        assertTrue(keyMintRuntimeIdentityConsistent(3, 4))
+        assertTrue(keyMintRuntimeIdentityConsistent(4, 41))
+        assertFalse(keyMintRuntimeIdentityConsistent(2, 41))
+        assertFalse(keyMintRuntimeIdentityConsistent(4, 4))
+    }
+
+    @Test
+    fun `missing projection does not invent a runtime conflict`() {
+        assertTrue(keyMintRuntimeIdentityConsistent(null, 300))
+        assertTrue(keyMintRuntimeIdentityConsistent(300, null))
+    }
+}

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/KeyMintCapabilityProbeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/KeyMintCapabilityProbeTest.kt
@@ -1,0 +1,394 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.tee.data.verification.keystore
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KeyMintCapabilityProbeTest {
+
+    @Test
+    fun `backend classifier keeps explicit legacy separate from keymint`() {
+        assertEquals(
+            KeyMintBackendFamily.LEGACY_KEYMASTER,
+            classifyKeyMintBackend(
+                attestationVersion = 4,
+                keymasterVersion = 41,
+                declaredKeyMintVersion = null,
+                legacyKeymasterDeclared = true,
+                runtimeIdentityConsistent = true,
+            ).family,
+        )
+        assertEquals(
+            KeyMintBackendFamily.KEYMINT,
+            classifyKeyMintBackend(
+                attestationVersion = 200,
+                keymasterVersion = 200,
+                declaredKeyMintVersion = null,
+                legacyKeymasterDeclared = false,
+                runtimeIdentityConsistent = true,
+            ).family,
+        )
+    }
+
+    @Test
+    fun `backend classifier skips unknown instead of assuming keymint1`() {
+        val decision = classifyKeyMintBackend(
+            attestationVersion = null,
+            keymasterVersion = null,
+            declaredKeyMintVersion = null,
+            legacyKeymasterDeclared = false,
+            runtimeIdentityConsistent = true,
+        )
+
+        assertEquals(KeyMintBackendFamily.UNKNOWN, decision.family)
+        assertTrue(decision.skipDetail.contains("could not be established"))
+    }
+
+    @Test
+    fun `backend classifier treats mixed version families as conflict`() {
+        val decision = classifyKeyMintBackend(
+            attestationVersion = 300,
+            keymasterVersion = 41,
+            declaredKeyMintVersion = null,
+            legacyKeymasterDeclared = false,
+            runtimeIdentityConsistent = false,
+        )
+
+        assertEquals(KeyMintBackendFamily.CONFLICT, decision.family)
+        assertTrue(decision.skipDetail.contains("runtime identity signals conflict"))
+    }
+
+    @Test
+    fun `backend classifier treats unequal keymint projections as conflict`() {
+        val decision = classifyKeyMintBackend(
+            attestationVersion = 100,
+            keymasterVersion = 300,
+            declaredKeyMintVersion = 300,
+            legacyKeymasterDeclared = false,
+            runtimeIdentityConsistent = false,
+        )
+
+        assertEquals(KeyMintBackendFamily.CONFLICT, decision.family)
+        assertTrue(decision.skipDetail.contains("runtime identity signals conflict"))
+    }
+
+    @Test
+    fun `mgf1 plan skips when selected security level identity conflicts`() {
+        val plan = resolveMgf1ProbePlan(
+            backend = KeyMintBackendDecision(
+                family = KeyMintBackendFamily.KEYMINT,
+                version = 300,
+                attestationVersion = 300,
+                keymasterVersion = 300,
+                skipDetail = "",
+            ),
+            securityLevelsConsistent = false,
+        )
+
+        assertEquals(Mgf1ProbeMode.SKIP, plan.mode)
+        assertTrue(plan.detail.contains("security levels disagree"))
+    }
+
+    @Test
+    fun `mgf1 plan uses operation only for keymint1 and keymint2`() {
+        listOf(100, 200).forEach { version ->
+            val plan = resolveMgf1ProbePlan(
+                backend = KeyMintBackendDecision(
+                    family = KeyMintBackendFamily.KEYMINT,
+                    version = version,
+                    attestationVersion = version,
+                    keymasterVersion = version,
+                    skipDetail = "",
+                ),
+                securityLevelsConsistent = true,
+            )
+
+            assertEquals(Mgf1ProbeMode.OPERATION_ONLY, plan.mode)
+        }
+    }
+
+    @Test
+    fun `mgf1 plan requires characteristics from keymint3 onward`() {
+        val plan = resolveMgf1ProbePlan(
+            backend = KeyMintBackendDecision(
+                family = KeyMintBackendFamily.KEYMINT,
+                version = 300,
+                attestationVersion = 300,
+                keymasterVersion = 300,
+                skipDetail = "",
+            ),
+            securityLevelsConsistent = true,
+        )
+
+        assertEquals(Mgf1ProbeMode.CHARACTERISTICS_AND_OPERATION, plan.mode)
+    }
+
+    @Test
+    fun `mgf1 plan preserves backend skip reason`() {
+        val plan = resolveMgf1ProbePlan(
+            backend = KeyMintBackendDecision(
+                family = KeyMintBackendFamily.CONFLICT,
+                version = 300,
+                attestationVersion = 100,
+                keymasterVersion = 300,
+                skipDetail = "runtime identity conflict",
+            ),
+            securityLevelsConsistent = true,
+        )
+
+        assertEquals(Mgf1ProbeMode.SKIP, plan.mode)
+        assertEquals("runtime identity conflict", plan.detail)
+    }
+
+    @Test
+    fun `mgf1 probe runs when generated key retains hardware sha256 authorization`() {
+        val capability = evaluateRsaOaepMgf1Capability(
+            authorizations = listOf(
+                AuthorizationSummary(tag = 0x10000002, intValue = 3, securityLevel = 1),
+                AuthorizationSummary(tag = 0x200000CB, intValue = 4, securityLevel = 1),
+            ),
+            attestationVersion = 300,
+            keymasterVersion = 300,
+        )
+
+        assertTrue(capability.supported)
+        assertTrue(capability.shouldExecute)
+    }
+
+    @Test
+    fun `mgf1 probe skips legacy key characteristics`() {
+        val capability = evaluateRsaOaepMgf1Capability(
+            authorizations = listOf(
+                AuthorizationSummary(tag = 0x10000002, intValue = 3, securityLevel = 1),
+                AuthorizationSummary(tag = 0x20000005, intValue = 4, securityLevel = 1),
+                AuthorizationSummary(tag = 0x6000012E, intValue = null, securityLevel = 100),
+            ),
+            attestationVersion = 4,
+            keymasterVersion = 41,
+        )
+
+        assertFalse(capability.supported)
+        assertFalse(capability.shouldExecute)
+        assertTrue(capability.detail.contains("legacy Keymaster/km_compat"))
+    }
+
+    @Test
+    fun `keymint3 unreadable characteristics fail closed`() {
+        val capability = evaluateRsaOaepMgf1Capability(
+            authorizations = emptyList(),
+            attestationVersion = 300,
+            keymasterVersion = 300,
+        )
+
+        assertFalse(capability.supported)
+        assertTrue(capability.shouldExecute)
+        assertTrue(capability.detail.contains("omit RSA_OAEP_MGF_DIGEST"))
+    }
+
+    @Test
+    fun `keymint3 missing mgf tag is failure not skip`() {
+        val capability = evaluateRsaOaepMgf1Capability(
+            authorizations = listOf(
+                AuthorizationSummary(tag = 0x10000002, intValue = 3, securityLevel = 1),
+            ),
+            attestationVersion = 300,
+            keymasterVersion = 300,
+        )
+
+        assertFalse(capability.supported)
+        assertTrue(capability.shouldExecute)
+        assertTrue(capability.detail.contains("KeyMint 3+"))
+    }
+
+    @Test
+    fun `keymint2 missing mgf tag uses raw operation checks`() {
+        val capability = evaluateRsaOaepMgf1Capability(
+            authorizations = listOf(
+                AuthorizationSummary(tag = 0x10000002, intValue = 3, securityLevel = 1),
+            ),
+            attestationVersion = 200,
+            keymasterVersion = 200,
+        )
+
+        assertTrue(capability.supported)
+        assertTrue(capability.shouldExecute)
+        assertTrue(capability.detail.contains("raw keystore2"))
+    }
+
+    @Test
+    fun `keymint1 missing mgf tag uses raw operation checks`() {
+        val capability = evaluateRsaOaepMgf1Capability(
+            authorizations = listOf(
+                AuthorizationSummary(tag = 0x10000002, intValue = 3, securityLevel = 1),
+            ),
+            attestationVersion = 100,
+            keymasterVersion = 100,
+        )
+
+        assertTrue(capability.supported)
+        assertTrue(capability.shouldExecute)
+        assertTrue(capability.detail.contains("raw keystore2"))
+    }
+
+    @Test
+    fun `legacy keymaster missing mgf tag still skips`() {
+        val capability = evaluateRsaOaepMgf1Capability(
+            authorizations = listOf(
+                AuthorizationSummary(tag = 0x10000002, intValue = 3, securityLevel = 1),
+            ),
+            attestationVersion = 4,
+            keymasterVersion = 41,
+        )
+
+        assertFalse(capability.supported)
+        assertFalse(capability.shouldExecute)
+        assertTrue(capability.detail.contains("legacy Keymaster/km_compat"))
+    }
+
+    @Test
+    fun `vintf keymint2 declaration does not override conflicting legacy signals`() {
+        val decision = classifyKeyMintBackend(
+            attestationVersion = 4,
+            keymasterVersion = 41,
+            declaredKeyMintVersion = 200,
+            legacyKeymasterDeclared = false,
+            runtimeIdentityConsistent = false,
+        )
+
+        assertEquals(KeyMintBackendFamily.CONFLICT, decision.family)
+    }
+
+    @Test
+    fun `highest observed keymint version controls strictness`() {
+        assertEquals(300, deriveObservedKeyMintVersion(300, 300, 200))
+        assertEquals(200, deriveObservedKeyMintVersion(200, 200, 300))
+        assertEquals(200, deriveObservedKeyMintVersion(4, 41, 200))
+    }
+
+    @Test
+    fun `vintf version is fallback only when runtime versions are absent`() {
+        assertEquals(300, deriveObservedKeyMintVersion(null, null, 300))
+        assertEquals(200, deriveObservedKeyMintVersion(200, null, 300))
+    }
+
+    @Test
+    fun `wrong hardware security level mgf tag is failure`() {
+        val capability = evaluateRsaOaepMgf1Capability(
+            authorizations = listOf(
+                AuthorizationSummary(tag = 0x200000CB, intValue = 4, securityLevel = 100),
+            ),
+            attestationVersion = 300,
+            keymasterVersion = 300,
+        )
+
+        assertFalse(capability.supported)
+        assertTrue(capability.shouldExecute)
+        assertTrue(capability.detail.contains("selected hardware security level"))
+    }
+
+    @Test
+    fun `extra mgf authorization is failure`() {
+        val capability = evaluateRsaOaepMgf1Capability(
+            authorizations = listOf(
+                AuthorizationSummary(tag = 0x200000CB, intValue = 4, securityLevel = 1),
+                AuthorizationSummary(tag = 0x200000CB, intValue = 2, securityLevel = 1),
+            ),
+            attestationVersion = 300,
+            keymasterVersion = 300,
+        )
+
+        assertFalse(capability.supported)
+        assertTrue(capability.shouldExecute)
+        assertTrue(capability.detail.contains("expected=[4]"))
+    }
+
+    @Test
+    fun `duplicate sha256 mgf authorization is failure`() {
+        val capability = evaluateRsaOaepMgf1Capability(
+            authorizations = listOf(
+                AuthorizationSummary(tag = 0x200000CB, intValue = 4, securityLevel = 1),
+                AuthorizationSummary(tag = 0x200000CB, intValue = 4, securityLevel = 1),
+            ),
+            attestationVersion = 300,
+            keymasterVersion = 300,
+        )
+
+        assertFalse(capability.supported)
+        assertTrue(capability.shouldExecute)
+    }
+
+    @Test
+    fun `strongbox sha256 mgf authorization matches selected level`() {
+        val capability = evaluateRsaOaepMgf1Capability(
+            authorizations = listOf(
+                AuthorizationSummary(tag = 0x200000CB, intValue = 4, securityLevel = 2),
+            ),
+            attestationVersion = 300,
+            keymasterVersion = 300,
+            expectedSecurityLevel = 2,
+        )
+
+        assertTrue(capability.supported)
+        assertTrue(capability.shouldExecute)
+    }
+
+    @Test
+    fun `keymint2 returned key security level mismatch fails`() {
+        val capability = evaluateRsaOaepMgf1Capability(
+            authorizations = emptyList(),
+            attestationVersion = 200,
+            keymasterVersion = 200,
+            expectedSecurityLevel = 2,
+            returnedSecurityLevel = 1,
+        )
+
+        assertFalse(capability.supported)
+        assertTrue(capability.shouldExecute)
+        assertTrue(capability.detail.contains("security level=1"))
+    }
+
+    @Test
+    fun `keymint3 returned key security level mismatch fails before characteristics`() {
+        val capability = evaluateRsaOaepMgf1Capability(
+            authorizations = listOf(
+                AuthorizationSummary(tag = 0x200000CB, intValue = 4, securityLevel = 2),
+            ),
+            attestationVersion = 300,
+            keymasterVersion = 300,
+            expectedSecurityLevel = 2,
+            returnedSecurityLevel = 1,
+        )
+
+        assertFalse(capability.supported)
+        assertTrue(capability.detail.contains("expected=2"))
+    }
+
+    @Test
+    fun `raw mgf rejection matrix matches vts cases and exact errors`() {
+        val cases = keyMintMgfRejectionCases()
+
+        assertTrue(cases.any { it.name == "default-sha1" && it.mgfDigest == null })
+        assertEquals(setOf(-78, -79), cases.single { it.name == "default-sha1" }.expectedErrorCodes)
+        assertEquals(3, cases.single { it.name == "explicit-sha224" }.mgfDigest)
+        assertEquals(setOf(-78), cases.single { it.name == "explicit-sha224" }.expectedErrorCodes)
+        assertEquals(0, cases.single { it.name == "unsupported-none" }.mgfDigest)
+        assertEquals(setOf(-79), cases.single { it.name == "unsupported-none" }.expectedErrorCodes)
+    }
+}

--- a/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/VintfKeyMintVersionProbeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/tee/data/verification/keystore/VintfKeyMintVersionProbeTest.kt
@@ -26,6 +26,24 @@ import org.junit.Test
 class VintfKeyMintVersionProbeTest {
 
     @Test
+    fun `old vendor aidl matching applies fallback rule to both attestation fields`() {
+        val declaration = keyMintDeclaration(aidlVersion = 5)
+
+        assertTrue(declaration.matches(400, 300, 202504))
+        assertTrue(!declaration.matches(550, 400, 202504))
+        assertTrue(!declaration.matches(400, 350, 202504))
+    }
+
+    @Test
+    fun `new vendor aidl matching requires both attestation fields to equal declaration`() {
+        val declaration = keyMintDeclaration(aidlVersion = 5)
+
+        assertTrue(declaration.matches(500, 500, 202604))
+        assertTrue(!declaration.matches(400, 500, 202604))
+        assertTrue(!declaration.matches(500, 400, 202604))
+    }
+
+    @Test
     fun `hidl version range expands for keymaster 4_1`() {
         withManifest(
             """
@@ -101,6 +119,7 @@ class VintfKeyMintVersionProbeTest {
             val result = VintfKeyMintVersionProbe(
                 manifestDirs = emptyList(),
                 manifestFiles = listOf(path),
+                vendorApiLevelReader = vendorApiLevelReader(202404),
             ).inspect(
                 snapshot(attestationVersion = 200, keymasterVersion = 200).copy(
                     tier = TeeTier.STRONGBOX,
@@ -196,10 +215,147 @@ class VintfKeyMintVersionProbeTest {
             val result = VintfKeyMintVersionProbe(
                 manifestDirs = emptyList(),
                 manifestFiles = listOf(path),
+                vendorApiLevelReader = vendorApiLevelReader(202604),
             ).inspect(snapshot(attestationVersion = 300, keymasterVersion = 41))
 
             assertEquals(VintfKeyMintVersionAnomalyKind.MISMATCH, result.anomalyKind)
             assertTrue(result.detail.contains("HAL family"))
+        }
+    }
+
+    @Test
+    fun `keymint runtime version disagreement is a mismatch`() {
+        withManifest(
+            """
+            <manifest version="1.0" type="device">
+                <hal format="aidl">
+                    <name>android.hardware.security.keymint</name>
+                    <version>3</version>
+                    <interface>
+                        <name>IKeyMintDevice</name>
+                        <instance>default</instance>
+                    </interface>
+                </hal>
+            </manifest>
+            """.trimIndent(),
+        ) { path ->
+            val result = VintfKeyMintVersionProbe(
+                manifestDirs = emptyList(),
+                manifestFiles = listOf(path),
+                vendorApiLevelReader = vendorApiLevelReader(202604),
+            ).inspect(snapshot(attestationVersion = 100, keymasterVersion = 300))
+
+            assertEquals(VintfKeyMintVersionAnomalyKind.MISMATCH, result.anomalyKind)
+            assertTrue(result.detail.contains("runtime identity"))
+        }
+    }
+
+    @Test
+    fun `older keymint runtime is compatible with newer aidl declaration on old vendor api`() {
+        withManifest(
+            """
+            <manifest version="1.0" type="device">
+                <hal format="aidl">
+                    <name>android.hardware.security.keymint</name>
+                    <version>5</version>
+                    <interface>
+                        <name>IKeyMintDevice</name>
+                        <instance>default</instance>
+                    </interface>
+                </hal>
+            </manifest>
+            """.trimIndent(),
+        ) { path ->
+            val result = VintfKeyMintVersionProbe(
+                manifestDirs = emptyList(),
+                manifestFiles = listOf(path),
+                vendorApiLevelReader = vendorApiLevelReader(202504),
+            ).inspect(snapshot(attestationVersion = 400, keymasterVersion = 400))
+
+            assertEquals(VintfKeyMintVersionAnomalyKind.NONE, result.anomalyKind)
+            assertTrue(result.comparedDeclarations.single().matches(400, 400, 202504))
+        }
+    }
+
+    @Test
+    fun `older keymint runtime mismatches newer aidl declaration on new vendor api`() {
+        withManifest(
+            """
+            <manifest version="1.0" type="device">
+                <hal format="aidl">
+                    <name>android.hardware.security.keymint</name>
+                    <version>5</version>
+                    <interface>
+                        <name>IKeyMintDevice</name>
+                        <instance>default</instance>
+                    </interface>
+                </hal>
+            </manifest>
+            """.trimIndent(),
+        ) { path ->
+            val result = VintfKeyMintVersionProbe(
+                manifestDirs = emptyList(),
+                manifestFiles = listOf(path),
+                vendorApiLevelReader = vendorApiLevelReader(202604),
+            ).inspect(snapshot(attestationVersion = 400, keymasterVersion = 400))
+
+            assertEquals(VintfKeyMintVersionAnomalyKind.MISMATCH, result.anomalyKind)
+        }
+    }
+
+    @Test
+    fun `unknown vendor api cannot return clean aidl comparison`() {
+        withManifest(
+            """
+            <manifest version="1.0" type="device">
+                <hal format="aidl">
+                    <name>android.hardware.security.keymint</name>
+                    <version>5</version>
+                    <interface>
+                        <name>IKeyMintDevice</name>
+                        <instance>default</instance>
+                    </interface>
+                </hal>
+            </manifest>
+            """.trimIndent(),
+        ) { path ->
+            val result = VintfKeyMintVersionProbe(
+                manifestDirs = emptyList(),
+                manifestFiles = listOf(path),
+                vendorApiLevelReader = VendorApiLevelReader {
+                    VendorApiLevelResult(null, "test vendor API unavailable")
+                },
+            ).inspect(snapshot(attestationVersion = 500, keymasterVersion = 500))
+
+            assertEquals(VintfKeyMintVersionAnomalyKind.UNREADABLE, result.anomalyKind)
+            assertTrue(!result.readable)
+            assertTrue(result.detail.contains("vendor API level could not be determined"))
+        }
+    }
+
+    @Test
+    fun `keymint runtime above aidl declaration remains mismatch`() {
+        withManifest(
+            """
+            <manifest version="1.0" type="device">
+                <hal format="aidl">
+                    <name>android.hardware.security.keymint</name>
+                    <version>5</version>
+                    <interface>
+                        <name>IKeyMintDevice</name>
+                        <instance>default</instance>
+                    </interface>
+                </hal>
+            </manifest>
+            """.trimIndent(),
+        ) { path ->
+            val result = VintfKeyMintVersionProbe(
+                manifestDirs = emptyList(),
+                manifestFiles = listOf(path),
+                vendorApiLevelReader = vendorApiLevelReader(202604),
+            ).inspect(snapshot(attestationVersion = 600, keymasterVersion = 600))
+
+            assertEquals(VintfKeyMintVersionAnomalyKind.MISMATCH, result.anomalyKind)
         }
     }
 
@@ -221,6 +377,7 @@ class VintfKeyMintVersionProbeTest {
             val result = VintfKeyMintVersionProbe(
                 manifestDirs = emptyList(),
                 manifestFiles = listOf(path),
+                vendorApiLevelReader = vendorApiLevelReader(202604),
             ).inspect(snapshot(attestationVersion = 100, keymasterVersion = 100))
 
             assertEquals(VintfKeyMintVersionAnomalyKind.NONE, result.anomalyKind)
@@ -254,6 +411,115 @@ class VintfKeyMintVersionProbeTest {
         }
     }
 
+    @Test
+    fun `malformed unrelated vintf fragments do not poison keymint result`() {
+        withManifestDirectory(
+            mapOf(
+                "android.hardware.security.keymint.xml" to """
+                    <manifest version="1.0" type="device">
+                        <hal format="aidl">
+                            <name>android.hardware.security.keymint</name>
+                            <version>2</version>
+                            <interface>
+                                <name>IKeyMintDevice</name>
+                                <instance>default</instance>
+                            </interface>
+                        </hal>
+                    </manifest>
+                """.trimIndent(),
+                "atcmdfwd-saidl.xml" to "/* Copyright */\nnot xml",
+                "vendor.qti.qesdsys.service.xml" to "/** Copyright */\nstill not xml",
+            ),
+        ) { path ->
+            val result = VintfKeyMintVersionProbe(
+                manifestDirs = listOf(path),
+                manifestFiles = emptyList(),
+                vendorApiLevelReader = vendorApiLevelReader(202604),
+            ).inspect(snapshot(attestationVersion = 200, keymasterVersion = 200))
+
+            assertEquals(VintfKeyMintVersionAnomalyKind.NONE, result.anomalyKind)
+            assertTrue(result.readable)
+            assertTrue(result.unreadablePaths.isEmpty())
+        }
+    }
+
+    @Test
+    fun `malformed keymint fragment remains unreadable`() {
+        withManifestDirectory(
+            mapOf(
+                "android.hardware.security.keymint.xml" to """
+                    /* Copyright */
+                    <manifest version="1.0" type="device">
+                        <hal format="aidl">
+                            <name>android.hardware.security.keymint</name>
+                        </hal>
+                    </manifest>
+                """.trimIndent(),
+            ),
+        ) { path ->
+            val result = VintfKeyMintVersionProbe(
+                manifestDirs = listOf(path),
+                manifestFiles = emptyList(),
+            ).inspect(snapshot(attestationVersion = 200, keymasterVersion = 200))
+
+            assertEquals(VintfKeyMintVersionAnomalyKind.UNREADABLE, result.anomalyKind)
+            assertTrue(!result.readable)
+            assertTrue(result.unreadablePaths.single().contains("keymint"))
+        }
+    }
+
+    @Test
+    fun `vendor api resolver uses direct vendor property first`() {
+        val properties = mapOf(
+            "ro.vendor.api_level" to "202604",
+            "ro.board.api_level" to "202504",
+            "ro.product.first_api_level" to "35",
+        )
+
+        val result = resolveVendorApiLevel(properties::get)
+
+        assertEquals(202604, result.level)
+        assertTrue(result.detail.contains("ro.vendor.api_level"))
+    }
+
+    @Test
+    fun `vendor api resolver mirrors vts board and product minimum`() {
+        val properties = mapOf(
+            "ro.vendor.api_level" to "-1",
+            "ro.board.api_level" to "202604",
+            "ro.product.first_api_level" to "202504",
+        )
+
+        val result = resolveVendorApiLevel(properties::get)
+
+        assertEquals(202504, result.level)
+        assertTrue(result.detail.contains("min(productApi=202504, boardApi=202604)"))
+    }
+
+    @Test
+    fun `vendor api resolver uses product when board properties are absent`() {
+        val properties = mapOf(
+            "ro.product.first_api_level" to "202504",
+        )
+
+        val result = resolveVendorApiLevel(properties::get)
+
+        assertEquals(202504, result.level)
+        assertTrue(result.detail.contains("boardApi=absent"))
+    }
+
+    @Test
+    fun `vendor api resolver falls back to build sdk and reports unknown when absent`() {
+        assertEquals(
+            37,
+            resolveVendorApiLevel(mapOf("ro.build.version.sdk" to "37")::get).level,
+        )
+
+        val unknown = resolveVendorApiLevel(emptyMap<String, String>()::get)
+        assertEquals(null, unknown.level)
+        assertTrue(unknown.detail.contains("Missing"))
+    }
+
     private fun withManifest(xml: String, block: (String) -> Unit) {
         val dir = Files.createTempDirectory("duck_vintf").toFile()
         try {
@@ -263,6 +529,34 @@ class VintfKeyMintVersionProbeTest {
         } finally {
             dir.deleteRecursively()
         }
+    }
+
+    private fun withManifestDirectory(files: Map<String, String>, block: (String) -> Unit) {
+        val dir = Files.createTempDirectory("duck_vintf_dir").toFile()
+        try {
+            files.forEach { (name, content) -> dir.resolve(name).writeText(content) }
+            block(dir.absolutePath)
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    private fun vendorApiLevelReader(level: Int): VendorApiLevelReader = VendorApiLevelReader {
+        VendorApiLevelResult(level, "test vendor API level=$level")
+    }
+
+    private fun keyMintDeclaration(aidlVersion: Int): VintfKeyMintVersionDeclaration {
+        return VintfKeyMintVersionDeclaration(
+            family = VintfKeyMintVersionFamily.KEYMINT_AIDL,
+            sourcePath = "/test/manifest.xml",
+            format = "aidl",
+            halName = "android.hardware.security.keymint",
+            interfaceName = "IKeyMintDevice",
+            instance = "default",
+            vintfVersion = aidlVersion.toString(),
+            expectedKeymasterVersion = aidlVersion * 100,
+            expectedAttestationVersion = aidlVersion * 100,
+        )
     }
 
     private fun snapshot(attestationVersion: Int?, keymasterVersion: Int?): AttestationSnapshot {


### PR DESCRIPTION
Tighten TEE verification around KeyMint runtime identity, VINTF declarations, and RSA-OAEP MGF1 capability probing. The previous implementation could infer a stricter KeyMint backend from conflicting version signals, treat an unexecuted MGF1 probe as a cryptographic failure when security-level identity was inconsistent, and apply overly permissive VINTF matching without considering the vendor API level.

This change makes backend selection explicit, applies the AOSP KeyMint version relationships directly, and keeps identity inconsistencies separate from capability failures.

KeyMint runtime identity:

* Add explicit validation for the relationship between attestationVersion and keymasterVersion.
* Treat Keymaster and KeyMint values as different version families and reject mixed-family observations instead of selecting a backend based on numeric magnitude.
* Require attestationVersion and keymasterVersion to be equal for native KeyMint runtimes.
* Preserve the AOSP-defined legacy Keymaster mappings:

  * Keymaster 2 -> Attestation 1
  * Keymaster 3 -> Attestation 2
  * Keymaster 4 -> Attestation 3
  * Keymaster 4.1 -> Attestation 4
* Keep missing version fields non-conflicting so that the validator does not invent a runtime identity mismatch from incomplete evidence.
* Pass the resulting runtimeIdentityConsistent state into the KeyMint capability probe so conflicting runtime identities cannot be used to select an arbitrary backend.

Explicit backend classification:

* Introduce explicit backend families for legacy Keymaster, native KeyMint, unknown backends, and conflicting runtime signals.
* Stop implicitly assuming KeyMint 1 when runtime identity information is unavailable or contradictory.
* Prefer observed attestation/keymaster runtime versions over VINTF declarations when determining the effective KeyMint version.
* Use the VINTF-declared version only as a fallback when no runtime KeyMint version is available.
* Prevent conflicting legacy/native signals or explicit legacy declarations from being silently promoted into a native KeyMint backend.
* Return an explicit skip reason whenever the backend cannot be selected unambiguously.

MGF1 probe planning:

* Introduce an explicit MGF1 probe plan to distinguish:

  * SKIP when the backend identity cannot be established or the selected security level is inconsistent.
  * OPERATION_ONLY for KeyMint 1 and KeyMint 2.
  * CHARACTERISTICS_AND_OPERATION for KeyMint 3 and later.
* Keep TEE/StrongBox security-level consistency separate from runtime version identity. A security-level mismatch is evidence that the certificate fields do not unambiguously identify the same IKeystoreSecurityLevel instance, not evidence that an MGF1 operation executed and failed.
* When security levels disagree, mark both MGF1 subchecks as not executed and successful from the capability-probe perspective, with an explicit skip reason, so the mismatch is not double-counted as a KeyMint crypto failure.
* Preserve the existing KeyMint 3+ characteristics contract while making the KeyMint 1/2 operation-only behavior explicit.
* Continue to fail closed for malformed or invalid KeyMint 3+ MGF1 characteristics rather than converting real capability failures into skips.
* Keep raw RSA-OAEP MGF1 authorization rejection checks subject to the selected backend and probe mode.

KeyMint version selection:

* Replace the previous "highest available version wins" behavior with runtime-first selection.
* Do not use a newer VINTF declaration to upgrade an observed older runtime into a stricter KeyMint capability path.
* Preserve VINTF as a version fallback only when both runtime version fields are unavailable.
* Add an explicit KeyMint 3 version constant so the characteristics boundary is represented directly in the probe planning logic.

VINTF KeyMint validation:

* Extend AIDL KeyMint VINTF matching to account for the vendor API level.
* For vendor API levels greater than the strict compatibility threshold, require both attestationVersion and keymasterVersion to exactly equal aidlVersion * 100.
* For older vendor API levels, require both runtime fields to:

  * be present,
  * use the 100-based KeyMint version encoding,
  * be multiples of 100, and
  * not exceed the declared AIDL version multiplied by 100.
* Keep HIDL Keymaster matching on its existing explicit keymaster/attestation version relationships.
* Treat an unavailable vendor API level as an incomplete/unreadable AIDL comparison instead of returning a potentially misleading clean result.

Vendor API level resolution:

* Add an injectable VendorApiLevelReader for deterministic validation and tests.
* Resolve the vendor API level using the same property precedence documented for the KeyMint VTS path:

  * ro.vendor.api_level
  * ro.board.api_level
  * ro.board.first_api_level
  * ro.product.first_api_level
  * ro.build.version.sdk
* When both board and product API levels are available, use the minimum value for the fallback calculation.
* Preserve diagnostic information describing which property source was used.
* Report SystemProperties reflection failures and missing properties as an unavailable vendor API level rather than silently substituting an unrelated value.

VINTF fragment handling:

* Restrict the focused KeyMint VINTF probe to fragments that can plausibly describe KeyMint or Keymaster.
* Recognize KeyMint/Keymaster fragments by filename or by the relevant HAL and interface markers in the XML content.
* Ignore malformed unrelated VINTF fragments so an invalid fragment for another HAL cannot poison an otherwise complete KeyMint result.
* Continue treating malformed KeyMint/Keymaster fragments as unreadable so relevant corruption still fails closed.
* Preserve aggregate manifest handling while avoiding unnecessary parsing of unrelated vendor VINTF fragments.

Reporting and diagnostics:

* Report runtime version identity mismatches separately from the KeyMint crypto capability row.
* Make the diagnostic text explicitly describe AOSP single-runtime mapping violations when both native KeyMint version fields disagree.
* Add runtimeIdentityConsistent, vendorApiLevel, and vendorApiDetail to the generated diagnostic payloads.
* Keep skipped MGF1 checks distinguishable from executed checks through the existing executed/ok fields and detailed skip reasons.
* Avoid turning prerequisite or identity failures into duplicate cryptographic failures.

Tests:

* Add regression coverage for native KeyMint version equality and mixed-family conflicts.
* Verify all supported legacy Keymaster-to-attestation mappings and invalid combinations.
* Verify that missing runtime projections do not create artificial identity conflicts.
* Add backend classification tests covering native KeyMint, legacy Keymaster, unknown, and conflicting inputs.
* Verify MGF1 probe planning for:

  * inconsistent security levels,
  * KeyMint 1,
  * KeyMint 2,
  * KeyMint 3+,
  * backend identity conflicts, and
  * preserved skip reasons.
* Verify KeyMint 1/2 operation-only behavior and KeyMint 3+ characteristics validation.
* Verify that invalid MGF1 characteristics remain capability failures rather than skips.
* Add VINTF tests for old and new vendor API matching rules, unavailable vendor API levels, runtime versions above the declaration, and older runtime versions under both compatibility regimes.
* Add tests ensuring malformed unrelated VINTF fragments are ignored while malformed KeyMint fragments remain unreadable.
* Add vendor API property-resolution tests for direct vendor properties, board/product fallback, build SDK fallback, and unavailable property sets.
* Add report-level regression coverage confirming skipped MGF1 checks do not increase supplementary crypto failure counts and that runtime identity mismatches are surfaced as explicit supplementary failures.

The resulting validation flow is intentionally conservative: runtime and security-level identity must be established before capability results are used, VINTF declarations cannot silently override observed runtime behavior, and only checks that actually execute can produce cryptographic capability failures.