### PR TITLE
fix: tighten proc mount view scanning

### DIFF
--- a/app/src/main/assets/github_contributors.json
+++ b/app/src/main/assets/github_contributors.json
@@ -7,7 +7,7 @@
       "asm",
       "kotlin"
     ],
-    "contributions": 109,
+    "contributions": 74,
     "name": "eltavine",
     "avatarAssetPath": "github_contributors/avatars/eltavine.jpg",
     "summaryKey": "author_summary_eltavine",
@@ -19,7 +19,7 @@
       "cpp",
       "kotlin"
     ],
-    "contributions": 33,
+    "contributions": 34,
     "name": "XiaoTong6666",
     "avatarAssetPath": "github_contributors/avatars/xiaotong6666.jpg",
     "summaryKey": "author_summary_xiaotong",

--- a/app/src/main/java/com/eltavine/duckdetector/MainActivity.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/MainActivity.kt
@@ -22,9 +22,10 @@ import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
+import android.widget.FrameLayout
 import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.ui.platform.ComposeView
 import com.eltavine.duckdetector.core.startup.preload.EarlyMountPreloadStore
 import com.eltavine.duckdetector.core.startup.preload.EarlyVirtualizationPreloadStore
 import com.eltavine.duckdetector.ui.DuckDetectorApp
@@ -40,13 +41,23 @@ class MainActivity : ComponentActivity() {
         EarlyVirtualizationPreloadStore.capture(intent)
         enableEdgeToEdge()
         procMountSampler = createProcMountSampler()
-        setContent {
+        val root = FrameLayout(this)
+        procMountSampler?.let { sampler ->
+            root.addView(sampler, FrameLayout.LayoutParams(1, 1))
+        }
+        val composeView = ComposeView(this)
+        root.addView(
+            composeView,
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+            ),
+        )
+        setContentView(root)
+        composeView.setContent {
             DuckDetectorTheme {
                 DuckDetectorApp()
             }
-        }
-        procMountSampler?.let { sampler ->
-            addContentView(sampler, ViewGroup.LayoutParams(1, 1))
         }
     }
 
@@ -66,7 +77,7 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun createProcMountSampler(): WebView? {
-        // PrivIsolated creates a WebView renderer before scanning other isolated mount views.
+        // Attach this before starting Compose, matching PrivIsolated's WebView-before-bind order.
         return runCatching {
             WebView(this).apply {
                 alpha = 0f

--- a/app/src/main/java/com/eltavine/duckdetector/features/virtualization/data/probes/ProcMountViewScanner.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/virtualization/data/probes/ProcMountViewScanner.kt
@@ -148,17 +148,16 @@ class ProcMountViewScanner(
     ): ProcMountViewScanResult {
         var expectedViewCount = 1
         val views = linkedSetOf<String>()
-        var tokenHit = false
-        var tokenKind = ""
-        var tokenHitDetail = ""
         var readablePidCount = 0
+        var scannedPidCount = 0
 
-        pids.forEach { pid ->
+        for (pid in pids) {
+            scannedPidCount += 1
             val mounts = runCatching { lineReader(pid) }
                 .getOrDefault(emptyList())
                 .mapNotNull { line -> ParsedProcMount.parse(line) }
             if (mounts.isEmpty()) {
-                return@forEach
+                continue
             }
             readablePidCount += 1
             if (mounts.first().optional.startsWith("shared")) {
@@ -173,13 +172,27 @@ class ProcMountViewScanner(
             // Match PrivIsolated's canonical order before hashing the table. 先规范排序再比较，
             // 避免相同 mount tree 仅因内核枚举顺序不同而被误判成两个视图。
             val builder = StringBuilder()
-            sorted.forEach { mount ->
+            for (mount in sorted) {
                 val signature = mount.signature()
                 val matchedToken = ROOT_TOKEN_SEQUENCES.firstOrNull { signature.contains(it) }
-                if (!tokenHit && matchedToken != null) {
-                    tokenHit = true
-                    tokenKind = matchedToken
-                    tokenHitDetail = mount.rawLine
+                if (matchedToken != null) {
+                    return ProcMountViewScanResult(
+                        available = true,
+                        distinctViewCount = views.size,
+                        expectedViewCount = expectedViewCount,
+                        scannedPidCount = scannedPidCount,
+                        tokenHit = true,
+                        tokenKind = matchedToken,
+                        tokenHitDetail = mount.rawLine,
+                        detail = buildString {
+                            append("Scanned ")
+                            append(scannedPidCount)
+                            append(" pid(s), ")
+                            append(readablePidCount)
+                            append(" readable mount table(s).\nDirect root token: ")
+                            append(mount.rawLine)
+                        },
+                    )
                 }
                 builder.append(signature).append('\n')
             }
@@ -191,13 +204,13 @@ class ProcMountViewScanner(
                 available = false,
                 distinctViewCount = 0,
                 expectedViewCount = expectedViewCount,
-                scannedPidCount = pids.size,
+                scannedPidCount = scannedPidCount,
                 tokenHit = false,
                 tokenKind = "",
                 tokenHitDetail = "",
                 detail = buildString {
                     append("Scanned ")
-                    append(pids.size)
+                    append(scannedPidCount)
                     append(" pid(s) but no process mount table was readable; cross-process mount view comparison is unavailable.")
                 },
             )
@@ -207,13 +220,13 @@ class ProcMountViewScanner(
             available = true,
             distinctViewCount = views.size,
             expectedViewCount = expectedViewCount,
-            scannedPidCount = pids.size,
-            tokenHit = tokenHit,
-            tokenKind = tokenKind,
-            tokenHitDetail = tokenHitDetail,
+            scannedPidCount = scannedPidCount,
+            tokenHit = false,
+            tokenKind = "",
+            tokenHitDetail = "",
             detail = buildString {
                 append("Scanned ")
-                append(pids.size)
+                append(scannedPidCount)
                 append(" pid(s), ")
                 append(readablePidCount)
                 append(" readable mount table(s), ")
@@ -221,10 +234,6 @@ class ProcMountViewScanner(
                 append(" distinct view(s), expected ")
                 append(expectedViewCount)
                 append('.')
-                if (tokenHit) {
-                    append("\nDirect root token: ")
-                    append(tokenHitDetail)
-                }
             },
         )
     }

--- a/app/src/test/java/com/eltavine/duckdetector/features/virtualization/data/probes/ProcMountViewScannerTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/virtualization/data/probes/ProcMountViewScannerTest.kt
@@ -67,15 +67,21 @@ class ProcMountViewScannerTest {
             "22 25 8:1 / / rw,relatime - ext4 /dev/block/dm-2 rw,seclabel",
             "40 22 8:1 /magisk /system rw,seclabel - overlay overlay ro,seclabel",
         )
+        var reads = 0
         val result = scanner.evaluate(
-            pids = listOf("1000", "2000"),
-            lineReader = { pid -> if (pid == "2000") magiskView else cleanMountInfo },
+            pids = listOf("1000", "2000", "3000"),
+            lineReader = { pid ->
+                reads += 1
+                if (pid == "2000") magiskView else cleanMountInfo
+            },
         )
 
         assertTrue(result.available)
         assertTrue(result.tokenHit)
         assertEquals("magisk", result.tokenKind)
         assertEquals(magiskView[1], result.tokenHitDetail)
+        assertEquals(2, reads)
+        assertEquals(2, result.scannedPidCount)
     }
 
     @Test


### PR DESCRIPTION
Ensure the WebView sampler is attached before Compose starts, accurately track scanned PIDs, and stop mount scanning immediately after detecting a direct root token. Add regression coverage for the new early-exit behavior.