### PR TITLE
feat(bootloader): add Widevine credential consistency probe

### DIFF
--- a/Duck Detector Solution.md
+++ b/Duck Detector Solution.md
@@ -17,6 +17,10 @@ Verified boot
 -通过resetprop弱隐藏
 -通过可信执行环境检测(tee)
 
+检测到Widevine L1凭据一致性异常
+-该结果表示DRM凭据、硬件会话或Java/native属性存在矛盾，不能单独证明当前bootloader已解锁
+-锁定设备也可能因历史解锁、ROM转换或OEM预配缺陷出现该结果，应结合RootOfTrust和boot属性判断
+
 **TEE**
 可信执行环境检测与预期不符
 -使用Oh My Keymint模块或近期更新的keystone伪装模块

--- a/Duck Detector Solution.md
+++ b/Duck Detector Solution.md
@@ -21,7 +21,7 @@ Verified boot
 -精确sentinel属性、明确支持HW_SECURE_ALL却返回较低最大会话级别，或Java/native属性不一致作为DRM一致性信号
 -Android允许不支持请求等级时选择下一较低等级，VirtualDevice也可调整最大等级；能力预检未确认HW_SECURE_ALL时不将较低会话判为异常
 -Provisioning、显式安全级别会话请求或本地key request失败仅表示检测不完整，不等于凭据无效
--Widevine Warning会将非解锁状态降为UNKNOWN，Danger会提升为UNLOCKED；既有UNLOCKED或FAILED_VERIFICATION保持不变
+-Widevine Warning/Danger会影响Bootloader Card的一致性assessment和严重度，但不改写权威BootloaderState；UI以问号标记该分离状态
 
 **TEE**
 可信执行环境检测与预期不符

--- a/Duck Detector Solution.md
+++ b/Duck Detector Solution.md
@@ -18,8 +18,10 @@ Verified boot
 -通过可信执行环境检测(tee)
 
 检测到Widevine L1凭据一致性异常
--该结果表示DRM凭据、硬件会话或Java/native属性存在矛盾，不能单独证明当前bootloader已解锁
--锁定设备也可能因历史解锁、ROM转换或OEM预配缺陷出现该结果，应结合RootOfTrust和boot属性判断
+-精确sentinel属性、明确支持HW_SECURE_ALL却返回较低最大会话级别，或Java/native属性不一致作为DRM一致性信号
+-Android允许不支持请求等级时选择下一较低等级，VirtualDevice也可调整最大等级；能力预检未确认HW_SECURE_ALL时不将较低会话判为异常
+-Provisioning、显式安全级别会话请求或本地key request失败仅表示检测不完整，不等于凭据无效
+-Widevine Warning/Danger会同步影响整体Bootloader卡片严重度，但不会改写BootloaderState，也不能证明当前解锁状态或解锁导致了DRM异常
 
 **TEE**
 可信执行环境检测与预期不符

--- a/Duck Detector Solution.md
+++ b/Duck Detector Solution.md
@@ -21,7 +21,7 @@ Verified boot
 -精确sentinel属性、明确支持HW_SECURE_ALL却返回较低最大会话级别，或Java/native属性不一致作为DRM一致性信号
 -Android允许不支持请求等级时选择下一较低等级，VirtualDevice也可调整最大等级；能力预检未确认HW_SECURE_ALL时不将较低会话判为异常
 -Provisioning、显式安全级别会话请求或本地key request失败仅表示检测不完整，不等于凭据无效
--Widevine Warning/Danger会同步影响整体Bootloader卡片严重度，但不会改写BootloaderState，也不能证明当前解锁状态或解锁导致了DRM异常
+-Widevine Warning会将非解锁状态降为UNKNOWN，Danger会提升为UNLOCKED；既有UNLOCKED或FAILED_VERIFICATION保持不变
 
 **TEE**
 可信执行环境检测与预期不符

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -56,6 +56,10 @@ set(SYSTEM_PROPERTIES_SOURCES
     systemproperties/native_bridge.cpp
 )
 
+set(BOOTLOADER_SOURCES
+    bootloader/widevine_native_bridge.cpp
+)
+
 set(MOUNT_SOURCES
     mount/detector_core.cpp
     mount/native_bridge.cpp
@@ -167,6 +171,7 @@ add_library(duckdetector SHARED
     ${CUSTOM_ROM_SOURCES}
     ${KERNEL_CHECK_SOURCES}
     ${SYSTEM_PROPERTIES_SOURCES}
+    ${BOOTLOADER_SOURCES}
     ${MOUNT_SOURCES}
     ${PRELOAD_SOURCES}
     ${MEMORY_SOURCES}
@@ -203,4 +208,5 @@ target_link_libraries(duckdetector
     EGL
     GLESv2
     log
+    mediandk
 )

--- a/app/src/main/cpp/bootloader/widevine_native_bridge.cpp
+++ b/app/src/main/cpp/bootloader/widevine_native_bridge.cpp
@@ -18,10 +18,15 @@
 #include <media/NdkMediaDrm.h>
 
 #include <array>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 
 namespace {
+
+    // Widevine securityLevel and systemId are short ASCII properties.
+    constexpr size_t MAX_PROPERTY_VALUE_LENGTH = 64;
 
     constexpr std::array<uint8_t, 16> WIDEVINE_UUID = {
             0xed, 0xef, 0x8b, 0xa9,
@@ -41,13 +46,34 @@ namespace {
 
     using MediaDrmPtr = std::unique_ptr<AMediaDrm, MediaDrmReleaser>;
 
-    void set_string(JNIEnv *env, jobjectArray output, jsize index, const std::string &value) {
+    bool copy_property_value(const char *value, std::string *output) {
+        if (value == nullptr || output == nullptr) {
+            return false;
+        }
+        output->clear();
+        for (size_t index = 0; index <= MAX_PROPERTY_VALUE_LENGTH; ++index) {
+            const auto character = static_cast<unsigned char>(value[index]);
+            if (character == '\0') {
+                return index > 0;
+            }
+            if (index == MAX_PROPERTY_VALUE_LENGTH || character < 0x20 || character > 0x7e) {
+                output->clear();
+                return false;
+            }
+            output->push_back(static_cast<char>(character));
+        }
+        output->clear();
+        return false;
+    }
+
+    bool set_string(JNIEnv *env, jobjectArray output, jsize index, const std::string &value) {
         jstring java_value = env->NewStringUTF(value.c_str());
         if (java_value == nullptr) {
-            return;
+            return false;
         }
         env->SetObjectArrayElement(output, index, java_value);
         env->DeleteLocalRef(java_value);
+        return !env->ExceptionCheck();
     }
 
 }  // namespace
@@ -69,45 +95,60 @@ Java_com_eltavine_duckdetector_features_bootloader_data_widevine_WidevineNativeB
     }
 
     if (!AMediaDrm_isCryptoSchemeSupported(WIDEVINE_UUID.data(), nullptr)) {
-        set_string(env, output, 0, "0");
+        if (!set_string(env, output, 0, "0")) {
+            return nullptr;
+        }
         return output;
     }
 
     MediaDrmPtr media_drm(AMediaDrm_createByUUID(WIDEVINE_UUID.data()));
     if (media_drm == nullptr) {
-        set_string(env, output, 0, "0");
+        if (!set_string(env, output, 0, "0")) {
+            return nullptr;
+        }
         return output;
     }
 
     const char *security_level_pointer = nullptr;
-    const media_status_t security_level_status = AMediaDrm_getPropertyString(
+    media_status_t security_level_status = AMediaDrm_getPropertyString(
             media_drm.get(),
             "securityLevel",
             &security_level_pointer
     );
-    const std::string security_level =
-            security_level_status == AMEDIA_OK && security_level_pointer != nullptr
-            ? security_level_pointer
-            : "";
+    std::string security_level;
+    if (security_level_status == AMEDIA_OK &&
+        !copy_property_value(security_level_pointer, &security_level)) {
+        security_level_status = AMEDIA_ERROR_MALFORMED;
+    }
 
     const char *system_id_pointer = nullptr;
-    const media_status_t system_id_status = AMediaDrm_getPropertyString(
+    media_status_t system_id_status = AMediaDrm_getPropertyString(
             media_drm.get(),
             "systemId",
             &system_id_pointer
     );
-    const std::string system_id = system_id_status == AMEDIA_OK && system_id_pointer != nullptr
-                                  ? system_id_pointer
-                                  : "";
-
-    set_string(env, output, 0, "1");
-    set_string(env, output, 1, std::to_string(security_level_status));
-    if (security_level_status == AMEDIA_OK) {
-        set_string(env, output, 2, security_level);
+    std::string system_id;
+    if (system_id_status == AMEDIA_OK &&
+        !copy_property_value(system_id_pointer, &system_id)) {
+        system_id_status = AMEDIA_ERROR_MALFORMED;
     }
-    set_string(env, output, 3, std::to_string(system_id_status));
+
+    if (!set_string(env, output, 0, "1") ||
+        !set_string(env, output, 1, std::to_string(security_level_status))) {
+        return nullptr;
+    }
+    if (security_level_status == AMEDIA_OK) {
+        if (!set_string(env, output, 2, security_level)) {
+            return nullptr;
+        }
+    }
+    if (!set_string(env, output, 3, std::to_string(system_id_status))) {
+        return nullptr;
+    }
     if (system_id_status == AMEDIA_OK) {
-        set_string(env, output, 4, system_id);
+        if (!set_string(env, output, 4, system_id)) {
+            return nullptr;
+        }
     }
     return output;
 }

--- a/app/src/main/cpp/bootloader/widevine_native_bridge.cpp
+++ b/app/src/main/cpp/bootloader/widevine_native_bridge.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <jni.h>
+#include <media/NdkMediaDrm.h>
+
+#include <array>
+#include <memory>
+#include <string>
+
+namespace {
+
+    constexpr std::array<uint8_t, 16> WIDEVINE_UUID = {
+            0xed, 0xef, 0x8b, 0xa9,
+            0x79, 0xd6,
+            0x4a, 0xce,
+            0xa3, 0xc8,
+            0x27, 0xdc, 0xd5, 0x1d, 0x21, 0xed,
+    };
+
+    struct MediaDrmReleaser {
+        void operator()(AMediaDrm *media_drm) const {
+            if (media_drm != nullptr) {
+                AMediaDrm_release(media_drm);
+            }
+        }
+    };
+
+    using MediaDrmPtr = std::unique_ptr<AMediaDrm, MediaDrmReleaser>;
+
+    void set_string(JNIEnv *env, jobjectArray output, jsize index, const std::string &value) {
+        jstring java_value = env->NewStringUTF(value.c_str());
+        if (java_value == nullptr) {
+            return;
+        }
+        env->SetObjectArrayElement(output, index, java_value);
+        env->DeleteLocalRef(java_value);
+    }
+
+}  // namespace
+
+extern "C" JNIEXPORT jobjectArray JNICALL
+Java_com_eltavine_duckdetector_features_bootloader_data_widevine_WidevineNativeBridge_nativeReadProperties(
+        JNIEnv *env,
+        jobject
+) {
+    jclass string_class = env->FindClass("java/lang/String");
+    if (string_class == nullptr) {
+        return nullptr;
+    }
+
+    jobjectArray output = env->NewObjectArray(5, string_class, nullptr);
+    env->DeleteLocalRef(string_class);
+    if (output == nullptr) {
+        return nullptr;
+    }
+
+    if (!AMediaDrm_isCryptoSchemeSupported(WIDEVINE_UUID.data(), nullptr)) {
+        set_string(env, output, 0, "0");
+        return output;
+    }
+
+    MediaDrmPtr media_drm(AMediaDrm_createByUUID(WIDEVINE_UUID.data()));
+    if (media_drm == nullptr) {
+        set_string(env, output, 0, "0");
+        return output;
+    }
+
+    const char *security_level_pointer = nullptr;
+    const media_status_t security_level_status = AMediaDrm_getPropertyString(
+            media_drm.get(),
+            "securityLevel",
+            &security_level_pointer
+    );
+    const std::string security_level =
+            security_level_status == AMEDIA_OK && security_level_pointer != nullptr
+            ? security_level_pointer
+            : "";
+
+    const char *system_id_pointer = nullptr;
+    const media_status_t system_id_status = AMediaDrm_getPropertyString(
+            media_drm.get(),
+            "systemId",
+            &system_id_pointer
+    );
+    const std::string system_id = system_id_status == AMEDIA_OK && system_id_pointer != nullptr
+                                  ? system_id_pointer
+                                  : "";
+
+    set_string(env, output, 0, "1");
+    set_string(env, output, 1, std::to_string(security_level_status));
+    if (security_level_status == AMEDIA_OK) {
+        set_string(env, output, 2, security_level);
+    }
+    set_string(env, output, 3, std::to_string(system_id_status));
+    if (system_id_status == AMEDIA_OK) {
+        set_string(env, output, 4, system_id);
+    }
+    return output;
+}

--- a/app/src/main/java/com/eltavine/duckdetector/core/ui/components/DetectorCardFrame.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/core/ui/components/DetectorCardFrame.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ExpandLess
 import androidx.compose.material.icons.rounded.ExpandMore
@@ -62,6 +63,9 @@ fun DetectorCardFrame(
     summary: String,
     leadingIcon: ImageVector,
     modifier: Modifier = Modifier,
+    leadingBadgeIcon: ImageVector? = null,
+    leadingBadgeStatus: DetectorStatus? = null,
+    leadingBadgeContentDescription: String? = null,
     expanded: Boolean? = null,
     onExpandedChange: ((Boolean) -> Unit)? = null,
     headerFacts: @Composable ColumnScope.() -> Unit = {},
@@ -70,6 +74,7 @@ fun DetectorCardFrame(
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val appearance = rememberStatusAppearance(status)
+    val leadingBadgeAppearance = rememberStatusAppearance(leadingBadgeStatus ?: status)
     var internalExpanded by rememberSaveable(title) { mutableStateOf(false) }
     val isExpanded = expanded ?: internalExpanded
     val toggleDescription = stringResource(
@@ -123,6 +128,25 @@ fun DetectorCardFrame(
                         contentDescription = null,
                         tint = appearance.iconTint,
                     )
+                    leadingBadgeIcon?.let { badgeIcon ->
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.BottomEnd)
+                                .size(22.dp)
+                                .background(
+                                    color = MaterialTheme.colorScheme.surfaceContainerLow,
+                                    shape = CircleShape,
+                                )
+                                .padding(3.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                imageVector = badgeIcon,
+                                contentDescription = leadingBadgeContentDescription,
+                                tint = leadingBadgeAppearance.iconTint,
+                            )
+                        }
+                    }
                 }
 
                 IconButton(

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/repository/BootloaderRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/repository/BootloaderRepository.kt
@@ -22,7 +22,6 @@ import com.eltavine.duckdetector.features.bootloader.data.rules.BootloaderCatalo
 import com.eltavine.duckdetector.features.bootloader.data.widevine.WidevineBootContext
 import com.eltavine.duckdetector.features.bootloader.data.widevine.WidevineBootloaderEvidence
 import com.eltavine.duckdetector.features.bootloader.data.widevine.WidevineCredentialRepository
-import com.eltavine.duckdetector.features.bootloader.data.widevine.resolveBootloaderState
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderEvidenceMode
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFinding
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFindingGroup
@@ -91,16 +90,15 @@ class BootloaderRepository(
         val bootConsistency = bootConsistencyProbe.inspect(attestation)
         val propertyContext = BootloaderPropertyContext.from(readsByProperty)
         val evidenceMode = resolveEvidenceMode(attestation, propertyContext)
-        val baseState = resolveState(attestation, propertyContext)
+        val state = resolveState(attestation, propertyContext)
         val widevineEvidence = widevineCredentialRepository.inspect(
             WidevineBootContext(
                 rootOfTrustUnlocked = isRootOfTrustUnlocked(attestation),
-                bootStateAppearsLocked = baseState == BootloaderState.VERIFIED ||
-                    baseState == BootloaderState.SELF_SIGNED ||
-                    baseState == BootloaderState.LOCKED_UNKNOWN,
+                bootStateAppearsLocked = state == BootloaderState.VERIFIED ||
+                    state == BootloaderState.SELF_SIGNED ||
+                    state == BootloaderState.LOCKED_UNKNOWN,
             ),
         )
-        val state = widevineEvidence.resolveBootloaderState(baseState)
         val sourceSignals = consistencyUtils.buildSourceMismatchSignals(readsByProperty.values)
         val consistencySignals = consistencyUtils.buildConsistencySignals(
             readsByProperty = readsByProperty,
@@ -108,16 +106,7 @@ class BootloaderRepository(
         )
 
         val findings = buildList {
-            addAll(
-                buildStateFindings(
-                    state,
-                    baseState,
-                    evidenceMode,
-                    attestation,
-                    trust,
-                    propertyContext,
-                ),
-            )
+            addAll(buildStateFindings(state, evidenceMode, attestation, trust, propertyContext))
             addAll(buildAttestationFindings(attestation, trust))
             addAll(buildPropertyFindings(propertyContext, readsByProperty))
             addAll(
@@ -131,7 +120,6 @@ class BootloaderRepository(
         }
         val impacts = buildImpacts(
             state = state,
-            baseState = baseState,
             evidenceMode = evidenceMode,
             trust = trust,
             propertyContext = propertyContext,
@@ -259,7 +247,6 @@ class BootloaderRepository(
 
     private fun buildStateFindings(
         state: BootloaderState,
-        baseState: BootloaderState,
         evidenceMode: BootloaderEvidenceMode,
         attestation: AttestationSnapshot,
         trust: CertificateTrustResult,
@@ -273,7 +260,7 @@ class BootloaderRepository(
                     value = stateLabel(state, evidenceMode),
                     group = BootloaderFindingGroup.STATE,
                     severity = stateSeverity(state),
-                    detail = stateDetail(state, baseState, evidenceMode),
+                    detail = stateDetail(state, evidenceMode),
                 ),
             )
             add(
@@ -577,7 +564,6 @@ class BootloaderRepository(
 
     private fun buildImpacts(
         state: BootloaderState,
-        baseState: BootloaderState,
         evidenceMode: BootloaderEvidenceMode,
         trust: CertificateTrustResult,
         propertyContext: BootloaderPropertyContext,
@@ -589,11 +575,7 @@ class BootloaderRepository(
             when (state) {
                 BootloaderState.UNLOCKED -> add(
                     BootloaderImpact(
-                        text = if (baseState != BootloaderState.UNLOCKED) {
-                            "A danger-level Widevine inconsistency escalated the bootloader result to unlocked."
-                        } else {
-                            "Unlocked bootloaders allow custom boot images and can disable or bypass normal verified-boot guarantees."
-                        },
+                        text = "Unlocked bootloaders allow custom boot images and can disable or bypass normal verified-boot guarantees.",
                         severity = BootloaderFindingSeverity.DANGER,
                     ),
                 )
@@ -844,20 +826,8 @@ class BootloaderRepository(
 
     private fun stateDetail(
         state: BootloaderState,
-        baseState: BootloaderState,
         evidenceMode: BootloaderEvidenceMode,
     ): String {
-        if (state != baseState) {
-            return when (state) {
-                BootloaderState.UNLOCKED ->
-                    "A danger-level Widevine consistency anomaly escalated the bootloader state to unlocked."
-
-                BootloaderState.UNKNOWN ->
-                    "A warning-level Widevine consistency anomaly made the bootloader state inconclusive."
-
-                else -> "Widevine consistency evidence changed the bootloader state."
-            }
-        }
         return when (state) {
             BootloaderState.VERIFIED -> if (evidenceMode == BootloaderEvidenceMode.PROPERTIES_ONLY) {
                 "Boot properties indicate a locked device and do not contradict a verified boot chain, but attestation RootOfTrust was unavailable."

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/repository/BootloaderRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/repository/BootloaderRepository.kt
@@ -19,6 +19,9 @@ package com.eltavine.duckdetector.features.bootloader.data.repository
 import android.content.Context
 import android.os.Build
 import com.eltavine.duckdetector.features.bootloader.data.rules.BootloaderCatalog
+import com.eltavine.duckdetector.features.bootloader.data.widevine.WidevineBootContext
+import com.eltavine.duckdetector.features.bootloader.data.widevine.WidevineBootloaderEvidence
+import com.eltavine.duckdetector.features.bootloader.data.widevine.WidevineCredentialRepository
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderEvidenceMode
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFinding
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFindingGroup
@@ -59,6 +62,7 @@ class BootloaderRepository(
     private val appContext = context.applicationContext
     private val trustAnalyzer = CertificateTrustAnalyzer(GoogleAttestationRootStore(appContext))
     private val bootConsistencyProbe = BootConsistencyProbe()
+    private val widevineCredentialRepository = WidevineCredentialRepository()
 
     suspend fun scan(): BootloaderReport = withContext(Dispatchers.Default) {
         runCatching { scanInternal() }
@@ -87,6 +91,14 @@ class BootloaderRepository(
         val propertyContext = BootloaderPropertyContext.from(readsByProperty)
         val evidenceMode = resolveEvidenceMode(attestation, propertyContext)
         val state = resolveState(attestation, propertyContext)
+        val widevineEvidence = widevineCredentialRepository.inspect(
+            WidevineBootContext(
+                rootOfTrustUnlocked = isRootOfTrustUnlocked(attestation),
+                bootStateAppearsLocked = state == BootloaderState.VERIFIED ||
+                    state == BootloaderState.SELF_SIGNED ||
+                    state == BootloaderState.LOCKED_UNKNOWN,
+            ),
+        )
         val sourceSignals = consistencyUtils.buildSourceMismatchSignals(readsByProperty.values)
         val consistencySignals = consistencyUtils.buildConsistencySignals(
             readsByProperty = readsByProperty,
@@ -97,7 +109,14 @@ class BootloaderRepository(
             addAll(buildStateFindings(state, evidenceMode, attestation, trust, propertyContext))
             addAll(buildAttestationFindings(attestation, trust))
             addAll(buildPropertyFindings(propertyContext, readsByProperty))
-            addAll(buildConsistencyFindings(bootConsistency, sourceSignals, consistencySignals))
+            addAll(
+                buildConsistencyFindings(
+                    bootConsistency,
+                    sourceSignals,
+                    consistencySignals,
+                    widevineEvidence,
+                ),
+            )
         }
         val impacts = buildImpacts(
             state = state,
@@ -106,6 +125,7 @@ class BootloaderRepository(
             propertyContext = propertyContext,
             bootConsistency = bootConsistency,
             findings = findings,
+            widevineEvidence = widevineEvidence,
         )
         val observedPropertyCount = readsByProperty
             .filterKeys { it in coreProperties }
@@ -135,6 +155,7 @@ class BootloaderRepository(
             sourceSignals = sourceSignals,
             consistencySignals = consistencySignals,
             propertyContext = propertyContext,
+            widevineEvidence = widevineEvidence,
         )
 
         if (findings.isEmpty() && attestation.errorMessage != null && observedPropertyCount == 0) {
@@ -158,7 +179,8 @@ class BootloaderRepository(
             consistencyFindingCount = bootloaderConsistencyCount(
                 bootConsistency,
                 sourceSignals,
-                consistencySignals
+                consistencySignals,
+                widevineEvidence,
             ),
             findings = findings,
             impacts = impacts,
@@ -451,6 +473,7 @@ class BootloaderRepository(
         bootConsistency: BootConsistencyResult,
         sourceSignals: List<SystemPropertySignal>,
         consistencySignals: List<SystemPropertySignal>,
+        widevineEvidence: WidevineBootloaderEvidence,
     ): List<BootloaderFinding> {
         val findings = mutableListOf<BootloaderFinding>()
 
@@ -534,6 +557,7 @@ class BootloaderRepository(
                 group = BootloaderFindingGroup.CONSISTENCY,
             )
         }
+        findings += widevineEvidence.findings
 
         return findings
     }
@@ -545,6 +569,7 @@ class BootloaderRepository(
         propertyContext: BootloaderPropertyContext,
         bootConsistency: BootConsistencyResult,
         findings: List<BootloaderFinding>,
+        widevineEvidence: WidevineBootloaderEvidence,
     ): List<BootloaderImpact> {
         return buildList {
             when (state) {
@@ -610,6 +635,8 @@ class BootloaderRepository(
                 )
             }
 
+            addAll(widevineEvidence.impacts)
+
             if (findings.none { it.severity == BootloaderFindingSeverity.DANGER || it.severity == BootloaderFindingSeverity.WARNING }) {
                 add(
                     BootloaderImpact(
@@ -644,6 +671,7 @@ class BootloaderRepository(
         sourceSignals: List<SystemPropertySignal>,
         consistencySignals: List<SystemPropertySignal>,
         propertyContext: BootloaderPropertyContext,
+        widevineEvidence: WidevineBootloaderEvidence,
     ): List<BootloaderMethodResult> {
         return listOf(
             BootloaderMethodResult(
@@ -774,6 +802,7 @@ class BootloaderRepository(
                 },
                 detail = "Raw-boot, lock-state, partition-verity, and build-profile coherence checks.",
             ),
+            widevineEvidence.method,
         )
     }
 
@@ -1131,6 +1160,7 @@ class BootloaderRepository(
         bootConsistency: BootConsistencyResult,
         sourceSignals: List<SystemPropertySignal>,
         consistencySignals: List<SystemPropertySignal>,
+        widevineEvidence: WidevineBootloaderEvidence,
     ): Int {
         val bootCount = listOf(
             bootConsistency.vbmetaDigestMismatch,
@@ -1139,7 +1169,14 @@ class BootloaderRepository(
             bootConsistency.verifiedBootKeyAllZeros,
             bootConsistency.verifiedStateUnlockedMismatch,
         ).count { it }
-        return bootCount + sourceSignals.size + consistencySignals.size
+        return bootCount + sourceSignals.size + consistencySignals.size +
+            widevineEvidence.anomalyCount
+    }
+
+    private fun isRootOfTrustUnlocked(snapshot: AttestationSnapshot): Boolean {
+        val rootOfTrust = snapshot.rootOfTrust ?: return false
+        return rootOfTrust.deviceLocked == false ||
+            rootOfTrust.verifiedBootState.equals("Unverified", ignoreCase = true)
     }
 
     private fun hasAttestation(snapshot: AttestationSnapshot): Boolean {

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/repository/BootloaderRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/repository/BootloaderRepository.kt
@@ -637,7 +637,11 @@ class BootloaderRepository(
 
             addAll(widevineEvidence.impacts)
 
-            if (findings.none { it.severity == BootloaderFindingSeverity.DANGER || it.severity == BootloaderFindingSeverity.WARNING }) {
+            if (findings.none {
+                    it.severity == BootloaderFindingSeverity.DANGER ||
+                        it.severity == BootloaderFindingSeverity.WARNING
+                }
+            ) {
                 add(
                     BootloaderImpact(
                         text = "No bootloader or verified-boot signal suggested an unlocked or obviously contradictory boot chain.",

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/repository/BootloaderRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/repository/BootloaderRepository.kt
@@ -22,6 +22,7 @@ import com.eltavine.duckdetector.features.bootloader.data.rules.BootloaderCatalo
 import com.eltavine.duckdetector.features.bootloader.data.widevine.WidevineBootContext
 import com.eltavine.duckdetector.features.bootloader.data.widevine.WidevineBootloaderEvidence
 import com.eltavine.duckdetector.features.bootloader.data.widevine.WidevineCredentialRepository
+import com.eltavine.duckdetector.features.bootloader.data.widevine.resolveBootloaderState
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderEvidenceMode
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFinding
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFindingGroup
@@ -90,15 +91,16 @@ class BootloaderRepository(
         val bootConsistency = bootConsistencyProbe.inspect(attestation)
         val propertyContext = BootloaderPropertyContext.from(readsByProperty)
         val evidenceMode = resolveEvidenceMode(attestation, propertyContext)
-        val state = resolveState(attestation, propertyContext)
+        val baseState = resolveState(attestation, propertyContext)
         val widevineEvidence = widevineCredentialRepository.inspect(
             WidevineBootContext(
                 rootOfTrustUnlocked = isRootOfTrustUnlocked(attestation),
-                bootStateAppearsLocked = state == BootloaderState.VERIFIED ||
-                    state == BootloaderState.SELF_SIGNED ||
-                    state == BootloaderState.LOCKED_UNKNOWN,
+                bootStateAppearsLocked = baseState == BootloaderState.VERIFIED ||
+                    baseState == BootloaderState.SELF_SIGNED ||
+                    baseState == BootloaderState.LOCKED_UNKNOWN,
             ),
         )
+        val state = widevineEvidence.resolveBootloaderState(baseState)
         val sourceSignals = consistencyUtils.buildSourceMismatchSignals(readsByProperty.values)
         val consistencySignals = consistencyUtils.buildConsistencySignals(
             readsByProperty = readsByProperty,
@@ -106,7 +108,16 @@ class BootloaderRepository(
         )
 
         val findings = buildList {
-            addAll(buildStateFindings(state, evidenceMode, attestation, trust, propertyContext))
+            addAll(
+                buildStateFindings(
+                    state,
+                    baseState,
+                    evidenceMode,
+                    attestation,
+                    trust,
+                    propertyContext,
+                ),
+            )
             addAll(buildAttestationFindings(attestation, trust))
             addAll(buildPropertyFindings(propertyContext, readsByProperty))
             addAll(
@@ -120,6 +131,7 @@ class BootloaderRepository(
         }
         val impacts = buildImpacts(
             state = state,
+            baseState = baseState,
             evidenceMode = evidenceMode,
             trust = trust,
             propertyContext = propertyContext,
@@ -247,6 +259,7 @@ class BootloaderRepository(
 
     private fun buildStateFindings(
         state: BootloaderState,
+        baseState: BootloaderState,
         evidenceMode: BootloaderEvidenceMode,
         attestation: AttestationSnapshot,
         trust: CertificateTrustResult,
@@ -260,7 +273,7 @@ class BootloaderRepository(
                     value = stateLabel(state, evidenceMode),
                     group = BootloaderFindingGroup.STATE,
                     severity = stateSeverity(state),
-                    detail = stateDetail(state, evidenceMode),
+                    detail = stateDetail(state, baseState, evidenceMode),
                 ),
             )
             add(
@@ -564,6 +577,7 @@ class BootloaderRepository(
 
     private fun buildImpacts(
         state: BootloaderState,
+        baseState: BootloaderState,
         evidenceMode: BootloaderEvidenceMode,
         trust: CertificateTrustResult,
         propertyContext: BootloaderPropertyContext,
@@ -575,7 +589,11 @@ class BootloaderRepository(
             when (state) {
                 BootloaderState.UNLOCKED -> add(
                     BootloaderImpact(
-                        text = "Unlocked bootloaders allow custom boot images and can disable or bypass normal verified-boot guarantees.",
+                        text = if (baseState != BootloaderState.UNLOCKED) {
+                            "A danger-level Widevine inconsistency escalated the bootloader result to unlocked."
+                        } else {
+                            "Unlocked bootloaders allow custom boot images and can disable or bypass normal verified-boot guarantees."
+                        },
                         severity = BootloaderFindingSeverity.DANGER,
                     ),
                 )
@@ -826,8 +844,20 @@ class BootloaderRepository(
 
     private fun stateDetail(
         state: BootloaderState,
+        baseState: BootloaderState,
         evidenceMode: BootloaderEvidenceMode,
     ): String {
+        if (state != baseState) {
+            return when (state) {
+                BootloaderState.UNLOCKED ->
+                    "A danger-level Widevine consistency anomaly escalated the bootloader state to unlocked."
+
+                BootloaderState.UNKNOWN ->
+                    "A warning-level Widevine consistency anomaly made the bootloader state inconclusive."
+
+                else -> "Widevine consistency evidence changed the bootloader state."
+            }
+        }
         return when (state) {
             BootloaderState.VERIFIED -> if (evidenceMode == BootloaderEvidenceMode.PROPERTIES_ONLY) {
                 "Boot properties indicate a locked device and do not contradict a verified boot chain, but attestation RootOfTrust was unavailable."

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialClassifier.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialClassifier.kt
@@ -1,0 +1,364 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.bootloader.data.widevine
+
+import java.util.Locale
+
+internal class WidevineCredentialClassifier {
+
+    fun classify(
+        snapshot: WidevineCredentialSnapshot,
+        bootContext: WidevineBootContext,
+    ): WidevineCredentialAssessment {
+        val credentialFinding = classifyCredential(snapshot, bootContext)
+        val parityFinding = classifyParity(snapshot)
+        val findings = listOf(credentialFinding, parityFinding)
+        val methodSeverity = findings.map { it.severity }.highestSeverity()
+        return WidevineCredentialAssessment(
+            findings = findings,
+            methodSummary = when (methodSeverity) {
+                WidevineAssessmentSeverity.DANGER -> "Credential anomaly"
+                WidevineAssessmentSeverity.WARNING -> "Needs review"
+                WidevineAssessmentSeverity.SUPPORT -> "Partial"
+                WidevineAssessmentSeverity.SAFE -> "Consistent"
+            },
+            methodSeverity = methodSeverity,
+            methodDetail = findings.joinToString("\n") { finding ->
+                "${finding.label}: ${finding.value}. ${finding.detail}"
+            },
+            impact = buildImpact(credentialFinding, parityFinding, bootContext),
+        )
+    }
+
+    private fun classifyCredential(
+        snapshot: WidevineCredentialSnapshot,
+        bootContext: WidevineBootContext,
+    ): WidevineAssessmentFinding {
+        if (snapshot.schemeSupported != true) {
+            return credentialFinding(
+                value = if (snapshot.schemeSupported == false) "Unsupported" else "Unavailable",
+                severity = WidevineAssessmentSeverity.SUPPORT,
+                detail = "Widevine support could not be established; no credential verdict was emitted.",
+            )
+        }
+
+        val securityLevel = snapshot.javaSecurityLevel.normalizedSecurityLevel()
+        val systemId = snapshot.javaSystemId.normalizedSystemId()
+        if (snapshot.javaSecurityLevel.status != WidevinePropertyStatus.AVAILABLE ||
+            snapshot.javaSystemId.status != WidevinePropertyStatus.AVAILABLE ||
+            securityLevel == null ||
+            systemId == null
+        ) {
+            return credentialFinding(
+                value = "Properties unavailable",
+                severity = WidevineAssessmentSeverity.SUPPORT,
+                detail = buildDetail(snapshot, bootContext),
+            )
+        }
+
+        val advertisedL1 = securityLevel == ADVERTISED_L1
+        val sentinel = advertisedL1 && systemId == WIDEVINE_SENTINEL_SYSTEM_ID
+        val sessionDowngrade = advertisedL1 &&
+            snapshot.sessionStatus == WidevineOperationStatus.SUCCESS &&
+            snapshot.actualSessionSecurityLevel != null &&
+            snapshot.actualSessionSecurityLevel != WidevineSessionSecurityLevel.HW_SECURE_ALL
+        val hardSessionFailure = advertisedL1 && snapshot.sessionStatus in setOf(
+            WidevineOperationStatus.NOT_PROVISIONED,
+            WidevineOperationStatus.UNSUPPORTED,
+            WidevineOperationStatus.FAILURE,
+        )
+        val sessionLevelFailure = advertisedL1 && snapshot.errors.any { error ->
+            error.stage == WidevineDrmErrorStage.SESSION_SECURITY_LEVEL && error.transient != true
+        }
+        val sentinelCredentialFailure = sentinel && (
+            snapshot.credentialStatus == WidevineOperationStatus.SUCCESS &&
+                snapshot.credentialAvailable == false ||
+                snapshot.credentialStatus == WidevineOperationStatus.NOT_PROVISIONED ||
+                snapshot.credentialStatus == WidevineOperationStatus.FAILURE ||
+                snapshot.keyRequestStatus == WidevineOperationStatus.NOT_PROVISIONED ||
+                snapshot.keyRequestStatus == WidevineOperationStatus.FAILURE
+            )
+        val independentlyConfirmedUnlock = sentinel && bootContext.rootOfTrustUnlocked
+
+        val detail = buildDetail(snapshot, bootContext)
+        return when {
+            sessionDowngrade -> credentialFinding(
+                value = "Session downgrade",
+                severity = WidevineAssessmentSeverity.DANGER,
+                detail = detail,
+            )
+
+            hardSessionFailure -> credentialFinding(
+                value = "Hardware session failed",
+                severity = WidevineAssessmentSeverity.DANGER,
+                detail = detail,
+            )
+
+            sentinelCredentialFailure -> credentialFinding(
+                value = "Invalid credential",
+                severity = WidevineAssessmentSeverity.DANGER,
+                detail = detail,
+            )
+
+            independentlyConfirmedUnlock -> credentialFinding(
+                value = "Unlock impact confirmed",
+                severity = WidevineAssessmentSeverity.DANGER,
+                detail = detail,
+            )
+
+            sentinel -> credentialFinding(
+                value = "Sentinel system ID",
+                severity = WidevineAssessmentSeverity.WARNING,
+                detail = detail,
+            )
+
+            sessionLevelFailure -> credentialFinding(
+                value = "Session level unavailable",
+                severity = WidevineAssessmentSeverity.WARNING,
+                detail = detail,
+            )
+
+            snapshot.sessionStatus == WidevineOperationStatus.RESOURCE_BUSY ||
+                snapshot.sessionStatus == WidevineOperationStatus.TRANSIENT_ERROR ->
+                credentialFinding(
+                    value = "Inconclusive",
+                    severity = WidevineAssessmentSeverity.SUPPORT,
+                    detail = detail,
+                )
+
+            snapshot.sessionStatus == WidevineOperationStatus.SUCCESS &&
+                snapshot.actualSessionSecurityLevel != null &&
+                snapshot.credentialStatus == WidevineOperationStatus.SUCCESS &&
+                snapshot.credentialAvailable == true &&
+                snapshot.keyRequestStatus == WidevineOperationStatus.SUCCESS ->
+                credentialFinding(
+                    value = "Consistent",
+                    severity = WidevineAssessmentSeverity.SAFE,
+                    detail = detail,
+                )
+
+            else -> credentialFinding(
+                value = "Partial",
+                severity = WidevineAssessmentSeverity.SUPPORT,
+                detail = detail,
+            )
+        }
+    }
+
+    private fun classifyParity(
+        snapshot: WidevineCredentialSnapshot,
+    ): WidevineAssessmentFinding {
+        if (!snapshot.native.available) {
+            return parityFinding(
+                value = "Native unavailable",
+                severity = WidevineAssessmentSeverity.SUPPORT,
+                detail = "The NDK property path was unavailable, so Java/native parity was not evaluated.",
+            )
+        }
+
+        val javaSecurity = snapshot.javaSecurityLevel.normalizedSecurityLevel()
+        val nativeSecurity = snapshot.native.securityLevel.normalizedSecurityLevel()
+        val javaSystemId = snapshot.javaSystemId.normalizedSystemId()
+        val nativeSystemId = snapshot.native.systemId.normalizedSystemId()
+        val securityComparable = snapshot.javaSecurityLevel.status == WidevinePropertyStatus.AVAILABLE &&
+            snapshot.native.securityLevel.status == WidevinePropertyStatus.AVAILABLE
+        val systemIdComparable = snapshot.javaSystemId.status == WidevinePropertyStatus.AVAILABLE &&
+            snapshot.native.systemId.status == WidevinePropertyStatus.AVAILABLE
+        val securityMismatch = securityComparable && javaSecurity != nativeSecurity
+        val systemIdMismatch = systemIdComparable && javaSystemId != nativeSystemId
+
+        if (securityMismatch || systemIdMismatch) {
+            val fields = buildList {
+                if (securityMismatch) add("securityLevel")
+                if (systemIdMismatch) add("systemId")
+            }
+            return parityFinding(
+                value = "Mismatch",
+                severity = WidevineAssessmentSeverity.WARNING,
+                detail = "Java and NDK reads differ for ${fields.joinToString(", ")}; a hook, spoof, or framework inconsistency is possible. " +
+                    parityValues(snapshot),
+            )
+        }
+
+        if (securityComparable && systemIdComparable) {
+            return parityFinding(
+                value = "Aligned",
+                severity = WidevineAssessmentSeverity.SAFE,
+                detail = parityValues(snapshot),
+            )
+        }
+
+        return parityFinding(
+            value = "Partial",
+            severity = WidevineAssessmentSeverity.SUPPORT,
+            detail = "One or more vendor properties were unavailable on either the Java or NDK path. " +
+                parityValues(snapshot),
+        )
+    }
+
+    private fun buildDetail(
+        snapshot: WidevineCredentialSnapshot,
+        bootContext: WidevineBootContext,
+    ): String {
+        return buildString {
+            append("Advertised level: ")
+            append(snapshot.javaSecurityLevel.normalizedSecurityLevel().displayValue())
+            append("; Java system ID: ")
+            append(snapshot.javaSystemId.normalizedSystemId().displayValue())
+            append("; actual session: ")
+            append(snapshot.actualSessionSecurityLevel?.name ?: snapshot.sessionStatus.name)
+            append("; credential availability: ")
+            append(
+                when {
+                    snapshot.credentialStatus != WidevineOperationStatus.SUCCESS ->
+                        snapshot.credentialStatus.name
+
+                    snapshot.credentialAvailable == true -> "AVAILABLE"
+                    else -> "UNAVAILABLE"
+                },
+            )
+            append("; local key request: ")
+            append(snapshot.keyRequestStatus.name)
+            append("; boot context: ")
+            append(
+                when {
+                    bootContext.rootOfTrustUnlocked -> "RootOfTrust confirms unlocked"
+                    bootContext.bootStateAppearsLocked -> "boot state appears locked"
+                    else -> "boot state is inconclusive"
+                },
+            )
+            if (snapshot.errors.isNotEmpty()) {
+                append("; sanitized errors: ")
+                append(snapshot.errors.joinToString(", ") { it.numericDescription() })
+            }
+            append('.')
+        }
+    }
+
+    private fun parityValues(snapshot: WidevineCredentialSnapshot): String {
+        return "securityLevel(Java=${snapshot.javaSecurityLevel.normalizedSecurityLevel().displayValue()}, " +
+            "NDK=${snapshot.native.securityLevel.normalizedSecurityLevel().displayValue()}); " +
+            "systemId(Java=${snapshot.javaSystemId.normalizedSystemId().displayValue()}, " +
+            "NDK=${snapshot.native.systemId.normalizedSystemId().displayValue()})."
+    }
+
+    private fun buildImpact(
+        credential: WidevineAssessmentFinding,
+        parity: WidevineAssessmentFinding,
+        bootContext: WidevineBootContext,
+    ): WidevineAssessmentFinding? {
+        return when {
+            credential.severity == WidevineAssessmentSeverity.DANGER ->
+                WidevineAssessmentFinding(
+                    id = "widevine_impact",
+                    label = "Widevine impact",
+                    value = "Operational inconsistency",
+                    severity = WidevineAssessmentSeverity.DANGER,
+                    detail = "The advertised L1 state conflicts with independent credential, session, or RootOfTrust evidence. This confirms a DRM credential anomaly, not a standalone bootloader-state verdict.",
+                )
+
+            credential.severity == WidevineAssessmentSeverity.WARNING ->
+                WidevineAssessmentFinding(
+                    id = "widevine_impact",
+                    label = "Widevine impact",
+                    value = "Credential anomaly",
+                    severity = WidevineAssessmentSeverity.WARNING,
+                    detail = if (bootContext.bootStateAppearsLocked) {
+                        "A locked-looking boot state with the exact Widevine sentinel may reflect historical unlocking, ROM conversion, spoofing, or an OEM provisioning defect."
+                    } else {
+                        "The exact Widevine sentinel is suspicious but does not independently establish the current bootloader lock state."
+                    },
+                )
+
+            parity.severity == WidevineAssessmentSeverity.WARNING ->
+                WidevineAssessmentFinding(
+                    id = "widevine_impact",
+                    label = "Widevine impact",
+                    value = "Cross-API mismatch",
+                    severity = WidevineAssessmentSeverity.WARNING,
+                    detail = "Java/native disagreement can indicate a MediaDrm hook, spoof, or vendor framework inconsistency.",
+                )
+
+            else -> null
+        }
+    }
+
+    private fun credentialFinding(
+        value: String,
+        severity: WidevineAssessmentSeverity,
+        detail: String,
+    ): WidevineAssessmentFinding {
+        return WidevineAssessmentFinding(
+            id = "widevine_credential",
+            label = "Widevine credential",
+            value = value,
+            severity = severity,
+            detail = detail,
+        )
+    }
+
+    private fun parityFinding(
+        value: String,
+        severity: WidevineAssessmentSeverity,
+        detail: String,
+    ): WidevineAssessmentFinding {
+        return WidevineAssessmentFinding(
+            id = "widevine_property_parity",
+            label = "Widevine Java/native parity",
+            value = value,
+            severity = severity,
+            detail = detail,
+        )
+    }
+
+    private fun WidevinePropertyRead.normalizedSecurityLevel(): String? {
+        return value?.trim()?.takeIf { it.isNotEmpty() }?.uppercase(Locale.ROOT)
+    }
+
+    private fun WidevinePropertyRead.normalizedSystemId(): String? {
+        return value?.trim()?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun String?.displayValue(): String = this ?: "unavailable"
+
+    private fun WidevineDrmError.numericDescription(): String {
+        return buildString {
+            append(stage.name)
+            append('(')
+            append(kind.name)
+            errorCode?.let { append(",code=$it") }
+            vendorError?.let { append(",vendor=$it") }
+            oemError?.let { append(",oem=$it") }
+            errorContext?.let { append(",context=$it") }
+            transient?.let { append(",transient=$it") }
+            append(')')
+        }
+    }
+
+    private fun List<WidevineAssessmentSeverity>.highestSeverity(): WidevineAssessmentSeverity {
+        return when {
+            WidevineAssessmentSeverity.DANGER in this -> WidevineAssessmentSeverity.DANGER
+            WidevineAssessmentSeverity.WARNING in this -> WidevineAssessmentSeverity.WARNING
+            WidevineAssessmentSeverity.SUPPORT in this -> WidevineAssessmentSeverity.SUPPORT
+            else -> WidevineAssessmentSeverity.SAFE
+        }
+    }
+
+    private companion object {
+        const val ADVERTISED_L1 = "L1"
+    }
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialClassifier.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialClassifier.kt
@@ -31,7 +31,7 @@ internal class WidevineCredentialClassifier {
         return WidevineCredentialAssessment(
             findings = findings,
             methodSummary = when (methodSeverity) {
-                WidevineAssessmentSeverity.DANGER -> "Credential anomaly"
+                WidevineAssessmentSeverity.DANGER -> "DRM inconsistency"
                 WidevineAssessmentSeverity.WARNING -> "Needs review"
                 WidevineAssessmentSeverity.SUPPORT -> "Partial"
                 WidevineAssessmentSeverity.SAFE -> "Consistent"
@@ -40,7 +40,7 @@ internal class WidevineCredentialClassifier {
             methodDetail = findings.joinToString("\n") { finding ->
                 "${finding.label}: ${finding.value}. ${finding.detail}"
             },
-            impact = buildImpact(credentialFinding, parityFinding, bootContext),
+            impact = buildImpact(credentialFinding, parityFinding),
         )
     }
 
@@ -59,24 +59,31 @@ internal class WidevineCredentialClassifier {
         val securityLevel = snapshot.javaSecurityLevel.normalizedSecurityLevel()
         val systemId = snapshot.javaSystemId.normalizedSystemId()
         if (snapshot.javaSecurityLevel.status != WidevinePropertyStatus.AVAILABLE ||
-            snapshot.javaSystemId.status != WidevinePropertyStatus.AVAILABLE ||
-            securityLevel == null ||
-            systemId == null
+            securityLevel == null
         ) {
             return credentialFinding(
-                value = "Properties unavailable",
+                value = "Security level unavailable",
                 severity = WidevineAssessmentSeverity.SUPPORT,
                 detail = buildDetail(snapshot, bootContext),
             )
         }
 
         val advertisedL1 = securityLevel == ADVERTISED_L1
-        val sentinel = advertisedL1 && systemId == WIDEVINE_SENTINEL_SYSTEM_ID
+        val systemIdAvailable = snapshot.javaSystemId.status == WidevinePropertyStatus.AVAILABLE &&
+            systemId != null
+        val sentinel = snapshot.javaSecurityLevel.status == WidevinePropertyStatus.AVAILABLE &&
+            snapshot.javaSystemId.status == WidevinePropertyStatus.AVAILABLE &&
+            snapshot.javaSecurityLevel.value == ADVERTISED_L1 &&
+            snapshot.javaSystemId.value == WIDEVINE_SENTINEL_SYSTEM_ID
         val sessionDowngrade = advertisedL1 &&
+            snapshot.hardwareSecureAllSupported == true &&
             snapshot.sessionStatus == WidevineOperationStatus.SUCCESS &&
-            snapshot.actualSessionSecurityLevel != null &&
-            snapshot.actualSessionSecurityLevel != WidevineSessionSecurityLevel.HW_SECURE_ALL
-        val hardSessionFailure = advertisedL1 && snapshot.sessionStatus in setOf(
+            snapshot.actualSessionSecurityLevel.isKnownBelowHardwareSecureAll()
+        val constrainedMaximumSession = advertisedL1 &&
+            snapshot.hardwareSecureAllSupported != true &&
+            snapshot.sessionStatus == WidevineOperationStatus.SUCCESS &&
+            snapshot.actualSessionSecurityLevel.isKnownBelowHardwareSecureAll()
+        val inconclusiveSessionFailure = advertisedL1 && snapshot.sessionStatus in setOf(
             WidevineOperationStatus.NOT_PROVISIONED,
             WidevineOperationStatus.UNSUPPORTED,
             WidevineOperationStatus.FAILURE,
@@ -84,38 +91,11 @@ internal class WidevineCredentialClassifier {
         val sessionLevelFailure = advertisedL1 && snapshot.errors.any { error ->
             error.stage == WidevineDrmErrorStage.SESSION_SECURITY_LEVEL && error.transient != true
         }
-        val sentinelCredentialFailure = sentinel && (
-            snapshot.credentialStatus == WidevineOperationStatus.SUCCESS &&
-                snapshot.credentialAvailable == false ||
-                snapshot.credentialStatus == WidevineOperationStatus.NOT_PROVISIONED ||
-                snapshot.credentialStatus == WidevineOperationStatus.FAILURE ||
-                snapshot.keyRequestStatus == WidevineOperationStatus.NOT_PROVISIONED ||
-                snapshot.keyRequestStatus == WidevineOperationStatus.FAILURE
-            )
-        val independentlyConfirmedUnlock = sentinel && bootContext.rootOfTrustUnlocked
 
         val detail = buildDetail(snapshot, bootContext)
         return when {
-            sessionDowngrade -> credentialFinding(
-                value = "Session downgrade",
-                severity = WidevineAssessmentSeverity.DANGER,
-                detail = detail,
-            )
-
-            hardSessionFailure -> credentialFinding(
-                value = "Hardware session failed",
-                severity = WidevineAssessmentSeverity.DANGER,
-                detail = detail,
-            )
-
-            sentinelCredentialFailure -> credentialFinding(
-                value = "Invalid credential",
-                severity = WidevineAssessmentSeverity.DANGER,
-                detail = detail,
-            )
-
-            independentlyConfirmedUnlock -> credentialFinding(
-                value = "Unlock impact confirmed",
+            sentinel && sessionDowngrade -> credentialFinding(
+                value = "Corroborated anomaly",
                 severity = WidevineAssessmentSeverity.DANGER,
                 detail = detail,
             )
@@ -126,22 +106,43 @@ internal class WidevineCredentialClassifier {
                 detail = detail,
             )
 
-            sessionLevelFailure -> credentialFinding(
-                value = "Session level unavailable",
+            sessionDowngrade -> credentialFinding(
+                value = "Lower security session",
                 severity = WidevineAssessmentSeverity.WARNING,
                 detail = detail,
             )
 
             snapshot.sessionStatus == WidevineOperationStatus.RESOURCE_BUSY ||
-                snapshot.sessionStatus == WidevineOperationStatus.TRANSIENT_ERROR ->
+                snapshot.sessionStatus == WidevineOperationStatus.TRANSIENT_ERROR ||
+                inconclusiveSessionFailure ->
                 credentialFinding(
-                    value = "Inconclusive",
+                    value = "Session inconclusive",
                     severity = WidevineAssessmentSeverity.SUPPORT,
                     detail = detail,
                 )
 
-            snapshot.sessionStatus == WidevineOperationStatus.SUCCESS &&
-                snapshot.actualSessionSecurityLevel != null &&
+            sessionLevelFailure -> credentialFinding(
+                value = "Session level unavailable",
+                severity = WidevineAssessmentSeverity.SUPPORT,
+                detail = detail,
+            )
+
+            constrainedMaximumSession -> credentialFinding(
+                value = "Maximum security constrained",
+                severity = WidevineAssessmentSeverity.SUPPORT,
+                detail = detail,
+            )
+
+            !systemIdAvailable -> credentialFinding(
+                value = "System ID unavailable",
+                severity = WidevineAssessmentSeverity.SUPPORT,
+                detail = detail,
+            )
+
+            advertisedL1 &&
+                snapshot.hardwareSecureAllSupported == true &&
+                snapshot.sessionStatus == WidevineOperationStatus.SUCCESS &&
+                snapshot.actualSessionSecurityLevel == WidevineSessionSecurityLevel.HW_SECURE_ALL &&
                 snapshot.credentialStatus == WidevineOperationStatus.SUCCESS &&
                 snapshot.credentialAvailable == true &&
                 snapshot.keyRequestStatus == WidevineOperationStatus.SUCCESS ->
@@ -170,16 +171,14 @@ internal class WidevineCredentialClassifier {
             )
         }
 
-        val javaSecurity = snapshot.javaSecurityLevel.normalizedSecurityLevel()
-        val nativeSecurity = snapshot.native.securityLevel.normalizedSecurityLevel()
-        val javaSystemId = snapshot.javaSystemId.normalizedSystemId()
-        val nativeSystemId = snapshot.native.systemId.normalizedSystemId()
         val securityComparable = snapshot.javaSecurityLevel.status == WidevinePropertyStatus.AVAILABLE &&
             snapshot.native.securityLevel.status == WidevinePropertyStatus.AVAILABLE
         val systemIdComparable = snapshot.javaSystemId.status == WidevinePropertyStatus.AVAILABLE &&
             snapshot.native.systemId.status == WidevinePropertyStatus.AVAILABLE
-        val securityMismatch = securityComparable && javaSecurity != nativeSecurity
-        val systemIdMismatch = systemIdComparable && javaSystemId != nativeSystemId
+        val securityMismatch = securityComparable &&
+            snapshot.javaSecurityLevel.value != snapshot.native.securityLevel.value
+        val systemIdMismatch = systemIdComparable &&
+            snapshot.javaSystemId.value != snapshot.native.systemId.value
 
         if (securityMismatch || systemIdMismatch) {
             val fields = buildList {
@@ -219,7 +218,15 @@ internal class WidevineCredentialClassifier {
             append(snapshot.javaSecurityLevel.normalizedSecurityLevel().displayValue())
             append("; Java system ID: ")
             append(snapshot.javaSystemId.normalizedSystemId().displayValue())
-            append("; actual session: ")
+            append("; video/mp4 HW_SECURE_ALL capability: ")
+            append(
+                when (snapshot.hardwareSecureAllSupported) {
+                    true -> "SUPPORTED"
+                    false -> "UNSUPPORTED"
+                    null -> "UNAVAILABLE"
+                },
+            )
+            append("; maximum session: ")
             append(snapshot.actualSessionSecurityLevel?.name ?: snapshot.sessionStatus.name)
             append("; credential availability: ")
             append(
@@ -236,9 +243,9 @@ internal class WidevineCredentialClassifier {
             append("; boot context: ")
             append(
                 when {
-                    bootContext.rootOfTrustUnlocked -> "RootOfTrust confirms unlocked"
-                    bootContext.bootStateAppearsLocked -> "boot state appears locked"
-                    else -> "boot state is inconclusive"
+                    bootContext.rootOfTrustUnlocked -> "independent RootOfTrust state is unlocked"
+                    bootContext.bootStateAppearsLocked -> "independent boot state appears locked"
+                    else -> "independent boot state is inconclusive"
                 },
             )
             if (snapshot.errors.isNotEmpty()) {
@@ -259,28 +266,29 @@ internal class WidevineCredentialClassifier {
     private fun buildImpact(
         credential: WidevineAssessmentFinding,
         parity: WidevineAssessmentFinding,
-        bootContext: WidevineBootContext,
     ): WidevineAssessmentFinding? {
         return when {
             credential.severity == WidevineAssessmentSeverity.DANGER ->
                 WidevineAssessmentFinding(
                     id = "widevine_impact",
                     label = "Widevine impact",
-                    value = "Operational inconsistency",
+                    value = "Auxiliary DRM inconsistency",
                     severity = WidevineAssessmentSeverity.DANGER,
-                    detail = "The advertised L1 state conflicts with independent credential, session, or RootOfTrust evidence. This confirms a DRM credential anomaly, not a standalone bootloader-state verdict.",
+                    detail = "The exact sentinel and a lower maximum-session level were observed even though the capability check reported video/mp4 HW_SECURE_ALL support. This is a stronger DRM inconsistency, but it neither determines bootloader state nor establishes causality.",
                 )
 
             credential.severity == WidevineAssessmentSeverity.WARNING ->
                 WidevineAssessmentFinding(
                     id = "widevine_impact",
                     label = "Widevine impact",
-                    value = "Credential anomaly",
+                    value = "Auxiliary DRM signal",
                     severity = WidevineAssessmentSeverity.WARNING,
-                    detail = if (bootContext.bootStateAppearsLocked) {
-                        "A locked-looking boot state with the exact Widevine sentinel may reflect historical unlocking, ROM conversion, spoofing, or an OEM provisioning defect."
-                    } else {
-                        "The exact Widevine sentinel is suspicious but does not independently establish the current bootloader lock state."
+                    detail = when (credential.value) {
+                        "Sentinel system ID" ->
+                            "The exact Widevine sentinel is suspicious, but it does not establish invalid credentials, the current bootloader state, or causality."
+
+                        else ->
+                            "The maximum-security session resolved below HW_SECURE_ALL even though the capability check reported support. This needs review but is not proof of invalid credentials or an unlocked bootloader."
                     },
                 )
 
@@ -334,6 +342,13 @@ internal class WidevineCredentialClassifier {
     }
 
     private fun String?.displayValue(): String = this ?: "unavailable"
+
+    private fun WidevineSessionSecurityLevel?.isKnownBelowHardwareSecureAll(): Boolean {
+        return this == WidevineSessionSecurityLevel.SW_SECURE_CRYPTO ||
+            this == WidevineSessionSecurityLevel.SW_SECURE_DECODE ||
+            this == WidevineSessionSecurityLevel.HW_SECURE_CRYPTO ||
+            this == WidevineSessionSecurityLevel.HW_SECURE_DECODE
+    }
 
     private fun WidevineDrmError.numericDescription(): String {
         return buildString {

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialClassifier.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialClassifier.kt
@@ -274,7 +274,7 @@ internal class WidevineCredentialClassifier {
                     label = "Widevine impact",
                     value = "Auxiliary DRM inconsistency",
                     severity = WidevineAssessmentSeverity.DANGER,
-                    detail = "The exact sentinel and a lower maximum-session level were observed even though the capability check reported video/mp4 HW_SECURE_ALL support. This is a stronger DRM inconsistency, but it neither determines bootloader state nor establishes causality.",
+                    detail = "The exact sentinel and a lower maximum-session level were observed despite video/mp4 HW_SECURE_ALL support. This policy classifies the bootloader as unlocked but does not establish why the DRM path diverged.",
                 )
 
             credential.severity == WidevineAssessmentSeverity.WARNING ->
@@ -285,10 +285,10 @@ internal class WidevineCredentialClassifier {
                     severity = WidevineAssessmentSeverity.WARNING,
                     detail = when (credential.value) {
                         "Sentinel system ID" ->
-                            "The exact Widevine sentinel is suspicious, but it does not establish invalid credentials, the current bootloader state, or causality."
+                            "The exact Widevine sentinel makes the bootloader state inconclusive until corroborated."
 
                         else ->
-                            "The maximum-security session resolved below HW_SECURE_ALL even though the capability check reported support. This needs review but is not proof of invalid credentials or an unlocked bootloader."
+                            "The maximum-security session resolved below HW_SECURE_ALL despite reported support, making the bootloader state inconclusive."
                     },
                 )
 

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialClassifier.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialClassifier.kt
@@ -274,7 +274,7 @@ internal class WidevineCredentialClassifier {
                     label = "Widevine impact",
                     value = "Auxiliary DRM inconsistency",
                     severity = WidevineAssessmentSeverity.DANGER,
-                    detail = "The exact sentinel and a lower maximum-session level were observed despite video/mp4 HW_SECURE_ALL support. This policy classifies the bootloader as unlocked but does not establish why the DRM path diverged.",
+                    detail = "The exact sentinel and a lower maximum-session level were observed despite video/mp4 HW_SECURE_ALL support. This is a critical DRM conflict, not standalone proof of the current bootloader state.",
                 )
 
             credential.severity == WidevineAssessmentSeverity.WARNING ->
@@ -285,10 +285,10 @@ internal class WidevineCredentialClassifier {
                     severity = WidevineAssessmentSeverity.WARNING,
                     detail = when (credential.value) {
                         "Sentinel system ID" ->
-                            "The exact Widevine sentinel makes the bootloader state inconclusive until corroborated."
+                            "The exact Widevine sentinel requires review but does not override the current bootloader state."
 
                         else ->
-                            "The maximum-security session resolved below HW_SECURE_ALL despite reported support, making the bootloader state inconclusive."
+                            "The maximum-security session resolved below HW_SECURE_ALL despite reported support; the DRM result requires review."
                     },
                 )
 

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialModels.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialModels.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.bootloader.data.widevine
+
+internal const val WIDEVINE_SENTINEL_SYSTEM_ID = "2147483647"
+
+internal enum class WidevinePropertyStatus {
+    NOT_ATTEMPTED,
+    AVAILABLE,
+    UNSUPPORTED,
+    ERROR,
+}
+
+internal data class WidevinePropertyRead(
+    val status: WidevinePropertyStatus = WidevinePropertyStatus.NOT_ATTEMPTED,
+    val value: String? = null,
+)
+
+internal enum class WidevineOperationStatus {
+    NOT_ATTEMPTED,
+    SUCCESS,
+    UNSUPPORTED,
+    NOT_PROVISIONED,
+    RESOURCE_BUSY,
+    TRANSIENT_ERROR,
+    FAILURE,
+}
+
+internal enum class WidevineSessionSecurityLevel {
+    UNKNOWN,
+    SW_SECURE_CRYPTO,
+    SW_SECURE_DECODE,
+    HW_SECURE_CRYPTO,
+    HW_SECURE_DECODE,
+    HW_SECURE_ALL,
+}
+
+internal enum class WidevineDrmErrorStage {
+    SUPPORT_CHECK,
+    CREATE,
+    JAVA_SECURITY_LEVEL,
+    JAVA_SYSTEM_ID,
+    SESSION_OPEN,
+    SESSION_SECURITY_LEVEL,
+    CREDENTIAL_AVAILABILITY,
+    KEY_REQUEST,
+    SESSION_CLOSE,
+    RELEASE,
+}
+
+internal enum class WidevineDrmErrorKind {
+    UNSUPPORTED_SCHEME,
+    UNSUPPORTED_PROPERTY,
+    NOT_PROVISIONED,
+    RESOURCE_BUSY,
+    STATE,
+    RUNTIME,
+}
+
+/** Numeric-only error metadata. Framework diagnostic strings are never retained. */
+internal data class WidevineDrmError(
+    val stage: WidevineDrmErrorStage,
+    val kind: WidevineDrmErrorKind,
+    val errorCode: Int? = null,
+    val vendorError: Int? = null,
+    val oemError: Int? = null,
+    val errorContext: Int? = null,
+    val transient: Boolean? = null,
+)
+
+internal data class WidevineNativeSnapshot(
+    val available: Boolean = false,
+    val securityLevel: WidevinePropertyRead = WidevinePropertyRead(),
+    val systemId: WidevinePropertyRead = WidevinePropertyRead(),
+    val securityLevelStatusCode: Int? = null,
+    val systemIdStatusCode: Int? = null,
+)
+
+/**
+ * Contains capability state only. Device-unique IDs and opaque key-request bytes are deliberately
+ * absent so they cannot cross the collection boundary.
+ */
+internal data class WidevineCredentialSnapshot(
+    val schemeSupported: Boolean? = null,
+    val javaSecurityLevel: WidevinePropertyRead = WidevinePropertyRead(),
+    val javaSystemId: WidevinePropertyRead = WidevinePropertyRead(),
+    val native: WidevineNativeSnapshot = WidevineNativeSnapshot(),
+    val sessionStatus: WidevineOperationStatus = WidevineOperationStatus.NOT_ATTEMPTED,
+    val actualSessionSecurityLevel: WidevineSessionSecurityLevel? = null,
+    val credentialStatus: WidevineOperationStatus = WidevineOperationStatus.NOT_ATTEMPTED,
+    val credentialAvailable: Boolean? = null,
+    val keyRequestStatus: WidevineOperationStatus = WidevineOperationStatus.NOT_ATTEMPTED,
+    val errors: List<WidevineDrmError> = emptyList(),
+)
+
+internal data class WidevineBootContext(
+    val rootOfTrustUnlocked: Boolean,
+    val bootStateAppearsLocked: Boolean,
+)
+
+internal enum class WidevineAssessmentSeverity {
+    SAFE,
+    WARNING,
+    DANGER,
+    SUPPORT,
+}
+
+internal data class WidevineAssessmentFinding(
+    val id: String,
+    val label: String,
+    val value: String,
+    val severity: WidevineAssessmentSeverity,
+    val detail: String,
+)
+
+internal data class WidevineCredentialAssessment(
+    val findings: List<WidevineAssessmentFinding>,
+    val methodSummary: String,
+    val methodSeverity: WidevineAssessmentSeverity,
+    val methodDetail: String,
+    val impact: WidevineAssessmentFinding? = null,
+) {
+    val anomalyCount: Int
+        get() = findings.count {
+            it.severity == WidevineAssessmentSeverity.WARNING ||
+                it.severity == WidevineAssessmentSeverity.DANGER
+        }
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialModels.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialModels.kt
@@ -17,6 +17,13 @@
 package com.eltavine.duckdetector.features.bootloader.data.widevine
 
 internal const val WIDEVINE_SENTINEL_SYSTEM_ID = "2147483647"
+internal const val MAX_WIDEVINE_PROPERTY_VALUE_LENGTH = 64
+
+internal fun String.isValidWidevinePropertyValue(): Boolean {
+    return isNotEmpty() &&
+        length <= MAX_WIDEVINE_PROPERTY_VALUE_LENGTH &&
+        all { character -> character.code in 0x20..0x7e }
+}
 
 internal enum class WidevinePropertyStatus {
     NOT_ATTEMPTED,
@@ -51,6 +58,7 @@ internal enum class WidevineSessionSecurityLevel {
 
 internal enum class WidevineDrmErrorStage {
     SUPPORT_CHECK,
+    SESSION_CAPABILITY,
     CREATE,
     JAVA_SECURITY_LEVEL,
     JAVA_SYSTEM_ID,
@@ -65,6 +73,8 @@ internal enum class WidevineDrmErrorStage {
 internal enum class WidevineDrmErrorKind {
     UNSUPPORTED_SCHEME,
     UNSUPPORTED_PROPERTY,
+    INVALID_PROPERTY_VALUE,
+    INVALID_SESSION_ID,
     NOT_PROVISIONED,
     RESOURCE_BUSY,
     STATE,
@@ -96,6 +106,7 @@ internal data class WidevineNativeSnapshot(
  */
 internal data class WidevineCredentialSnapshot(
     val schemeSupported: Boolean? = null,
+    val hardwareSecureAllSupported: Boolean? = null,
     val javaSecurityLevel: WidevinePropertyRead = WidevinePropertyRead(),
     val javaSystemId: WidevinePropertyRead = WidevinePropertyRead(),
     val native: WidevineNativeSnapshot = WidevineNativeSnapshot(),

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialProbe.kt
@@ -18,11 +18,13 @@ package com.eltavine.duckdetector.features.bootloader.data.widevine
 
 import android.media.MediaDrm
 import android.media.MediaDrm.MediaDrmStateException
-import android.media.MediaDrmException
+import android.media.MediaDrm.SessionException
+import android.media.MediaDrmThrowable
 import android.media.NotProvisionedException
 import android.media.ResourceBusyException
 import android.media.UnsupportedSchemeException
 import android.os.Build
+import androidx.annotation.RequiresApi
 import java.util.UUID
 
 internal fun interface WidevineCredentialSource {
@@ -32,13 +34,15 @@ internal fun interface WidevineCredentialSource {
 internal interface WidevineMediaDrmFactory {
     fun isCryptoSchemeSupported(): Boolean
 
+    fun isHardwareSecureAllSupported(): Boolean
+
     fun create(): WidevineMediaDrmClient
 }
 
 internal interface WidevineMediaDrmClient : AutoCloseable {
     fun getPropertyString(name: String): String
 
-    fun openHardwareSecureAllSession(): ByteArray
+    fun openMaximumSecuritySession(): ByteArray
 
     fun getSecurityLevel(sessionId: ByteArray): WidevineSessionSecurityLevel
 
@@ -49,16 +53,30 @@ internal interface WidevineMediaDrmClient : AutoCloseable {
     fun closeSession(sessionId: ByteArray)
 }
 
+internal data class WidevineDrmErrorMetadata(
+    val errorCode: Int? = null,
+    val vendorError: Int? = null,
+    val oemError: Int? = null,
+    val errorContext: Int? = null,
+    val transient: Boolean? = null,
+)
+
+internal fun interface WidevineDrmErrorMetadataReader {
+    fun read(throwable: Exception): WidevineDrmErrorMetadata
+}
+
 internal class WidevineCredentialProbe(
     private val mediaDrmFactory: WidevineMediaDrmFactory = AndroidWidevineMediaDrmFactory,
     private val nativePropertyReader: WidevineNativePropertyReader = WidevineNativeBridge(),
+    private val errorMetadataReader: WidevineDrmErrorMetadataReader =
+        AndroidWidevineDrmErrorMetadataReader,
 ) : WidevineCredentialSource {
 
     override fun collect(): WidevineCredentialSnapshot {
         val errors = mutableListOf<WidevineDrmError>()
         val supported = try {
             mediaDrmFactory.isCryptoSchemeSupported()
-        } catch (throwable: Throwable) {
+        } catch (throwable: Exception) {
             errors += sanitizeError(WidevineDrmErrorStage.SUPPORT_CHECK, throwable)
             return WidevineCredentialSnapshot(errors = errors)
         }
@@ -66,6 +84,12 @@ internal class WidevineCredentialProbe(
             return WidevineCredentialSnapshot(schemeSupported = false)
         }
 
+        val hardwareSecureAllSupported = try {
+            mediaDrmFactory.isHardwareSecureAllSupported()
+        } catch (throwable: Exception) {
+            errors += sanitizeError(WidevineDrmErrorStage.SESSION_CAPABILITY, throwable)
+            null
+        }
         val nativeSnapshot = nativePropertyReader.readProperties()
         var javaSecurityLevel = WidevinePropertyRead()
         var javaSystemId = WidevinePropertyRead()
@@ -80,7 +104,7 @@ internal class WidevineCredentialProbe(
         try {
             mediaDrm = try {
                 mediaDrmFactory.create()
-            } catch (throwable: Throwable) {
+            } catch (throwable: Exception) {
                 errors += sanitizeError(WidevineDrmErrorStage.CREATE, throwable)
                 null
             }
@@ -100,9 +124,18 @@ internal class WidevineCredentialProbe(
                 }
 
                 try {
-                    sessionId = mediaDrm.openHardwareSecureAllSession()
-                    sessionStatus = WidevineOperationStatus.SUCCESS
-                } catch (throwable: Throwable) {
+                    val openedSession = mediaDrm.openMaximumSecuritySession()
+                    if (openedSession.isEmpty()) {
+                        errors += WidevineDrmError(
+                            stage = WidevineDrmErrorStage.SESSION_OPEN,
+                            kind = WidevineDrmErrorKind.INVALID_SESSION_ID,
+                        )
+                        sessionStatus = WidevineOperationStatus.FAILURE
+                    } else {
+                        sessionId = openedSession
+                        sessionStatus = WidevineOperationStatus.SUCCESS
+                    }
+                } catch (throwable: Exception) {
                     val error = sanitizeError(WidevineDrmErrorStage.SESSION_OPEN, throwable)
                     errors += error
                     sessionStatus = error.toOperationStatus()
@@ -111,7 +144,7 @@ internal class WidevineCredentialProbe(
                 sessionId?.let { openedSession ->
                     try {
                         actualSecurityLevel = mediaDrm.getSecurityLevel(openedSession)
-                    } catch (throwable: Throwable) {
+                    } catch (throwable: Exception) {
                         errors += sanitizeError(
                             WidevineDrmErrorStage.SESSION_SECURITY_LEVEL,
                             throwable,
@@ -122,7 +155,7 @@ internal class WidevineCredentialProbe(
                 try {
                     credentialAvailable = mediaDrm.hasDeviceUniqueId()
                     credentialStatus = WidevineOperationStatus.SUCCESS
-                } catch (throwable: Throwable) {
+                } catch (throwable: Exception) {
                     val error = sanitizeError(
                         WidevineDrmErrorStage.CREDENTIAL_AVAILABILITY,
                         throwable,
@@ -135,7 +168,7 @@ internal class WidevineCredentialProbe(
                     try {
                         mediaDrm.generateTestKeyRequest(openedSession)
                         keyRequestStatus = WidevineOperationStatus.SUCCESS
-                    } catch (throwable: Throwable) {
+                    } catch (throwable: Exception) {
                         val error = sanitizeError(WidevineDrmErrorStage.KEY_REQUEST, throwable)
                         errors += error
                         keyRequestStatus = error.toOperationStatus()
@@ -145,24 +178,30 @@ internal class WidevineCredentialProbe(
         } finally {
             val client = mediaDrm
             val openedSession = sessionId
-            if (client != null && openedSession != null) {
-                try {
-                    client.closeSession(openedSession)
-                } catch (throwable: Throwable) {
-                    errors += sanitizeError(WidevineDrmErrorStage.SESSION_CLOSE, throwable)
+            try {
+                if (client != null && openedSession != null) {
+                    try {
+                        client.closeSession(openedSession)
+                    } catch (throwable: Exception) {
+                        errors += sanitizeError(WidevineDrmErrorStage.SESSION_CLOSE, throwable)
+                    } finally {
+                        openedSession.fill(0)
+                    }
                 }
-            }
-            if (client != null) {
-                try {
-                    client.close()
-                } catch (throwable: Throwable) {
-                    errors += sanitizeError(WidevineDrmErrorStage.RELEASE, throwable)
+            } finally {
+                if (client != null) {
+                    try {
+                        client.close()
+                    } catch (throwable: Exception) {
+                        errors += sanitizeError(WidevineDrmErrorStage.RELEASE, throwable)
+                    }
                 }
             }
         }
 
         return WidevineCredentialSnapshot(
             schemeSupported = true,
+            hardwareSecureAllSupported = hardwareSecureAllSupported,
             javaSecurityLevel = javaSecurityLevel,
             javaSystemId = javaSystemId,
             native = nativeSnapshot,
@@ -181,11 +220,20 @@ internal class WidevineCredentialProbe(
         block: () -> String,
     ): WidevinePropertyRead {
         return try {
-            WidevinePropertyRead(
-                status = WidevinePropertyStatus.AVAILABLE,
-                value = block(),
-            )
-        } catch (throwable: Throwable) {
+            val value = block()
+            if (value.isValidWidevinePropertyValue()) {
+                WidevinePropertyRead(
+                    status = WidevinePropertyStatus.AVAILABLE,
+                    value = value,
+                )
+            } else {
+                errors += WidevineDrmError(
+                    stage = stage,
+                    kind = WidevineDrmErrorKind.INVALID_PROPERTY_VALUE,
+                )
+                WidevinePropertyRead(status = WidevinePropertyStatus.ERROR)
+            }
+        } catch (throwable: Exception) {
             val error = sanitizeError(stage, throwable)
             errors += error
             WidevinePropertyRead(
@@ -200,56 +248,41 @@ internal class WidevineCredentialProbe(
 
     private fun sanitizeError(
         stage: WidevineDrmErrorStage,
-        throwable: Throwable,
+        throwable: Exception,
     ): WidevineDrmError {
         val stateException = throwable as? MediaDrmStateException
-        val mediaDrmException = throwable as? MediaDrmException
+        val sessionException = throwable as? SessionException
+        val numericMetadata = try {
+            errorMetadataReader.read(throwable)
+        } catch (_: Exception) {
+            WidevineDrmErrorMetadata()
+        }
+        val unsupportedProperty = stage.isPropertyStage() && (
+            throwable is IllegalArgumentException ||
+                throwable is UnsupportedOperationException ||
+                stateException != null &&
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                numericMetadata.errorCode == MediaDrm.ErrorCodes.ERROR_UNSUPPORTED_OPERATION
+        )
         return WidevineDrmError(
             stage = stage,
             kind = when {
                 throwable is UnsupportedSchemeException -> WidevineDrmErrorKind.UNSUPPORTED_SCHEME
                 throwable is NotProvisionedException -> WidevineDrmErrorKind.NOT_PROVISIONED
                 throwable is ResourceBusyException -> WidevineDrmErrorKind.RESOURCE_BUSY
-                throwable is IllegalArgumentException && stage.isPropertyStage() ->
-                    WidevineDrmErrorKind.UNSUPPORTED_PROPERTY
+                sessionException != null && numericMetadata.transient == true ->
+                    WidevineDrmErrorKind.RESOURCE_BUSY
 
-                throwable is UnsupportedOperationException && stage.isPropertyStage() ->
-                    WidevineDrmErrorKind.UNSUPPORTED_PROPERTY
-
-                stateException != null -> WidevineDrmErrorKind.STATE
+                unsupportedProperty -> WidevineDrmErrorKind.UNSUPPORTED_PROPERTY
+                stateException != null || sessionException != null -> WidevineDrmErrorKind.STATE
                 else -> WidevineDrmErrorKind.RUNTIME
             },
-            errorCode = stateException?.sanitizedErrorCode(),
-            vendorError = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                mediaDrmException?.vendorError
-            } else {
-                null
-            },
-            oemError = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                mediaDrmException?.oemError
-            } else {
-                null
-            },
-            errorContext = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                mediaDrmException?.errorContext
-            } else {
-                null
-            },
-            transient = if (stateException != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                stateException.isTransient
-            } else {
-                null
-            },
+            errorCode = numericMetadata.errorCode,
+            vendorError = numericMetadata.vendorError,
+            oemError = numericMetadata.oemError,
+            errorContext = numericMetadata.errorContext,
+            transient = numericMetadata.transient,
         )
-    }
-
-    private fun MediaDrmStateException.sanitizedErrorCode(): Int? {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            return errorCode
-        }
-        val match = LEGACY_DIAGNOSTIC_ERROR.find(diagnosticInfo) ?: return null
-        val magnitude = match.groupValues[2].toIntOrNull() ?: return null
-        return if (match.groupValues[1].isNotEmpty()) -magnitude else magnitude
     }
 
     private fun WidevineDrmErrorStage.isPropertyStage(): Boolean {
@@ -277,7 +310,69 @@ internal class WidevineCredentialProbe(
     private companion object {
         const val PROPERTY_SECURITY_LEVEL = "securityLevel"
         const val PROPERTY_SYSTEM_ID = "systemId"
-        val LEGACY_DIAGNOSTIC_ERROR = Regex("error_(neg_)?(\\d+)")
+    }
+}
+
+private object AndroidWidevineDrmErrorMetadataReader : WidevineDrmErrorMetadataReader {
+
+    override fun read(throwable: Exception): WidevineDrmErrorMetadata {
+        val stateException = throwable as? MediaDrmStateException
+        val sessionException = throwable as? SessionException
+        val api34Metadata = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            Api34.read(throwable)
+        } else {
+            WidevineDrmErrorMetadata()
+        }
+        return api34Metadata.copy(
+            errorCode = when {
+                stateException != null -> stateException.sanitizedErrorCode()
+                sessionException != null -> sessionException.sanitizedErrorCode()
+                else -> null
+            },
+            transient = when {
+                stateException != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ->
+                    stateException.isTransient
+
+                sessionException != null -> sessionException.isTransientCompat()
+                else -> null
+            },
+        )
+    }
+
+    private fun MediaDrmStateException.sanitizedErrorCode(): Int? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return errorCode
+        }
+        val match = LEGACY_DIAGNOSTIC_ERROR.find(diagnosticInfo) ?: return null
+        val magnitude = match.groupValues[2].toIntOrNull() ?: return null
+        return if (match.groupValues[1].isNotEmpty()) -magnitude else magnitude
+    }
+
+    @Suppress("DEPRECATION")
+    private fun SessionException.sanitizedErrorCode(): Int = errorCode
+
+    @Suppress("DEPRECATION")
+    private fun SessionException.isTransientCompat(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            isTransient
+        } else {
+            errorCode == SessionException.ERROR_RESOURCE_CONTENTION
+        }
+    }
+
+    private val LEGACY_DIAGNOSTIC_ERROR = Regex("error_(neg_)?(\\d+)")
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private object Api34 {
+        fun read(throwable: Throwable): WidevineDrmErrorMetadata {
+            val mediaDrmThrowable = throwable as? MediaDrmThrowable
+                ?: return WidevineDrmErrorMetadata()
+            return WidevineDrmErrorMetadata(
+                vendorError = mediaDrmThrowable.vendorError,
+                oemError = mediaDrmThrowable.oemError,
+                errorContext = mediaDrmThrowable.errorContext,
+            )
+        }
     }
 }
 
@@ -286,6 +381,14 @@ private object AndroidWidevineMediaDrmFactory : WidevineMediaDrmFactory {
 
     override fun isCryptoSchemeSupported(): Boolean {
         return MediaDrm.isCryptoSchemeSupported(widevineUuid)
+    }
+
+    override fun isHardwareSecureAllSupported(): Boolean {
+        return MediaDrm.isCryptoSchemeSupported(
+            widevineUuid,
+            WIDEVINE_TEST_MIME_TYPE,
+            MediaDrm.SECURITY_LEVEL_HW_SECURE_ALL,
+        )
     }
 
     override fun create(): WidevineMediaDrmClient {
@@ -299,8 +402,8 @@ private class AndroidWidevineMediaDrmClient(
 
     override fun getPropertyString(name: String): String = mediaDrm.getPropertyString(name)
 
-    override fun openHardwareSecureAllSession(): ByteArray {
-        return mediaDrm.openSession(MediaDrm.SECURITY_LEVEL_HW_SECURE_ALL)
+    override fun openMaximumSecuritySession(): ByteArray {
+        return mediaDrm.openSession()
     }
 
     override fun getSecurityLevel(sessionId: ByteArray): WidevineSessionSecurityLevel {
@@ -325,17 +428,23 @@ private class AndroidWidevineMediaDrmClient(
     }
 
     override fun hasDeviceUniqueId(): Boolean {
-        return mediaDrm.getPropertyByteArray(MediaDrm.PROPERTY_DEVICE_UNIQUE_ID).isNotEmpty()
+        val deviceUniqueId = mediaDrm.getPropertyByteArray(MediaDrm.PROPERTY_DEVICE_UNIQUE_ID)
+        return try {
+            deviceUniqueId.isNotEmpty()
+        } finally {
+            deviceUniqueId.fill(0)
+        }
     }
 
     override fun generateTestKeyRequest(sessionId: ByteArray) {
-        mediaDrm.getKeyRequest(
+        val request = mediaDrm.getKeyRequest(
             sessionId,
-            TEST_PSSH,
-            TEST_MIME_TYPE,
+            TEST_PSSH.copyOf(),
+            WIDEVINE_TEST_MIME_TYPE,
             MediaDrm.KEY_TYPE_STREAMING,
             hashMapOf(),
         )
+        request.data.fill(0)
     }
 
     override fun closeSession(sessionId: ByteArray) {
@@ -347,8 +456,6 @@ private class AndroidWidevineMediaDrmClient(
     }
 
     private companion object {
-        const val TEST_MIME_TYPE = "video/mp4"
-
         // Common Encryption PSSH v0 with the Widevine system ID and a fixed non-secret test KID.
         val TEST_PSSH = intArrayOf(
             0x00, 0x00, 0x00, 0x32,
@@ -363,3 +470,5 @@ private class AndroidWidevineMediaDrmClient(
         ).map(Int::toByte).toByteArray()
     }
 }
+
+private const val WIDEVINE_TEST_MIME_TYPE = "video/mp4"

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialProbe.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialProbe.kt
@@ -1,0 +1,365 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.bootloader.data.widevine
+
+import android.media.MediaDrm
+import android.media.MediaDrm.MediaDrmStateException
+import android.media.MediaDrmException
+import android.media.NotProvisionedException
+import android.media.ResourceBusyException
+import android.media.UnsupportedSchemeException
+import android.os.Build
+import java.util.UUID
+
+internal fun interface WidevineCredentialSource {
+    fun collect(): WidevineCredentialSnapshot
+}
+
+internal interface WidevineMediaDrmFactory {
+    fun isCryptoSchemeSupported(): Boolean
+
+    fun create(): WidevineMediaDrmClient
+}
+
+internal interface WidevineMediaDrmClient : AutoCloseable {
+    fun getPropertyString(name: String): String
+
+    fun openHardwareSecureAllSession(): ByteArray
+
+    fun getSecurityLevel(sessionId: ByteArray): WidevineSessionSecurityLevel
+
+    fun hasDeviceUniqueId(): Boolean
+
+    fun generateTestKeyRequest(sessionId: ByteArray)
+
+    fun closeSession(sessionId: ByteArray)
+}
+
+internal class WidevineCredentialProbe(
+    private val mediaDrmFactory: WidevineMediaDrmFactory = AndroidWidevineMediaDrmFactory,
+    private val nativePropertyReader: WidevineNativePropertyReader = WidevineNativeBridge(),
+) : WidevineCredentialSource {
+
+    override fun collect(): WidevineCredentialSnapshot {
+        val errors = mutableListOf<WidevineDrmError>()
+        val supported = try {
+            mediaDrmFactory.isCryptoSchemeSupported()
+        } catch (throwable: Throwable) {
+            errors += sanitizeError(WidevineDrmErrorStage.SUPPORT_CHECK, throwable)
+            return WidevineCredentialSnapshot(errors = errors)
+        }
+        if (!supported) {
+            return WidevineCredentialSnapshot(schemeSupported = false)
+        }
+
+        val nativeSnapshot = nativePropertyReader.readProperties()
+        var javaSecurityLevel = WidevinePropertyRead()
+        var javaSystemId = WidevinePropertyRead()
+        var sessionStatus = WidevineOperationStatus.NOT_ATTEMPTED
+        var actualSecurityLevel: WidevineSessionSecurityLevel? = null
+        var credentialStatus = WidevineOperationStatus.NOT_ATTEMPTED
+        var credentialAvailable: Boolean? = null
+        var keyRequestStatus = WidevineOperationStatus.NOT_ATTEMPTED
+        var mediaDrm: WidevineMediaDrmClient? = null
+        var sessionId: ByteArray? = null
+
+        try {
+            mediaDrm = try {
+                mediaDrmFactory.create()
+            } catch (throwable: Throwable) {
+                errors += sanitizeError(WidevineDrmErrorStage.CREATE, throwable)
+                null
+            }
+
+            if (mediaDrm != null) {
+                javaSecurityLevel = readProperty(
+                    stage = WidevineDrmErrorStage.JAVA_SECURITY_LEVEL,
+                    errors = errors,
+                ) {
+                    mediaDrm.getPropertyString(PROPERTY_SECURITY_LEVEL)
+                }
+                javaSystemId = readProperty(
+                    stage = WidevineDrmErrorStage.JAVA_SYSTEM_ID,
+                    errors = errors,
+                ) {
+                    mediaDrm.getPropertyString(PROPERTY_SYSTEM_ID)
+                }
+
+                try {
+                    sessionId = mediaDrm.openHardwareSecureAllSession()
+                    sessionStatus = WidevineOperationStatus.SUCCESS
+                } catch (throwable: Throwable) {
+                    val error = sanitizeError(WidevineDrmErrorStage.SESSION_OPEN, throwable)
+                    errors += error
+                    sessionStatus = error.toOperationStatus()
+                }
+
+                sessionId?.let { openedSession ->
+                    try {
+                        actualSecurityLevel = mediaDrm.getSecurityLevel(openedSession)
+                    } catch (throwable: Throwable) {
+                        errors += sanitizeError(
+                            WidevineDrmErrorStage.SESSION_SECURITY_LEVEL,
+                            throwable,
+                        )
+                    }
+                }
+
+                try {
+                    credentialAvailable = mediaDrm.hasDeviceUniqueId()
+                    credentialStatus = WidevineOperationStatus.SUCCESS
+                } catch (throwable: Throwable) {
+                    val error = sanitizeError(
+                        WidevineDrmErrorStage.CREDENTIAL_AVAILABILITY,
+                        throwable,
+                    )
+                    errors += error
+                    credentialStatus = error.toOperationStatus()
+                }
+
+                sessionId?.let { openedSession ->
+                    try {
+                        mediaDrm.generateTestKeyRequest(openedSession)
+                        keyRequestStatus = WidevineOperationStatus.SUCCESS
+                    } catch (throwable: Throwable) {
+                        val error = sanitizeError(WidevineDrmErrorStage.KEY_REQUEST, throwable)
+                        errors += error
+                        keyRequestStatus = error.toOperationStatus()
+                    }
+                }
+            }
+        } finally {
+            val client = mediaDrm
+            val openedSession = sessionId
+            if (client != null && openedSession != null) {
+                try {
+                    client.closeSession(openedSession)
+                } catch (throwable: Throwable) {
+                    errors += sanitizeError(WidevineDrmErrorStage.SESSION_CLOSE, throwable)
+                }
+            }
+            if (client != null) {
+                try {
+                    client.close()
+                } catch (throwable: Throwable) {
+                    errors += sanitizeError(WidevineDrmErrorStage.RELEASE, throwable)
+                }
+            }
+        }
+
+        return WidevineCredentialSnapshot(
+            schemeSupported = true,
+            javaSecurityLevel = javaSecurityLevel,
+            javaSystemId = javaSystemId,
+            native = nativeSnapshot,
+            sessionStatus = sessionStatus,
+            actualSessionSecurityLevel = actualSecurityLevel,
+            credentialStatus = credentialStatus,
+            credentialAvailable = credentialAvailable,
+            keyRequestStatus = keyRequestStatus,
+            errors = errors.toList(),
+        )
+    }
+
+    private fun readProperty(
+        stage: WidevineDrmErrorStage,
+        errors: MutableList<WidevineDrmError>,
+        block: () -> String,
+    ): WidevinePropertyRead {
+        return try {
+            WidevinePropertyRead(
+                status = WidevinePropertyStatus.AVAILABLE,
+                value = block(),
+            )
+        } catch (throwable: Throwable) {
+            val error = sanitizeError(stage, throwable)
+            errors += error
+            WidevinePropertyRead(
+                status = if (error.kind == WidevineDrmErrorKind.UNSUPPORTED_PROPERTY) {
+                    WidevinePropertyStatus.UNSUPPORTED
+                } else {
+                    WidevinePropertyStatus.ERROR
+                },
+            )
+        }
+    }
+
+    private fun sanitizeError(
+        stage: WidevineDrmErrorStage,
+        throwable: Throwable,
+    ): WidevineDrmError {
+        val stateException = throwable as? MediaDrmStateException
+        val mediaDrmException = throwable as? MediaDrmException
+        return WidevineDrmError(
+            stage = stage,
+            kind = when {
+                throwable is UnsupportedSchemeException -> WidevineDrmErrorKind.UNSUPPORTED_SCHEME
+                throwable is NotProvisionedException -> WidevineDrmErrorKind.NOT_PROVISIONED
+                throwable is ResourceBusyException -> WidevineDrmErrorKind.RESOURCE_BUSY
+                throwable is IllegalArgumentException && stage.isPropertyStage() ->
+                    WidevineDrmErrorKind.UNSUPPORTED_PROPERTY
+
+                throwable is UnsupportedOperationException && stage.isPropertyStage() ->
+                    WidevineDrmErrorKind.UNSUPPORTED_PROPERTY
+
+                stateException != null -> WidevineDrmErrorKind.STATE
+                else -> WidevineDrmErrorKind.RUNTIME
+            },
+            errorCode = stateException?.sanitizedErrorCode(),
+            vendorError = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                mediaDrmException?.vendorError
+            } else {
+                null
+            },
+            oemError = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                mediaDrmException?.oemError
+            } else {
+                null
+            },
+            errorContext = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                mediaDrmException?.errorContext
+            } else {
+                null
+            },
+            transient = if (stateException != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                stateException.isTransient
+            } else {
+                null
+            },
+        )
+    }
+
+    private fun MediaDrmStateException.sanitizedErrorCode(): Int? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            return errorCode
+        }
+        val match = LEGACY_DIAGNOSTIC_ERROR.find(diagnosticInfo) ?: return null
+        val magnitude = match.groupValues[2].toIntOrNull() ?: return null
+        return if (match.groupValues[1].isNotEmpty()) -magnitude else magnitude
+    }
+
+    private fun WidevineDrmErrorStage.isPropertyStage(): Boolean {
+        return this == WidevineDrmErrorStage.JAVA_SECURITY_LEVEL ||
+            this == WidevineDrmErrorStage.JAVA_SYSTEM_ID
+    }
+
+    private fun WidevineDrmError.toOperationStatus(): WidevineOperationStatus {
+        return when {
+            kind == WidevineDrmErrorKind.UNSUPPORTED_SCHEME ||
+                kind == WidevineDrmErrorKind.UNSUPPORTED_PROPERTY ->
+                WidevineOperationStatus.UNSUPPORTED
+
+            kind == WidevineDrmErrorKind.NOT_PROVISIONED ->
+                WidevineOperationStatus.NOT_PROVISIONED
+
+            kind == WidevineDrmErrorKind.RESOURCE_BUSY ->
+                WidevineOperationStatus.RESOURCE_BUSY
+
+            transient == true -> WidevineOperationStatus.TRANSIENT_ERROR
+            else -> WidevineOperationStatus.FAILURE
+        }
+    }
+
+    private companion object {
+        const val PROPERTY_SECURITY_LEVEL = "securityLevel"
+        const val PROPERTY_SYSTEM_ID = "systemId"
+        val LEGACY_DIAGNOSTIC_ERROR = Regex("error_(neg_)?(\\d+)")
+    }
+}
+
+private object AndroidWidevineMediaDrmFactory : WidevineMediaDrmFactory {
+    private val widevineUuid = UUID.fromString("edef8ba9-79d6-4ace-a3c8-27dcd51d21ed")
+
+    override fun isCryptoSchemeSupported(): Boolean {
+        return MediaDrm.isCryptoSchemeSupported(widevineUuid)
+    }
+
+    override fun create(): WidevineMediaDrmClient {
+        return AndroidWidevineMediaDrmClient(MediaDrm(widevineUuid))
+    }
+}
+
+private class AndroidWidevineMediaDrmClient(
+    private val mediaDrm: MediaDrm,
+) : WidevineMediaDrmClient {
+
+    override fun getPropertyString(name: String): String = mediaDrm.getPropertyString(name)
+
+    override fun openHardwareSecureAllSession(): ByteArray {
+        return mediaDrm.openSession(MediaDrm.SECURITY_LEVEL_HW_SECURE_ALL)
+    }
+
+    override fun getSecurityLevel(sessionId: ByteArray): WidevineSessionSecurityLevel {
+        return when (mediaDrm.getSecurityLevel(sessionId)) {
+            MediaDrm.SECURITY_LEVEL_SW_SECURE_CRYPTO ->
+                WidevineSessionSecurityLevel.SW_SECURE_CRYPTO
+
+            MediaDrm.SECURITY_LEVEL_SW_SECURE_DECODE ->
+                WidevineSessionSecurityLevel.SW_SECURE_DECODE
+
+            MediaDrm.SECURITY_LEVEL_HW_SECURE_CRYPTO ->
+                WidevineSessionSecurityLevel.HW_SECURE_CRYPTO
+
+            MediaDrm.SECURITY_LEVEL_HW_SECURE_DECODE ->
+                WidevineSessionSecurityLevel.HW_SECURE_DECODE
+
+            MediaDrm.SECURITY_LEVEL_HW_SECURE_ALL ->
+                WidevineSessionSecurityLevel.HW_SECURE_ALL
+
+            else -> WidevineSessionSecurityLevel.UNKNOWN
+        }
+    }
+
+    override fun hasDeviceUniqueId(): Boolean {
+        return mediaDrm.getPropertyByteArray(MediaDrm.PROPERTY_DEVICE_UNIQUE_ID).isNotEmpty()
+    }
+
+    override fun generateTestKeyRequest(sessionId: ByteArray) {
+        mediaDrm.getKeyRequest(
+            sessionId,
+            TEST_PSSH,
+            TEST_MIME_TYPE,
+            MediaDrm.KEY_TYPE_STREAMING,
+            hashMapOf(),
+        )
+    }
+
+    override fun closeSession(sessionId: ByteArray) {
+        mediaDrm.closeSession(sessionId)
+    }
+
+    override fun close() {
+        mediaDrm.close()
+    }
+
+    private companion object {
+        const val TEST_MIME_TYPE = "video/mp4"
+
+        // Common Encryption PSSH v0 with the Widevine system ID and a fixed non-secret test KID.
+        val TEST_PSSH = intArrayOf(
+            0x00, 0x00, 0x00, 0x32,
+            0x70, 0x73, 0x73, 0x68,
+            0x00, 0x00, 0x00, 0x00,
+            0xed, 0xef, 0x8b, 0xa9, 0x79, 0xd6, 0x4a, 0xce,
+            0xa3, 0xc8, 0x27, 0xdc, 0xd5, 0x1d, 0x21, 0xed,
+            0x00, 0x00, 0x00, 0x12,
+            0x12, 0x10,
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+            0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+        ).map(Int::toByte).toByteArray()
+    }
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepository.kt
@@ -22,6 +22,7 @@ import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFindingSev
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderImpact
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderMethodOutcome
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderMethodResult
+import com.eltavine.duckdetector.features.bootloader.domain.BootloaderState
 
 internal data class WidevineBootloaderEvidence(
     val findings: List<BootloaderFinding>,
@@ -29,6 +30,23 @@ internal data class WidevineBootloaderEvidence(
     val method: BootloaderMethodResult,
     val anomalyCount: Int,
 )
+
+internal fun WidevineBootloaderEvidence.resolveBootloaderState(
+    baseState: BootloaderState,
+): BootloaderState {
+    // Preserve stronger boot failures; Widevine escalates every other state.
+    if (baseState == BootloaderState.UNLOCKED ||
+        baseState == BootloaderState.FAILED_VERIFICATION
+    ) {
+        return baseState
+    }
+    return when (method.outcome) {
+        BootloaderMethodOutcome.DANGER -> BootloaderState.UNLOCKED
+        BootloaderMethodOutcome.WARNING -> BootloaderState.UNKNOWN
+        BootloaderMethodOutcome.CLEAN,
+        BootloaderMethodOutcome.SUPPORT -> baseState
+    }
+}
 
 internal class WidevineCredentialRepository(
     private val source: WidevineCredentialSource = WidevineCredentialProbe(),

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepository.kt
@@ -22,7 +22,6 @@ import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFindingSev
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderImpact
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderMethodOutcome
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderMethodResult
-import com.eltavine.duckdetector.features.bootloader.domain.BootloaderState
 
 internal data class WidevineBootloaderEvidence(
     val findings: List<BootloaderFinding>,
@@ -30,23 +29,6 @@ internal data class WidevineBootloaderEvidence(
     val method: BootloaderMethodResult,
     val anomalyCount: Int,
 )
-
-internal fun WidevineBootloaderEvidence.resolveBootloaderState(
-    baseState: BootloaderState,
-): BootloaderState {
-    // Preserve stronger boot failures; Widevine escalates every other state.
-    if (baseState == BootloaderState.UNLOCKED ||
-        baseState == BootloaderState.FAILED_VERIFICATION
-    ) {
-        return baseState
-    }
-    return when (method.outcome) {
-        BootloaderMethodOutcome.DANGER -> BootloaderState.UNLOCKED
-        BootloaderMethodOutcome.WARNING -> BootloaderState.UNKNOWN
-        BootloaderMethodOutcome.CLEAN,
-        BootloaderMethodOutcome.SUPPORT -> baseState
-    }
-}
 
 internal class WidevineCredentialRepository(
     private val source: WidevineCredentialSource = WidevineCredentialProbe(),

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepository.kt
@@ -36,8 +36,11 @@ internal class WidevineCredentialRepository(
 ) {
 
     fun inspect(bootContext: WidevineBootContext): WidevineBootloaderEvidence {
-        val snapshot = runCatching { source.collect() }
-            .getOrDefault(WidevineCredentialSnapshot())
+        val snapshot = try {
+            source.collect()
+        } catch (_: Exception) {
+            WidevineCredentialSnapshot()
+        }
         val assessment = classifier.classify(snapshot, bootContext)
         return WidevineBootloaderEvidence(
             findings = assessment.findings.map { finding ->

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepository.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepository.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.bootloader.data.widevine
+
+import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFinding
+import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFindingGroup
+import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFindingSeverity
+import com.eltavine.duckdetector.features.bootloader.domain.BootloaderImpact
+import com.eltavine.duckdetector.features.bootloader.domain.BootloaderMethodOutcome
+import com.eltavine.duckdetector.features.bootloader.domain.BootloaderMethodResult
+
+internal data class WidevineBootloaderEvidence(
+    val findings: List<BootloaderFinding>,
+    val impacts: List<BootloaderImpact>,
+    val method: BootloaderMethodResult,
+    val anomalyCount: Int,
+)
+
+internal class WidevineCredentialRepository(
+    private val source: WidevineCredentialSource = WidevineCredentialProbe(),
+    private val classifier: WidevineCredentialClassifier = WidevineCredentialClassifier(),
+) {
+
+    fun inspect(bootContext: WidevineBootContext): WidevineBootloaderEvidence {
+        val snapshot = runCatching { source.collect() }
+            .getOrDefault(WidevineCredentialSnapshot())
+        val assessment = classifier.classify(snapshot, bootContext)
+        return WidevineBootloaderEvidence(
+            findings = assessment.findings.map { finding ->
+                BootloaderFinding(
+                    id = finding.id,
+                    label = finding.label,
+                    value = finding.value,
+                    group = BootloaderFindingGroup.CONSISTENCY,
+                    severity = finding.severity.toFindingSeverity(),
+                    detail = finding.detail,
+                )
+            },
+            impacts = assessment.impact?.let { impact ->
+                listOf(
+                    BootloaderImpact(
+                        text = impact.detail,
+                        severity = impact.severity.toFindingSeverity(),
+                    ),
+                )
+            }.orEmpty(),
+            method = BootloaderMethodResult(
+                label = "Widevine credential",
+                summary = assessment.methodSummary,
+                outcome = assessment.methodSeverity.toMethodOutcome(),
+                detail = assessment.methodDetail,
+            ),
+            anomalyCount = assessment.anomalyCount,
+        )
+    }
+
+    private fun WidevineAssessmentSeverity.toFindingSeverity(): BootloaderFindingSeverity {
+        return when (this) {
+            WidevineAssessmentSeverity.SAFE -> BootloaderFindingSeverity.SAFE
+            WidevineAssessmentSeverity.WARNING -> BootloaderFindingSeverity.WARNING
+            WidevineAssessmentSeverity.DANGER -> BootloaderFindingSeverity.DANGER
+            WidevineAssessmentSeverity.SUPPORT -> BootloaderFindingSeverity.INFO
+        }
+    }
+
+    private fun WidevineAssessmentSeverity.toMethodOutcome(): BootloaderMethodOutcome {
+        return when (this) {
+            WidevineAssessmentSeverity.SAFE -> BootloaderMethodOutcome.CLEAN
+            WidevineAssessmentSeverity.WARNING -> BootloaderMethodOutcome.WARNING
+            WidevineAssessmentSeverity.DANGER -> BootloaderMethodOutcome.DANGER
+            WidevineAssessmentSeverity.SUPPORT -> BootloaderMethodOutcome.SUPPORT
+        }
+    }
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineNativeBridge.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineNativeBridge.kt
@@ -23,8 +23,13 @@ internal fun interface WidevineNativePropertyReader {
 internal class WidevineNativeBridge : WidevineNativePropertyReader {
 
     override fun readProperties(): WidevineNativeSnapshot {
-        return runCatching { parse(nativeReadProperties()) }
-            .getOrDefault(WidevineNativeSnapshot())
+        return try {
+            parse(nativeReadProperties())
+        } catch (_: LinkageError) {
+            WidevineNativeSnapshot()
+        } catch (_: Exception) {
+            WidevineNativeSnapshot()
+        }
     }
 
     internal fun parse(raw: Array<String?>): WidevineNativeSnapshot {
@@ -34,6 +39,14 @@ internal class WidevineNativeBridge : WidevineNativePropertyReader {
 
         val securityStatus = raw[INDEX_SECURITY_STATUS].toStatusCode()
         val systemIdStatus = raw[INDEX_SYSTEM_ID_STATUS].toStatusCode()
+        if (securityStatus == MEDIA_ERROR_INVALID_OBJECT &&
+            systemIdStatus == MEDIA_ERROR_INVALID_OBJECT
+        ) {
+            return WidevineNativeSnapshot(
+                securityLevelStatusCode = securityStatus,
+                systemIdStatusCode = systemIdStatus,
+            )
+        }
         return WidevineNativeSnapshot(
             available = true,
             securityLevel = propertyRead(securityStatus, raw[INDEX_SECURITY_VALUE]),
@@ -45,12 +58,16 @@ internal class WidevineNativeBridge : WidevineNativePropertyReader {
 
     private fun propertyRead(statusCode: Int?, value: String?): WidevinePropertyRead {
         return when {
-            statusCode == MEDIA_STATUS_OK -> WidevinePropertyRead(
-                status = WidevinePropertyStatus.AVAILABLE,
-                value = value,
-            )
+            statusCode == MEDIA_STATUS_OK && value?.isValidWidevinePropertyValue() == true ->
+                WidevinePropertyRead(
+                    status = WidevinePropertyStatus.AVAILABLE,
+                    value = value,
+                )
 
-            statusCode != null -> WidevinePropertyRead(WidevinePropertyStatus.UNSUPPORTED)
+            statusCode == MEDIA_ERROR_UNSUPPORTED ||
+                statusCode == MEDIA_ERROR_INVALID_PARAMETER ->
+                WidevinePropertyRead(WidevinePropertyStatus.UNSUPPORTED)
+
             else -> WidevinePropertyRead(WidevinePropertyStatus.ERROR)
         }
     }
@@ -61,6 +78,10 @@ internal class WidevineNativeBridge : WidevineNativePropertyReader {
 
     private companion object {
         const val MEDIA_STATUS_OK = 0
+        const val MEDIA_ERROR_UNSUPPORTED = -10002
+        const val MEDIA_ERROR_INVALID_OBJECT = -10003
+        // NdkMediaDrm maps DRM_CANNOT_HANDLE (including unknown vendor properties) to this code.
+        const val MEDIA_ERROR_INVALID_PARAMETER = -10004
         const val PAYLOAD_FIELD_COUNT = 5
         const val INDEX_AVAILABLE = 0
         const val INDEX_SECURITY_STATUS = 1
@@ -69,7 +90,13 @@ internal class WidevineNativeBridge : WidevineNativePropertyReader {
         const val INDEX_SYSTEM_ID_VALUE = 4
 
         init {
-            runCatching { System.loadLibrary("duckdetector") }
+            try {
+                System.loadLibrary("duckdetector")
+            } catch (_: LinkageError) {
+                // The Java MediaDrm path remains available when the optional native path cannot load.
+            } catch (_: SecurityException) {
+                // A runtime loading policy can disable parity collection without disabling the probe.
+            }
         }
     }
 }

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineNativeBridge.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineNativeBridge.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.bootloader.data.widevine
+
+internal fun interface WidevineNativePropertyReader {
+    fun readProperties(): WidevineNativeSnapshot
+}
+
+internal class WidevineNativeBridge : WidevineNativePropertyReader {
+
+    override fun readProperties(): WidevineNativeSnapshot {
+        return runCatching { parse(nativeReadProperties()) }
+            .getOrDefault(WidevineNativeSnapshot())
+    }
+
+    internal fun parse(raw: Array<String?>): WidevineNativeSnapshot {
+        if (raw.size < PAYLOAD_FIELD_COUNT || raw[INDEX_AVAILABLE] != "1") {
+            return WidevineNativeSnapshot()
+        }
+
+        val securityStatus = raw[INDEX_SECURITY_STATUS].toStatusCode()
+        val systemIdStatus = raw[INDEX_SYSTEM_ID_STATUS].toStatusCode()
+        return WidevineNativeSnapshot(
+            available = true,
+            securityLevel = propertyRead(securityStatus, raw[INDEX_SECURITY_VALUE]),
+            systemId = propertyRead(systemIdStatus, raw[INDEX_SYSTEM_ID_VALUE]),
+            securityLevelStatusCode = securityStatus,
+            systemIdStatusCode = systemIdStatus,
+        )
+    }
+
+    private fun propertyRead(statusCode: Int?, value: String?): WidevinePropertyRead {
+        return when {
+            statusCode == MEDIA_STATUS_OK -> WidevinePropertyRead(
+                status = WidevinePropertyStatus.AVAILABLE,
+                value = value,
+            )
+
+            statusCode != null -> WidevinePropertyRead(WidevinePropertyStatus.UNSUPPORTED)
+            else -> WidevinePropertyRead(WidevinePropertyStatus.ERROR)
+        }
+    }
+
+    private fun String?.toStatusCode(): Int? = this?.toIntOrNull()
+
+    private external fun nativeReadProperties(): Array<String?>
+
+    private companion object {
+        const val MEDIA_STATUS_OK = 0
+        const val PAYLOAD_FIELD_COUNT = 5
+        const val INDEX_AVAILABLE = 0
+        const val INDEX_SECURITY_STATUS = 1
+        const val INDEX_SECURITY_VALUE = 2
+        const val INDEX_SYSTEM_ID_STATUS = 3
+        const val INDEX_SYSTEM_ID_VALUE = 4
+
+        init {
+            runCatching { System.loadLibrary("duckdetector") }
+        }
+    }
+}

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/presentation/BootloaderCardModelMapper.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/presentation/BootloaderCardModelMapper.kt
@@ -27,6 +27,7 @@ import com.eltavine.duckdetector.features.bootloader.domain.BootloaderReport
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderStage
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderState
 import com.eltavine.duckdetector.features.bootloader.ui.model.BootloaderCardModel
+import com.eltavine.duckdetector.features.bootloader.ui.model.BootloaderCardAssessment
 import com.eltavine.duckdetector.features.bootloader.ui.model.BootloaderDetailRowModel
 import com.eltavine.duckdetector.features.bootloader.ui.model.BootloaderHeaderFactModel
 import com.eltavine.duckdetector.features.bootloader.ui.model.BootloaderImpactItemModel
@@ -42,6 +43,7 @@ class BootloaderCardModelMapper {
             title = "Bootloader",
             subtitle = buildSubtitle(report),
             status = report.toDetectorStatus(),
+            assessment = report.toCardAssessment(),
             verdict = buildVerdict(report),
             summary = buildSummary(report),
             headerFacts = buildHeaderFacts(report),
@@ -138,7 +140,7 @@ class BootloaderCardModelMapper {
                 BootloaderHeaderFactModel(
                     label = "State",
                     value = stateLabel(report.state),
-                    status = report.toDetectorStatus(),
+                    status = report.authoritativeStateStatus(),
                 ),
                 BootloaderHeaderFactModel(
                     label = "Proof",
@@ -420,7 +422,7 @@ class BootloaderCardModelMapper {
     )
 
     private fun List<BootloaderFinding>.areWidevineOnly(): Boolean {
-        return isNotEmpty() && all { finding -> finding.id.startsWith("widevine_") }
+        return isNotEmpty() && all { finding -> finding.id.startsWith(WIDEVINE_FINDING_PREFIX) }
     }
 
     private fun severityStatus(severity: BootloaderFindingSeverity): DetectorStatus {
@@ -508,5 +510,38 @@ class BootloaderCardModelMapper {
                 else -> DetectorStatus.allClear()
             }
         }
+    }
+
+    private fun BootloaderReport.toCardAssessment(): BootloaderCardAssessment {
+        val widevineFindings = findings.filter { finding ->
+            finding.id.startsWith(WIDEVINE_FINDING_PREFIX)
+        }
+        return when {
+            widevineFindings.any { it.severity == BootloaderFindingSeverity.DANGER } ->
+                BootloaderCardAssessment.CONSISTENCY_CONFLICT
+
+            widevineFindings.any { it.severity == BootloaderFindingSeverity.WARNING } ->
+                BootloaderCardAssessment.CONSISTENCY_REVIEW
+
+            else -> BootloaderCardAssessment.AUTHORITATIVE
+        }
+    }
+
+    // Card severity may include Widevine; the State fact remains authoritative.
+    private fun BootloaderReport.authoritativeStateStatus(): DetectorStatus {
+        return when (state) {
+            BootloaderState.VERIFIED -> DetectorStatus.allClear()
+            BootloaderState.SELF_SIGNED,
+            BootloaderState.LOCKED_UNKNOWN -> DetectorStatus.warning()
+
+            BootloaderState.UNLOCKED,
+            BootloaderState.FAILED_VERIFICATION -> DetectorStatus.danger()
+
+            BootloaderState.UNKNOWN -> DetectorStatus.info(InfoKind.SUPPORT)
+        }
+    }
+
+    private companion object {
+        const val WIDEVINE_FINDING_PREFIX = "widevine_"
     }
 }

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/presentation/BootloaderCardModelMapper.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/presentation/BootloaderCardModelMapper.kt
@@ -76,8 +76,18 @@ class BootloaderCardModelMapper {
             BootloaderStage.LOADING -> "Scanning boot state and verified boot evidence"
             BootloaderStage.FAILED -> "Bootloader scan failed"
             BootloaderStage.READY -> when {
-                report.dangerFindings.isNotEmpty() -> "${report.dangerFindings.size} critical boot integrity signal(s)"
-                report.warningFindings.isNotEmpty() -> "${report.warningFindings.size} boot state signal(s) need review"
+                report.dangerFindings.isNotEmpty() -> if (report.dangerFindings.areWidevineOnly()) {
+                    "${report.dangerFindings.size} critical DRM consistency signal(s)"
+                } else {
+                    "${report.dangerFindings.size} critical boot integrity signal(s)"
+                }
+
+                report.warningFindings.isNotEmpty() -> if (report.warningFindings.areWidevineOnly()) {
+                    "${report.warningFindings.size} DRM consistency signal(s) need review"
+                } else {
+                    "${report.warningFindings.size} boot state signal(s) need review"
+                }
+
                 report.state == BootloaderState.VERIFIED && report.evidenceMode == BootloaderEvidenceMode.ATTESTATION ->
                     "Locked and attested verified"
 
@@ -99,10 +109,10 @@ class BootloaderCardModelMapper {
 
             BootloaderStage.READY -> when {
                 report.dangerFindings.isNotEmpty() ->
-                    "Unlocked state, attestation contradictions, broken certificate trust, verified-boot failures, or an operational Widevine L1 inconsistency indicate reduced device trust."
+                    "Unlocked state, attestation contradictions, broken certificate trust, verified-boot failures, or a corroborated Widevine DRM inconsistency indicate reduced device trust."
 
                 report.warningFindings.isNotEmpty() ->
-                    "The boot chain is not obviously broken, but custom-root, software-only, Widevine credential, or cross-source coherence signals still need review."
+                    "The boot chain is not obviously broken, but custom-root, software-only, Widevine DRM, or cross-source coherence signals still need review."
 
                 report.evidenceMode == BootloaderEvidenceMode.PROPERTIES_ONLY ->
                     "Boot properties look conservative, but the result falls back to software-readable signals because attestation RootOfTrust was unavailable."
@@ -294,7 +304,11 @@ class BootloaderCardModelMapper {
                     label = "Cross-checks",
                     value = report.consistencyFindingCount.toString(),
                     status = if (report.consistencyFindingCount > 0) {
-                        if (report.dangerFindings.any { it.group.name == "CONSISTENCY" }) DetectorStatus.danger() else DetectorStatus.warning()
+                        if (report.dangerFindings.any { it.group.name == "CONSISTENCY" }) {
+                            DetectorStatus.danger()
+                        } else {
+                            DetectorStatus.warning()
+                        }
                     } else {
                         DetectorStatus.allClear()
                     },
@@ -404,6 +418,10 @@ class BootloaderCardModelMapper {
         "Attestation chain",
         "Hardware-backed",
     )
+
+    private fun List<BootloaderFinding>.areWidevineOnly(): Boolean {
+        return isNotEmpty() && all { finding -> finding.id.startsWith("widevine_") }
+    }
 
     private fun severityStatus(severity: BootloaderFindingSeverity): DetectorStatus {
         return when (severity) {

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/presentation/BootloaderCardModelMapper.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/presentation/BootloaderCardModelMapper.kt
@@ -65,7 +65,7 @@ class BootloaderCardModelMapper {
 
     private fun buildSubtitle(report: BootloaderReport): String {
         return when (report.stage) {
-            BootloaderStage.LOADING -> "attestation + boot props + raw boot consistency"
+            BootloaderStage.LOADING -> "attestation + boot props + DRM consistency"
             BootloaderStage.FAILED -> "local bootloader scan failed"
             BootloaderStage.READY -> "${report.checkedPropertyCount} props · ${report.attestationChainLength} certs · ${report.consistencyFindingCount} cross-checks"
         }
@@ -92,17 +92,17 @@ class BootloaderCardModelMapper {
     private fun buildSummary(report: BootloaderReport): String {
         return when (report.stage) {
             BootloaderStage.LOADING ->
-                "Attestation RootOfTrust, certificate trust, boot properties, raw androidboot parameters, and source consistency checks are collecting local evidence."
+                "Attestation RootOfTrust, certificate trust, boot properties, raw androidboot parameters, and Widevine credential consistency checks are collecting local evidence."
 
             BootloaderStage.FAILED ->
                 report.errorMessage ?: "Bootloader scan failed before evidence could be assembled."
 
             BootloaderStage.READY -> when {
                 report.dangerFindings.isNotEmpty() ->
-                    "Unlocked state, attestation contradictions, broken certificate trust, or verified-boot failures indicate reduced boot-chain trust."
+                    "Unlocked state, attestation contradictions, broken certificate trust, verified-boot failures, or an operational Widevine L1 inconsistency indicate reduced device trust."
 
                 report.warningFindings.isNotEmpty() ->
-                    "The boot chain is not obviously broken, but the evidence still shows custom-root, software-only, or coherence signals worth reviewing."
+                    "The boot chain is not obviously broken, but custom-root, software-only, Widevine credential, or cross-source coherence signals still need review."
 
                 report.evidenceMode == BootloaderEvidenceMode.PROPERTIES_ONLY ->
                     "Boot properties look conservative, but the result falls back to software-readable signals because attestation RootOfTrust was unavailable."
@@ -375,7 +375,9 @@ class BootloaderCardModelMapper {
     private fun consistencyPlaceholders(): List<String> = listOf(
         "Attested hash vs vbmeta digest",
         "Verified boot coherence",
-        "Property source mismatch"
+        "Property source mismatch",
+        "Widevine credential",
+        "Widevine Java/native parity",
     )
 
     private fun methodPlaceholders(): List<String> = listOf(
@@ -389,6 +391,7 @@ class BootloaderCardModelMapper {
         "Raw boot params",
         "Source consistency",
         "Cross-check rules",
+        "Widevine credential",
     )
 
     private fun scanPlaceholders(): List<String> = listOf(

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/ui/card/BootloaderDetectorCard.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/ui/card/BootloaderDetectorCard.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.automirrored.rounded.FactCheck
 import androidx.compose.material.icons.rounded.CrisisAlert
 import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.Key
+import androidx.compose.material.icons.rounded.QuestionMark
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.VerifiedUser
@@ -38,12 +39,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.eltavine.duckdetector.R
 import com.eltavine.duckdetector.core.ui.components.DetectorCardFrame
 import com.eltavine.duckdetector.core.ui.components.DetectorDetailRowBlock
 import com.eltavine.duckdetector.core.ui.components.DetectorSectionFrame
 import com.eltavine.duckdetector.core.ui.components.WrapSafeText
 import com.eltavine.duckdetector.core.ui.presentation.rememberStatusAppearance
+import com.eltavine.duckdetector.features.bootloader.ui.model.BootloaderCardAssessment
 import com.eltavine.duckdetector.features.bootloader.ui.model.BootloaderCardModel
 import com.eltavine.duckdetector.features.bootloader.ui.model.BootloaderDetailRowModel
 import com.eltavine.duckdetector.features.bootloader.ui.model.BootloaderHeaderFactModel
@@ -55,6 +59,14 @@ fun BootloaderDetectorCard(
     model: BootloaderCardModel,
     modifier: Modifier = Modifier,
 ) {
+    val consistencyDescription = when (model.assessment) {
+        BootloaderCardAssessment.AUTHORITATIVE -> null
+        BootloaderCardAssessment.CONSISTENCY_REVIEW ->
+            stringResource(R.string.bootloader_widevine_consistency_review)
+
+        BootloaderCardAssessment.CONSISTENCY_CONFLICT ->
+            stringResource(R.string.bootloader_widevine_consistency_conflict)
+    }
     DetectorCardFrame(
         title = model.title,
         subtitle = model.subtitle,
@@ -62,6 +74,13 @@ fun BootloaderDetectorCard(
         verdict = model.verdict,
         summary = model.summary,
         leadingIcon = Icons.Rounded.VerifiedUser,
+        leadingBadgeIcon = if (model.showConsistencyQuestionIcon) {
+            Icons.Rounded.QuestionMark
+        } else {
+            null
+        },
+        leadingBadgeStatus = model.assessmentStatus,
+        leadingBadgeContentDescription = consistencyDescription,
         modifier = modifier,
         headerFacts = {
             BootloaderCollapsedOverview(model = model)

--- a/app/src/main/java/com/eltavine/duckdetector/features/bootloader/ui/model/BootloaderCardModel.kt
+++ b/app/src/main/java/com/eltavine/duckdetector/features/bootloader/ui/model/BootloaderCardModel.kt
@@ -18,10 +18,17 @@ package com.eltavine.duckdetector.features.bootloader.ui.model
 
 import com.eltavine.duckdetector.core.ui.model.DetectorStatus
 
+enum class BootloaderCardAssessment {
+    AUTHORITATIVE,
+    CONSISTENCY_REVIEW,
+    CONSISTENCY_CONFLICT,
+}
+
 data class BootloaderCardModel(
     val title: String,
     val subtitle: String,
     val status: DetectorStatus,
+    val assessment: BootloaderCardAssessment,
     val verdict: String,
     val summary: String,
     val headerFacts: List<BootloaderHeaderFactModel>,
@@ -32,7 +39,17 @@ data class BootloaderCardModel(
     val impactItems: List<BootloaderImpactItemModel>,
     val methodRows: List<BootloaderDetailRowModel>,
     val scanRows: List<BootloaderDetailRowModel>,
-)
+) {
+    val showConsistencyQuestionIcon: Boolean
+        get() = assessment != BootloaderCardAssessment.AUTHORITATIVE
+
+    val assessmentStatus: DetectorStatus?
+        get() = when (assessment) {
+            BootloaderCardAssessment.AUTHORITATIVE -> null
+            BootloaderCardAssessment.CONSISTENCY_REVIEW -> DetectorStatus.warning()
+            BootloaderCardAssessment.CONSISTENCY_CONFLICT -> DetectorStatus.danger()
+        }
+}
 
 data class BootloaderHeaderFactModel(
     val label: String,

--- a/app/src/main/res/values/mainscreen_strings.xml
+++ b/app/src/main/res/values/mainscreen_strings.xml
@@ -29,6 +29,8 @@ limitations under the License.
     <string name="dashboard_additional">Additional</string>
     <string name="dashboard_detectors">Detectors</string>
     <string name="card_expand">Expand card</string>
+    <string name="bootloader_widevine_consistency_review">Widevine consistency needs review</string>
+    <string name="bootloader_widevine_consistency_conflict">Critical Widevine consistency conflict</string>
     <string name="card_collapse">Collapse card</string>
     <string name="card_action_view_details">View details</string>
     <string name="card_action_review_evidence">Review evidence</string>

--- a/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialClassifierTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialClassifierTest.kt
@@ -17,6 +17,8 @@
 package com.eltavine.duckdetector.features.bootloader.data.widevine
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class WidevineCredentialClassifierTest {
@@ -57,7 +59,17 @@ class WidevineCredentialClassifierTest {
     }
 
     @Test
-    fun `sentinel system id without advertised L1 does not trigger sentinel rule`() {
+    fun `sentinel comparison does not accept padded property values`() {
+        val assessment = classifier.classify(
+            snapshot(systemId = " $WIDEVINE_SENTINEL_SYSTEM_ID "),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.SAFE, assessment.credential().severity)
+    }
+
+    @Test
+    fun `sentinel system id without advertised L1 is partial`() {
         val assessment = classifier.classify(
             snapshot(
                 systemId = WIDEVINE_SENTINEL_SYSTEM_ID,
@@ -67,11 +79,12 @@ class WidevineCredentialClassifierTest {
             lockedContext,
         )
 
-        assertEquals(WidevineAssessmentSeverity.SAFE, assessment.credential().severity)
+        assertEquals(WidevineAssessmentSeverity.SUPPORT, assessment.credential().severity)
+        assertEquals("Partial", assessment.credential().value)
     }
 
     @Test
-    fun `sentinel with independently confirmed unlock is danger`() {
+    fun `independent RootOfTrust unlock does not escalate sentinel`() {
         val assessment = classifier.classify(
             snapshot(systemId = WIDEVINE_SENTINEL_SYSTEM_ID),
             WidevineBootContext(
@@ -80,8 +93,10 @@ class WidevineCredentialClassifierTest {
             ),
         )
 
-        assertEquals(WidevineAssessmentSeverity.DANGER, assessment.credential().severity)
-        assertEquals("Unlock impact confirmed", assessment.credential().value)
+        assertEquals(WidevineAssessmentSeverity.WARNING, assessment.credential().severity)
+        assertEquals("Sentinel system ID", assessment.credential().value)
+        assertTrue(assessment.credential().detail.contains("independent RootOfTrust state is unlocked"))
+        assertFalse(assessment.impact?.detail.orEmpty().contains("confirms", ignoreCase = true))
     }
 
     @Test
@@ -95,11 +110,11 @@ class WidevineCredentialClassifierTest {
         )
 
         assertEquals(WidevineAssessmentSeverity.DANGER, assessment.credential().severity)
-        assertEquals("Session downgrade", assessment.credential().value)
+        assertEquals("Corroborated anomaly", assessment.credential().value)
     }
 
     @Test
-    fun `L1 session downgrade is danger without sentinel`() {
+    fun `L1 lower session is warning without sentinel`() {
         val assessment = classifier.classify(
             snapshot(
                 systemId = "38497",
@@ -108,11 +123,86 @@ class WidevineCredentialClassifierTest {
             lockedContext,
         )
 
-        assertEquals(WidevineAssessmentSeverity.DANGER, assessment.credential().severity)
+        assertEquals(WidevineAssessmentSeverity.WARNING, assessment.credential().severity)
+        assertEquals("Lower security session", assessment.credential().value)
     }
 
     @Test
-    fun `non transient L1 hardware session failure is danger`() {
+    fun `L1 lower session remains warning when system id is unavailable`() {
+        val assessment = classifier.classify(
+            snapshot(
+                systemId = "38497",
+                actualLevel = WidevineSessionSecurityLevel.HW_SECURE_DECODE,
+            ).copy(
+                javaSystemId = WidevinePropertyRead(WidevinePropertyStatus.UNSUPPORTED),
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.WARNING, assessment.credential().severity)
+        assertEquals("Lower security session", assessment.credential().value)
+    }
+
+    @Test
+    fun `documented lower maximum session is support when HW secure all is unsupported`() {
+        val assessment = classifier.classify(
+            snapshot(
+                systemId = "38497",
+                hardwareSecureAllSupported = false,
+                actualLevel = WidevineSessionSecurityLevel.HW_SECURE_DECODE,
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.SUPPORT, assessment.credential().severity)
+        assertEquals("Maximum security constrained", assessment.credential().value)
+    }
+
+    @Test
+    fun `documented lower maximum session does not escalate sentinel`() {
+        val assessment = classifier.classify(
+            snapshot(
+                systemId = WIDEVINE_SENTINEL_SYSTEM_ID,
+                hardwareSecureAllSupported = false,
+                actualLevel = WidevineSessionSecurityLevel.SW_SECURE_CRYPTO,
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.WARNING, assessment.credential().severity)
+        assertEquals("Sentinel system ID", assessment.credential().value)
+    }
+
+    @Test
+    fun `unknown advertised security level is partial rather than clean`() {
+        val assessment = classifier.classify(
+            snapshot(
+                systemId = "38497",
+                securityLevel = "vendor-defined",
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.SUPPORT, assessment.credential().severity)
+        assertEquals("Partial", assessment.credential().value)
+    }
+
+    @Test
+    fun `unknown actual session level is partial rather than a confirmed downgrade`() {
+        val assessment = classifier.classify(
+            snapshot(
+                systemId = "38497",
+                actualLevel = WidevineSessionSecurityLevel.UNKNOWN,
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.SUPPORT, assessment.credential().severity)
+        assertEquals("Partial", assessment.credential().value)
+    }
+
+    @Test
+    fun `non transient L1 hardware session failure is support only`() {
         val assessment = classifier.classify(
             snapshot(
                 systemId = "38497",
@@ -123,12 +213,12 @@ class WidevineCredentialClassifierTest {
             lockedContext,
         )
 
-        assertEquals(WidevineAssessmentSeverity.DANGER, assessment.credential().severity)
-        assertEquals("Hardware session failed", assessment.credential().value)
+        assertEquals(WidevineAssessmentSeverity.SUPPORT, assessment.credential().severity)
+        assertEquals("Session inconclusive", assessment.credential().value)
     }
 
     @Test
-    fun `sentinel with provisioning failure is danger`() {
+    fun `provisioning failure does not escalate sentinel`() {
         val assessment = classifier.classify(
             snapshot(
                 systemId = WIDEVINE_SENTINEL_SYSTEM_ID,
@@ -138,12 +228,12 @@ class WidevineCredentialClassifierTest {
             lockedContext,
         )
 
-        assertEquals(WidevineAssessmentSeverity.DANGER, assessment.credential().severity)
-        assertEquals("Invalid credential", assessment.credential().value)
+        assertEquals(WidevineAssessmentSeverity.WARNING, assessment.credential().severity)
+        assertEquals("Sentinel system ID", assessment.credential().value)
     }
 
     @Test
-    fun `sentinel with non transient local key request failure is danger`() {
+    fun `local key request failure does not escalate sentinel`() {
         val assessment = classifier.classify(
             snapshot(
                 systemId = WIDEVINE_SENTINEL_SYSTEM_ID,
@@ -152,8 +242,8 @@ class WidevineCredentialClassifierTest {
             lockedContext,
         )
 
-        assertEquals(WidevineAssessmentSeverity.DANGER, assessment.credential().severity)
-        assertEquals("Invalid credential", assessment.credential().value)
+        assertEquals(WidevineAssessmentSeverity.WARNING, assessment.credential().severity)
+        assertEquals("Sentinel system ID", assessment.credential().value)
     }
 
     @Test
@@ -169,7 +259,23 @@ class WidevineCredentialClassifierTest {
         )
 
         assertEquals(WidevineAssessmentSeverity.SUPPORT, assessment.credential().severity)
-        assertEquals("Inconclusive", assessment.credential().value)
+        assertEquals("Session inconclusive", assessment.credential().value)
+    }
+
+    @Test
+    fun `unsupported maximum security session is support only`() {
+        val assessment = classifier.classify(
+            snapshot(
+                systemId = "38497",
+                sessionStatus = WidevineOperationStatus.UNSUPPORTED,
+                actualLevel = null,
+                keyRequestStatus = WidevineOperationStatus.NOT_ATTEMPTED,
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.SUPPORT, assessment.credential().severity)
+        assertEquals("Session inconclusive", assessment.credential().value)
     }
 
     @Test
@@ -201,6 +307,21 @@ class WidevineCredentialClassifierTest {
     }
 
     @Test
+    fun `Java and native property formatting difference is warning`() {
+        val assessment = classifier.classify(
+            snapshot(systemId = "38497").copy(
+                native = snapshot(systemId = "38497").native.copy(
+                    securityLevel = property("l1"),
+                ),
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.WARNING, assessment.parity().severity)
+        assertEquals("Mismatch", assessment.parity().value)
+    }
+
+    @Test
     fun `native unavailability only reduces coverage`() {
         val assessment = classifier.classify(
             snapshot(systemId = "38497").copy(native = WidevineNativeSnapshot()),
@@ -215,6 +336,7 @@ class WidevineCredentialClassifierTest {
         systemId: String,
         securityLevel: String = "L1",
         nativeSystemId: String = systemId,
+        hardwareSecureAllSupported: Boolean? = true,
         sessionStatus: WidevineOperationStatus = WidevineOperationStatus.SUCCESS,
         actualLevel: WidevineSessionSecurityLevel? = WidevineSessionSecurityLevel.HW_SECURE_ALL,
         credentialStatus: WidevineOperationStatus = WidevineOperationStatus.SUCCESS,
@@ -223,6 +345,7 @@ class WidevineCredentialClassifierTest {
     ): WidevineCredentialSnapshot {
         return WidevineCredentialSnapshot(
             schemeSupported = true,
+            hardwareSecureAllSupported = hardwareSecureAllSupported,
             javaSecurityLevel = property(securityLevel),
             javaSystemId = property(systemId),
             native = WidevineNativeSnapshot(

--- a/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialClassifierTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialClassifierTest.kt
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.bootloader.data.widevine
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WidevineCredentialClassifierTest {
+
+    private val classifier = WidevineCredentialClassifier()
+    private val lockedContext = WidevineBootContext(
+        rootOfTrustUnlocked = false,
+        bootStateAppearsLocked = true,
+    )
+
+    @Test
+    fun `normal system id and working hardware session are clean`() {
+        val assessment = classifier.classify(snapshot(systemId = "38497"), lockedContext)
+
+        assertEquals(WidevineAssessmentSeverity.SAFE, assessment.credential().severity)
+        assertEquals("Consistent", assessment.credential().value)
+    }
+
+    @Test
+    fun `unrelated ten digit system id does not match sentinel`() {
+        val assessment = classifier.classify(
+            snapshot(systemId = "1234567890"),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.SAFE, assessment.credential().severity)
+    }
+
+    @Test
+    fun `exact sentinel on locked looking boot state is warning`() {
+        val assessment = classifier.classify(
+            snapshot(systemId = WIDEVINE_SENTINEL_SYSTEM_ID),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.WARNING, assessment.credential().severity)
+        assertEquals("Sentinel system ID", assessment.credential().value)
+    }
+
+    @Test
+    fun `sentinel system id without advertised L1 does not trigger sentinel rule`() {
+        val assessment = classifier.classify(
+            snapshot(
+                systemId = WIDEVINE_SENTINEL_SYSTEM_ID,
+                securityLevel = "L3",
+                actualLevel = WidevineSessionSecurityLevel.SW_SECURE_CRYPTO,
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.SAFE, assessment.credential().severity)
+    }
+
+    @Test
+    fun `sentinel with independently confirmed unlock is danger`() {
+        val assessment = classifier.classify(
+            snapshot(systemId = WIDEVINE_SENTINEL_SYSTEM_ID),
+            WidevineBootContext(
+                rootOfTrustUnlocked = true,
+                bootStateAppearsLocked = false,
+            ),
+        )
+
+        assertEquals(WidevineAssessmentSeverity.DANGER, assessment.credential().severity)
+        assertEquals("Unlock impact confirmed", assessment.credential().value)
+    }
+
+    @Test
+    fun `sentinel with downgraded session is danger`() {
+        val assessment = classifier.classify(
+            snapshot(
+                systemId = WIDEVINE_SENTINEL_SYSTEM_ID,
+                actualLevel = WidevineSessionSecurityLevel.SW_SECURE_CRYPTO,
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.DANGER, assessment.credential().severity)
+        assertEquals("Session downgrade", assessment.credential().value)
+    }
+
+    @Test
+    fun `L1 session downgrade is danger without sentinel`() {
+        val assessment = classifier.classify(
+            snapshot(
+                systemId = "38497",
+                actualLevel = WidevineSessionSecurityLevel.HW_SECURE_DECODE,
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.DANGER, assessment.credential().severity)
+    }
+
+    @Test
+    fun `non transient L1 hardware session failure is danger`() {
+        val assessment = classifier.classify(
+            snapshot(
+                systemId = "38497",
+                sessionStatus = WidevineOperationStatus.FAILURE,
+                actualLevel = null,
+                keyRequestStatus = WidevineOperationStatus.NOT_ATTEMPTED,
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.DANGER, assessment.credential().severity)
+        assertEquals("Hardware session failed", assessment.credential().value)
+    }
+
+    @Test
+    fun `sentinel with provisioning failure is danger`() {
+        val assessment = classifier.classify(
+            snapshot(
+                systemId = WIDEVINE_SENTINEL_SYSTEM_ID,
+                credentialStatus = WidevineOperationStatus.NOT_PROVISIONED,
+                credentialAvailable = null,
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.DANGER, assessment.credential().severity)
+        assertEquals("Invalid credential", assessment.credential().value)
+    }
+
+    @Test
+    fun `sentinel with non transient local key request failure is danger`() {
+        val assessment = classifier.classify(
+            snapshot(
+                systemId = WIDEVINE_SENTINEL_SYSTEM_ID,
+                keyRequestStatus = WidevineOperationStatus.FAILURE,
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.DANGER, assessment.credential().severity)
+        assertEquals("Invalid credential", assessment.credential().value)
+    }
+
+    @Test
+    fun `resource busy hardware session is support only`() {
+        val assessment = classifier.classify(
+            snapshot(
+                systemId = "38497",
+                sessionStatus = WidevineOperationStatus.RESOURCE_BUSY,
+                actualLevel = null,
+                keyRequestStatus = WidevineOperationStatus.NOT_ATTEMPTED,
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.SUPPORT, assessment.credential().severity)
+        assertEquals("Inconclusive", assessment.credential().value)
+    }
+
+    @Test
+    fun `missing credential without sentinel is partial rather than clean or danger`() {
+        val assessment = classifier.classify(
+            snapshot(
+                systemId = "38497",
+                credentialAvailable = false,
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.SUPPORT, assessment.credential().severity)
+        assertEquals("Partial", assessment.credential().value)
+    }
+
+    @Test
+    fun `Java and native system id mismatch is warning`() {
+        val assessment = classifier.classify(
+            snapshot(
+                systemId = "38497",
+                nativeSystemId = WIDEVINE_SENTINEL_SYSTEM_ID,
+            ),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.WARNING, assessment.parity().severity)
+        assertEquals("Mismatch", assessment.parity().value)
+    }
+
+    @Test
+    fun `native unavailability only reduces coverage`() {
+        val assessment = classifier.classify(
+            snapshot(systemId = "38497").copy(native = WidevineNativeSnapshot()),
+            lockedContext,
+        )
+
+        assertEquals(WidevineAssessmentSeverity.SUPPORT, assessment.parity().severity)
+        assertEquals("Native unavailable", assessment.parity().value)
+    }
+
+    private fun snapshot(
+        systemId: String,
+        securityLevel: String = "L1",
+        nativeSystemId: String = systemId,
+        sessionStatus: WidevineOperationStatus = WidevineOperationStatus.SUCCESS,
+        actualLevel: WidevineSessionSecurityLevel? = WidevineSessionSecurityLevel.HW_SECURE_ALL,
+        credentialStatus: WidevineOperationStatus = WidevineOperationStatus.SUCCESS,
+        credentialAvailable: Boolean? = true,
+        keyRequestStatus: WidevineOperationStatus = WidevineOperationStatus.SUCCESS,
+    ): WidevineCredentialSnapshot {
+        return WidevineCredentialSnapshot(
+            schemeSupported = true,
+            javaSecurityLevel = property(securityLevel),
+            javaSystemId = property(systemId),
+            native = WidevineNativeSnapshot(
+                available = true,
+                securityLevel = property(securityLevel),
+                systemId = property(nativeSystemId),
+                securityLevelStatusCode = 0,
+                systemIdStatusCode = 0,
+            ),
+            sessionStatus = sessionStatus,
+            actualSessionSecurityLevel = actualLevel,
+            credentialStatus = credentialStatus,
+            credentialAvailable = credentialAvailable,
+            keyRequestStatus = keyRequestStatus,
+        )
+    }
+
+    private fun property(value: String): WidevinePropertyRead {
+        return WidevinePropertyRead(WidevinePropertyStatus.AVAILABLE, value)
+    }
+
+    private fun WidevineCredentialAssessment.credential(): WidevineAssessmentFinding {
+        return findings.single { it.id == "widevine_credential" }
+    }
+
+    private fun WidevineCredentialAssessment.parity(): WidevineAssessmentFinding {
+        return findings.single { it.id == "widevine_property_parity" }
+    }
+}

--- a/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialProbeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialProbeTest.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.bootloader.data.widevine
+
+import android.media.NotProvisionedException
+import android.media.ResourceBusyException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WidevineCredentialProbeTest {
+
+    @Test
+    fun `successful probe closes session and MediaDrm without retaining opaque data`() {
+        val client = FakeMediaDrmClient()
+        val probe = probe(client)
+
+        val snapshot = probe.collect()
+
+        assertEquals(WidevineOperationStatus.SUCCESS, snapshot.sessionStatus)
+        assertEquals(WidevineSessionSecurityLevel.HW_SECURE_ALL, snapshot.actualSessionSecurityLevel)
+        assertEquals(WidevineOperationStatus.SUCCESS, snapshot.credentialStatus)
+        assertEquals(true, snapshot.credentialAvailable)
+        assertEquals(WidevineOperationStatus.SUCCESS, snapshot.keyRequestStatus)
+        assertTrue(client.deviceUniqueIdChecked)
+        assertTrue(client.keyRequestGenerated)
+        assertTrue(client.sessionClosed)
+        assertTrue(client.closed)
+        assertFalse(
+            WidevineCredentialSnapshot::class.java.declaredFields.any { field ->
+                field.name.contains("uniqueId", ignoreCase = true) ||
+                    field.name.contains("requestData", ignoreCase = true)
+            },
+        )
+    }
+
+    @Test
+    fun `resource busy session is inconclusive and MediaDrm is still closed`() {
+        val client = FakeMediaDrmClient(
+            openError = ResourceBusyException("busy"),
+        )
+
+        val snapshot = probe(client).collect()
+
+        assertEquals(WidevineOperationStatus.RESOURCE_BUSY, snapshot.sessionStatus)
+        assertFalse(client.sessionClosed)
+        assertTrue(client.closed)
+        assertEquals(WidevineDrmErrorKind.RESOURCE_BUSY, snapshot.errors.single().kind)
+    }
+
+    @Test
+    fun `key request provisioning failure is classified without retaining message`() {
+        val client = FakeMediaDrmClient(
+            keyRequestError = NotProvisionedException("sensitive vendor text"),
+        )
+
+        val snapshot = probe(client).collect()
+
+        assertEquals(WidevineOperationStatus.NOT_PROVISIONED, snapshot.keyRequestStatus)
+        assertEquals(WidevineDrmErrorKind.NOT_PROVISIONED, snapshot.errors.single().kind)
+        assertFalse(snapshot.toString().contains("sensitive vendor text"))
+        assertTrue(client.sessionClosed)
+        assertTrue(client.closed)
+    }
+
+    @Test
+    fun `unknown private properties are support state rather than failure verdict`() {
+        val client = FakeMediaDrmClient(propertyError = IllegalArgumentException("unknown"))
+
+        val snapshot = probe(client).collect()
+
+        assertEquals(WidevinePropertyStatus.UNSUPPORTED, snapshot.javaSecurityLevel.status)
+        assertEquals(WidevinePropertyStatus.UNSUPPORTED, snapshot.javaSystemId.status)
+        assertEquals(2, snapshot.errors.count {
+            it.kind == WidevineDrmErrorKind.UNSUPPORTED_PROPERTY
+        })
+        assertTrue(client.closed)
+    }
+
+    @Test
+    fun `unsupported scheme skips Java and native collection`() {
+        var nativeRead = false
+        val probe = WidevineCredentialProbe(
+            mediaDrmFactory = object : WidevineMediaDrmFactory {
+                override fun isCryptoSchemeSupported(): Boolean = false
+
+                override fun create(): WidevineMediaDrmClient {
+                    throw AssertionError("create must not be called")
+                }
+            },
+            nativePropertyReader = WidevineNativePropertyReader {
+                nativeRead = true
+                WidevineNativeSnapshot()
+            },
+        )
+
+        val snapshot = probe.collect()
+
+        assertEquals(false, snapshot.schemeSupported)
+        assertFalse(nativeRead)
+    }
+
+    private fun probe(client: FakeMediaDrmClient): WidevineCredentialProbe {
+        return WidevineCredentialProbe(
+            mediaDrmFactory = object : WidevineMediaDrmFactory {
+                override fun isCryptoSchemeSupported(): Boolean = true
+
+                override fun create(): WidevineMediaDrmClient = client
+            },
+            nativePropertyReader = WidevineNativePropertyReader {
+                WidevineNativeSnapshot(
+                    available = true,
+                    securityLevel = WidevinePropertyRead(
+                        WidevinePropertyStatus.AVAILABLE,
+                        "L1",
+                    ),
+                    systemId = WidevinePropertyRead(
+                        WidevinePropertyStatus.AVAILABLE,
+                        "38497",
+                    ),
+                    securityLevelStatusCode = 0,
+                    systemIdStatusCode = 0,
+                )
+            },
+        )
+    }
+
+    private class FakeMediaDrmClient(
+        private val openError: Throwable? = null,
+        private val keyRequestError: Throwable? = null,
+        private val propertyError: Throwable? = null,
+    ) : WidevineMediaDrmClient {
+        var deviceUniqueIdChecked = false
+        var keyRequestGenerated = false
+        var sessionClosed = false
+        var closed = false
+
+        override fun getPropertyString(name: String): String {
+            propertyError?.let { throw it }
+            return when (name) {
+                "securityLevel" -> "L1"
+                "systemId" -> "38497"
+                else -> error("unexpected property")
+            }
+        }
+
+        override fun openHardwareSecureAllSession(): ByteArray {
+            openError?.let { throw it }
+            return byteArrayOf(1, 2, 3)
+        }
+
+        override fun getSecurityLevel(sessionId: ByteArray): WidevineSessionSecurityLevel {
+            return WidevineSessionSecurityLevel.HW_SECURE_ALL
+        }
+
+        override fun hasDeviceUniqueId(): Boolean {
+            deviceUniqueIdChecked = true
+            return true
+        }
+
+        override fun generateTestKeyRequest(sessionId: ByteArray) {
+            keyRequestGenerated = true
+            keyRequestError?.let { throw it }
+        }
+
+        override fun closeSession(sessionId: ByteArray) {
+            sessionClosed = true
+        }
+
+        override fun close() {
+            closed = true
+        }
+    }
+}

--- a/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialProbeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialProbeTest.kt
@@ -16,6 +16,7 @@
 
 package com.eltavine.duckdetector.features.bootloader.data.widevine
 
+import android.media.MediaDrm.SessionException
 import android.media.NotProvisionedException
 import android.media.ResourceBusyException
 import org.junit.Assert.assertEquals
@@ -32,6 +33,7 @@ class WidevineCredentialProbeTest {
 
         val snapshot = probe.collect()
 
+        assertEquals(true, snapshot.hardwareSecureAllSupported)
         assertEquals(WidevineOperationStatus.SUCCESS, snapshot.sessionStatus)
         assertEquals(WidevineSessionSecurityLevel.HW_SECURE_ALL, snapshot.actualSessionSecurityLevel)
         assertEquals(WidevineOperationStatus.SUCCESS, snapshot.credentialStatus)
@@ -41,6 +43,7 @@ class WidevineCredentialProbeTest {
         assertTrue(client.keyRequestGenerated)
         assertTrue(client.sessionClosed)
         assertTrue(client.closed)
+        assertTrue(client.openedSession?.all { it == 0.toByte() } == true)
         assertFalse(
             WidevineCredentialSnapshot::class.java.declaredFields.any { field ->
                 field.name.contains("uniqueId", ignoreCase = true) ||
@@ -64,6 +67,34 @@ class WidevineCredentialProbeTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
+    fun `session exception resource contention is transient and sanitized`() {
+        val client = FakeMediaDrmClient(
+            openError = SessionException(
+                SessionException.ERROR_RESOURCE_CONTENTION,
+                "sensitive vendor text",
+            ),
+        )
+
+        val snapshot = probe(
+            client = client,
+            errorMetadataReader = WidevineDrmErrorMetadataReader {
+                WidevineDrmErrorMetadata(
+                    errorCode = SessionException.ERROR_RESOURCE_CONTENTION,
+                    transient = true,
+                )
+            },
+        ).collect()
+
+        assertEquals(WidevineOperationStatus.RESOURCE_BUSY, snapshot.sessionStatus)
+        assertEquals(WidevineDrmErrorKind.RESOURCE_BUSY, snapshot.errors.single().kind)
+        assertEquals(SessionException.ERROR_RESOURCE_CONTENTION, snapshot.errors.single().errorCode)
+        assertEquals(true, snapshot.errors.single().transient)
+        assertFalse(snapshot.toString().contains("sensitive vendor text"))
+        assertTrue(client.closed)
+    }
+
+    @Test
     fun `key request provisioning failure is classified without retaining message`() {
         val client = FakeMediaDrmClient(
             keyRequestError = NotProvisionedException("sensitive vendor text"),
@@ -76,6 +107,40 @@ class WidevineCredentialProbeTest {
         assertFalse(snapshot.toString().contains("sensitive vendor text"))
         assertTrue(client.sessionClosed)
         assertTrue(client.closed)
+    }
+
+    @Test
+    fun `session close failure is sanitized and does not skip MediaDrm release`() {
+        val client = FakeMediaDrmClient(
+            closeSessionError = IllegalStateException("sensitive close text"),
+        )
+
+        val snapshot = probe(client).collect()
+
+        assertTrue(client.sessionCloseAttempted)
+        assertTrue(client.closed)
+        assertTrue(client.openedSession?.all { it == 0.toByte() } == true)
+        assertEquals(WidevineDrmErrorStage.SESSION_CLOSE, snapshot.errors.single().stage)
+        assertEquals(WidevineDrmErrorKind.RUNTIME, snapshot.errors.single().kind)
+        assertFalse(snapshot.toString().contains("sensitive close text"))
+    }
+
+    @Test
+    fun `fatal session close error still attempts MediaDrm release and propagates`() {
+        val client = FakeMediaDrmClient(
+            closeSessionError = AssertionError("fatal close"),
+        )
+
+        try {
+            probe(client).collect()
+            throw AssertionError("Expected close error to propagate")
+        } catch (error: AssertionError) {
+            assertEquals("fatal close", error.message)
+        }
+
+        assertTrue(client.sessionCloseAttempted)
+        assertTrue(client.closed)
+        assertTrue(client.openedSession?.all { it == 0.toByte() } == true)
     }
 
     @Test
@@ -93,11 +158,32 @@ class WidevineCredentialProbeTest {
     }
 
     @Test
+    fun `oversized private property is rejected without retaining its value`() {
+        val oversizedValue = "x".repeat(MAX_WIDEVINE_PROPERTY_VALUE_LENGTH + 1)
+        val client = FakeMediaDrmClient(systemIdValue = oversizedValue)
+
+        val snapshot = probe(client).collect()
+
+        assertEquals(WidevinePropertyStatus.ERROR, snapshot.javaSystemId.status)
+        assertEquals(null, snapshot.javaSystemId.value)
+        assertTrue(snapshot.errors.any { error ->
+            error.stage == WidevineDrmErrorStage.JAVA_SYSTEM_ID &&
+                error.kind == WidevineDrmErrorKind.INVALID_PROPERTY_VALUE
+        })
+        assertFalse(snapshot.toString().contains(oversizedValue))
+        assertTrue(client.closed)
+    }
+
+    @Test
     fun `unsupported scheme skips Java and native collection`() {
         var nativeRead = false
         val probe = WidevineCredentialProbe(
             mediaDrmFactory = object : WidevineMediaDrmFactory {
                 override fun isCryptoSchemeSupported(): Boolean = false
+
+                override fun isHardwareSecureAllSupported(): Boolean {
+                    throw AssertionError("capability check must not be called")
+                }
 
                 override fun create(): WidevineMediaDrmClient {
                     throw AssertionError("create must not be called")
@@ -115,10 +201,56 @@ class WidevineCredentialProbeTest {
         assertFalse(nativeRead)
     }
 
-    private fun probe(client: FakeMediaDrmClient): WidevineCredentialProbe {
+    @Test
+    fun `capability check failure is sanitized without aborting collection`() {
+        val client = FakeMediaDrmClient()
+
+        val snapshot = probe(
+            client = client,
+            capabilityError = IllegalStateException("sensitive capability text"),
+        ).collect()
+
+        assertEquals(null, snapshot.hardwareSecureAllSupported)
+        assertEquals(WidevineOperationStatus.SUCCESS, snapshot.sessionStatus)
+        assertTrue(snapshot.errors.any { error ->
+            error.stage == WidevineDrmErrorStage.SESSION_CAPABILITY
+        })
+        assertFalse(snapshot.toString().contains("sensitive capability text"))
+        assertTrue(client.sessionClosed)
+        assertTrue(client.closed)
+    }
+
+    @Test
+    fun `empty session id is rejected and never used`() {
+        val client = FakeMediaDrmClient(emptySessionId = true)
+
+        val snapshot = probe(client).collect()
+
+        assertEquals(WidevineOperationStatus.FAILURE, snapshot.sessionStatus)
+        assertEquals(null, snapshot.actualSessionSecurityLevel)
+        assertEquals(WidevineOperationStatus.NOT_ATTEMPTED, snapshot.keyRequestStatus)
+        assertFalse(client.sessionCloseAttempted)
+        assertTrue(snapshot.errors.any { error ->
+            error.stage == WidevineDrmErrorStage.SESSION_OPEN &&
+                error.kind == WidevineDrmErrorKind.INVALID_SESSION_ID
+        })
+        assertTrue(client.closed)
+    }
+
+    private fun probe(
+        client: FakeMediaDrmClient,
+        errorMetadataReader: WidevineDrmErrorMetadataReader? = null,
+        hardwareSecureAllSupported: Boolean = true,
+        capabilityError: Exception? = null,
+    ): WidevineCredentialProbe {
         return WidevineCredentialProbe(
             mediaDrmFactory = object : WidevineMediaDrmFactory {
                 override fun isCryptoSchemeSupported(): Boolean = true
+
+                override fun isHardwareSecureAllSupported(): Boolean {
+                    capabilityError?.let { throw it }
+                    return hardwareSecureAllSupported
+                }
 
                 override fun create(): WidevineMediaDrmClient = client
             },
@@ -137,6 +269,9 @@ class WidevineCredentialProbeTest {
                     systemIdStatusCode = 0,
                 )
             },
+            errorMetadataReader = errorMetadataReader ?: WidevineDrmErrorMetadataReader {
+                WidevineDrmErrorMetadata()
+            },
         )
     }
 
@@ -144,24 +279,34 @@ class WidevineCredentialProbeTest {
         private val openError: Throwable? = null,
         private val keyRequestError: Throwable? = null,
         private val propertyError: Throwable? = null,
+        private val closeSessionError: Throwable? = null,
+        private val securityLevelValue: String = "L1",
+        private val systemIdValue: String = "38497",
+        private val emptySessionId: Boolean = false,
     ) : WidevineMediaDrmClient {
         var deviceUniqueIdChecked = false
         var keyRequestGenerated = false
         var sessionClosed = false
+        var sessionCloseAttempted = false
         var closed = false
+        var openedSession: ByteArray? = null
 
         override fun getPropertyString(name: String): String {
             propertyError?.let { throw it }
             return when (name) {
-                "securityLevel" -> "L1"
-                "systemId" -> "38497"
+                "securityLevel" -> securityLevelValue
+                "systemId" -> systemIdValue
                 else -> error("unexpected property")
             }
         }
 
-        override fun openHardwareSecureAllSession(): ByteArray {
+        override fun openMaximumSecuritySession(): ByteArray {
             openError?.let { throw it }
-            return byteArrayOf(1, 2, 3)
+            return if (emptySessionId) {
+                byteArrayOf()
+            } else {
+                byteArrayOf(1, 2, 3).also { openedSession = it }
+            }
         }
 
         override fun getSecurityLevel(sessionId: ByteArray): WidevineSessionSecurityLevel {
@@ -179,6 +324,8 @@ class WidevineCredentialProbeTest {
         }
 
         override fun closeSession(sessionId: ByteArray) {
+            sessionCloseAttempted = true
+            closeSessionError?.let { throw it }
             sessionClosed = true
         }
 

--- a/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepositoryTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepositoryTest.kt
@@ -19,7 +19,6 @@ package com.eltavine.duckdetector.features.bootloader.data.widevine
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFindingGroup
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFindingSeverity
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderMethodOutcome
-import com.eltavine.duckdetector.features.bootloader.domain.BootloaderState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -27,7 +26,7 @@ import org.junit.Test
 class WidevineCredentialRepositoryTest {
 
     @Test
-    fun `sentinel warning makes a verified bootloader state unknown`() {
+    fun `sentinel maps to consistency warning without a bootloader state result`() {
         val repository = repository(snapshot(systemId = WIDEVINE_SENTINEL_SYSTEM_ID))
 
         val evidence = repository.inspect(
@@ -43,10 +42,6 @@ class WidevineCredentialRepositoryTest {
             evidence.findings.single { it.id == "widevine_credential" }.severity,
         )
         assertEquals(BootloaderMethodOutcome.WARNING, evidence.method.outcome)
-        assertEquals(
-            BootloaderState.UNKNOWN,
-            evidence.resolveBootloaderState(BootloaderState.VERIFIED),
-        )
         assertEquals(1, evidence.anomalyCount)
         assertEquals(BootloaderFindingSeverity.WARNING, evidence.impacts.single().severity)
     }
@@ -88,31 +83,6 @@ class WidevineCredentialRepositoryTest {
         val credential = evidence.findings.single { it.id == "widevine_credential" }
         assertEquals(BootloaderFindingSeverity.DANGER, credential.severity)
         assertEquals(BootloaderMethodOutcome.DANGER, evidence.method.outcome)
-        assertEquals(
-            BootloaderState.UNLOCKED,
-            evidence.resolveBootloaderState(BootloaderState.VERIFIED),
-        )
-    }
-
-    @Test
-    fun `Widevine never weakens an existing authoritative failure state`() {
-        val warningEvidence = repository(
-            snapshot(systemId = WIDEVINE_SENTINEL_SYSTEM_ID),
-        ).inspect(
-            WidevineBootContext(
-                rootOfTrustUnlocked = false,
-                bootStateAppearsLocked = true,
-            ),
-        )
-
-        assertEquals(
-            BootloaderState.UNLOCKED,
-            warningEvidence.resolveBootloaderState(BootloaderState.UNLOCKED),
-        )
-        assertEquals(
-            BootloaderState.FAILED_VERIFICATION,
-            warningEvidence.resolveBootloaderState(BootloaderState.FAILED_VERIFICATION),
-        )
     }
 
     @Test

--- a/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepositoryTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepositoryTest.kt
@@ -19,6 +19,7 @@ package com.eltavine.duckdetector.features.bootloader.data.widevine
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFindingGroup
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFindingSeverity
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderMethodOutcome
+import com.eltavine.duckdetector.features.bootloader.domain.BootloaderState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -26,7 +27,7 @@ import org.junit.Test
 class WidevineCredentialRepositoryTest {
 
     @Test
-    fun `sentinel maps to consistency warning without a bootloader state result`() {
+    fun `sentinel warning makes a verified bootloader state unknown`() {
         val repository = repository(snapshot(systemId = WIDEVINE_SENTINEL_SYSTEM_ID))
 
         val evidence = repository.inspect(
@@ -42,6 +43,10 @@ class WidevineCredentialRepositoryTest {
             evidence.findings.single { it.id == "widevine_credential" }.severity,
         )
         assertEquals(BootloaderMethodOutcome.WARNING, evidence.method.outcome)
+        assertEquals(
+            BootloaderState.UNKNOWN,
+            evidence.resolveBootloaderState(BootloaderState.VERIFIED),
+        )
         assertEquals(1, evidence.anomalyCount)
         assertEquals(BootloaderFindingSeverity.WARNING, evidence.impacts.single().severity)
     }
@@ -83,6 +88,31 @@ class WidevineCredentialRepositoryTest {
         val credential = evidence.findings.single { it.id == "widevine_credential" }
         assertEquals(BootloaderFindingSeverity.DANGER, credential.severity)
         assertEquals(BootloaderMethodOutcome.DANGER, evidence.method.outcome)
+        assertEquals(
+            BootloaderState.UNLOCKED,
+            evidence.resolveBootloaderState(BootloaderState.VERIFIED),
+        )
+    }
+
+    @Test
+    fun `Widevine never weakens an existing authoritative failure state`() {
+        val warningEvidence = repository(
+            snapshot(systemId = WIDEVINE_SENTINEL_SYSTEM_ID),
+        ).inspect(
+            WidevineBootContext(
+                rootOfTrustUnlocked = false,
+                bootStateAppearsLocked = true,
+            ),
+        )
+
+        assertEquals(
+            BootloaderState.UNLOCKED,
+            warningEvidence.resolveBootloaderState(BootloaderState.UNLOCKED),
+        )
+        assertEquals(
+            BootloaderState.FAILED_VERIFICATION,
+            warningEvidence.resolveBootloaderState(BootloaderState.FAILED_VERIFICATION),
+        )
     }
 
     @Test

--- a/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepositoryTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepositoryTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.bootloader.data.widevine
+
+import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFindingGroup
+import com.eltavine.duckdetector.features.bootloader.domain.BootloaderFindingSeverity
+import com.eltavine.duckdetector.features.bootloader.domain.BootloaderMethodOutcome
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WidevineCredentialRepositoryTest {
+
+    @Test
+    fun `sentinel maps to consistency warning without a bootloader state result`() {
+        val repository = repository(snapshot(systemId = WIDEVINE_SENTINEL_SYSTEM_ID))
+
+        val evidence = repository.inspect(
+            WidevineBootContext(
+                rootOfTrustUnlocked = false,
+                bootStateAppearsLocked = true,
+            ),
+        )
+
+        assertTrue(evidence.findings.all { it.group == BootloaderFindingGroup.CONSISTENCY })
+        assertEquals(
+            BootloaderFindingSeverity.WARNING,
+            evidence.findings.single { it.id == "widevine_credential" }.severity,
+        )
+        assertEquals(BootloaderMethodOutcome.WARNING, evidence.method.outcome)
+        assertEquals(1, evidence.anomalyCount)
+        assertEquals(BootloaderFindingSeverity.WARNING, evidence.impacts.single().severity)
+    }
+
+    @Test
+    fun `RootOfTrust unlock escalates sentinel evidence to danger`() {
+        val repository = repository(snapshot(systemId = WIDEVINE_SENTINEL_SYSTEM_ID))
+
+        val evidence = repository.inspect(
+            WidevineBootContext(
+                rootOfTrustUnlocked = true,
+                bootStateAppearsLocked = false,
+            ),
+        )
+
+        assertEquals(
+            BootloaderFindingSeverity.DANGER,
+            evidence.findings.single { it.id == "widevine_credential" }.severity,
+        )
+        assertEquals(BootloaderMethodOutcome.DANGER, evidence.method.outcome)
+    }
+
+    @Test
+    fun `unsupported Widevine maps to support method and no anomaly`() {
+        val repository = repository(WidevineCredentialSnapshot(schemeSupported = false))
+
+        val evidence = repository.inspect(
+            WidevineBootContext(
+                rootOfTrustUnlocked = false,
+                bootStateAppearsLocked = true,
+            ),
+        )
+
+        assertEquals(BootloaderMethodOutcome.SUPPORT, evidence.method.outcome)
+        assertEquals(0, evidence.anomalyCount)
+        assertTrue(evidence.impacts.isEmpty())
+    }
+
+    private fun repository(snapshot: WidevineCredentialSnapshot): WidevineCredentialRepository {
+        return WidevineCredentialRepository(
+            source = WidevineCredentialSource { snapshot },
+        )
+    }
+
+    private fun snapshot(systemId: String): WidevineCredentialSnapshot {
+        val securityLevel = WidevinePropertyRead(WidevinePropertyStatus.AVAILABLE, "L1")
+        val id = WidevinePropertyRead(WidevinePropertyStatus.AVAILABLE, systemId)
+        return WidevineCredentialSnapshot(
+            schemeSupported = true,
+            javaSecurityLevel = securityLevel,
+            javaSystemId = id,
+            native = WidevineNativeSnapshot(
+                available = true,
+                securityLevel = securityLevel,
+                systemId = id,
+                securityLevelStatusCode = 0,
+                systemIdStatusCode = 0,
+            ),
+            sessionStatus = WidevineOperationStatus.SUCCESS,
+            actualSessionSecurityLevel = WidevineSessionSecurityLevel.HW_SECURE_ALL,
+            credentialStatus = WidevineOperationStatus.SUCCESS,
+            credentialAvailable = true,
+            keyRequestStatus = WidevineOperationStatus.SUCCESS,
+        )
+    }
+}

--- a/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepositoryTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineCredentialRepositoryTest.kt
@@ -47,7 +47,7 @@ class WidevineCredentialRepositoryTest {
     }
 
     @Test
-    fun `RootOfTrust unlock escalates sentinel evidence to danger`() {
+    fun `RootOfTrust unlock remains separate from sentinel evidence`() {
         val repository = repository(snapshot(systemId = WIDEVINE_SENTINEL_SYSTEM_ID))
 
         val evidence = repository.inspect(
@@ -58,9 +58,30 @@ class WidevineCredentialRepositoryTest {
         )
 
         assertEquals(
-            BootloaderFindingSeverity.DANGER,
+            BootloaderFindingSeverity.WARNING,
             evidence.findings.single { it.id == "widevine_credential" }.severity,
         )
+        assertEquals(BootloaderMethodOutcome.WARNING, evidence.method.outcome)
+    }
+
+    @Test
+    fun `corroborated Widevine anomaly maps to danger`() {
+        val repository = repository(
+            snapshot(
+                systemId = WIDEVINE_SENTINEL_SYSTEM_ID,
+                actualLevel = WidevineSessionSecurityLevel.SW_SECURE_CRYPTO,
+            ),
+        )
+
+        val evidence = repository.inspect(
+            WidevineBootContext(
+                rootOfTrustUnlocked = false,
+                bootStateAppearsLocked = true,
+            ),
+        )
+
+        val credential = evidence.findings.single { it.id == "widevine_credential" }
+        assertEquals(BootloaderFindingSeverity.DANGER, credential.severity)
         assertEquals(BootloaderMethodOutcome.DANGER, evidence.method.outcome)
     }
 
@@ -86,11 +107,15 @@ class WidevineCredentialRepositoryTest {
         )
     }
 
-    private fun snapshot(systemId: String): WidevineCredentialSnapshot {
+    private fun snapshot(
+        systemId: String,
+        actualLevel: WidevineSessionSecurityLevel = WidevineSessionSecurityLevel.HW_SECURE_ALL,
+    ): WidevineCredentialSnapshot {
         val securityLevel = WidevinePropertyRead(WidevinePropertyStatus.AVAILABLE, "L1")
         val id = WidevinePropertyRead(WidevinePropertyStatus.AVAILABLE, systemId)
         return WidevineCredentialSnapshot(
             schemeSupported = true,
+            hardwareSecureAllSupported = true,
             javaSecurityLevel = securityLevel,
             javaSystemId = id,
             native = WidevineNativeSnapshot(
@@ -101,7 +126,7 @@ class WidevineCredentialRepositoryTest {
                 systemIdStatusCode = 0,
             ),
             sessionStatus = WidevineOperationStatus.SUCCESS,
-            actualSessionSecurityLevel = WidevineSessionSecurityLevel.HW_SECURE_ALL,
+            actualSessionSecurityLevel = actualLevel,
             credentialStatus = WidevineOperationStatus.SUCCESS,
             credentialAvailable = true,
             keyRequestStatus = WidevineOperationStatus.SUCCESS,

--- a/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineNativeBridgeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineNativeBridgeTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Duck Apps Contributor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.eltavine.duckdetector.features.bootloader.data.widevine
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WidevineNativeBridgeTest {
+
+    private val bridge = WidevineNativeBridge()
+
+    @Test
+    fun `successful native payload preserves both property reads`() {
+        val snapshot = bridge.parse(
+            arrayOf("1", "0", "L1", "0", "38497"),
+        )
+
+        assertTrue(snapshot.available)
+        assertEquals(WidevinePropertyStatus.AVAILABLE, snapshot.securityLevel.status)
+        assertEquals("L1", snapshot.securityLevel.value)
+        assertEquals(WidevinePropertyStatus.AVAILABLE, snapshot.systemId.status)
+        assertEquals("38497", snapshot.systemId.value)
+    }
+
+    @Test
+    fun `native property status errors do not become property values`() {
+        val snapshot = bridge.parse(
+            arrayOf("1", "-10001", null, "-10002", null),
+        )
+
+        assertTrue(snapshot.available)
+        assertEquals(WidevinePropertyStatus.UNSUPPORTED, snapshot.securityLevel.status)
+        assertEquals(null, snapshot.securityLevel.value)
+        assertEquals(-10001, snapshot.securityLevelStatusCode)
+        assertEquals(WidevinePropertyStatus.UNSUPPORTED, snapshot.systemId.status)
+    }
+
+    @Test
+    fun `unavailable native payload reduces coverage`() {
+        val snapshot = bridge.parse(arrayOf("0", null, null, null, null))
+
+        assertFalse(snapshot.available)
+    }
+}

--- a/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineNativeBridgeTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/bootloader/data/widevine/WidevineNativeBridgeTest.kt
@@ -39,16 +39,54 @@ class WidevineNativeBridgeTest {
     }
 
     @Test
-    fun `native property status errors do not become property values`() {
+    fun `native property statuses distinguish unsupported from runtime errors`() {
         val snapshot = bridge.parse(
             arrayOf("1", "-10001", null, "-10002", null),
         )
 
         assertTrue(snapshot.available)
-        assertEquals(WidevinePropertyStatus.UNSUPPORTED, snapshot.securityLevel.status)
+        assertEquals(WidevinePropertyStatus.ERROR, snapshot.securityLevel.status)
         assertEquals(null, snapshot.securityLevel.value)
         assertEquals(-10001, snapshot.securityLevelStatusCode)
         assertEquals(WidevinePropertyStatus.UNSUPPORTED, snapshot.systemId.status)
+    }
+
+    @Test
+    fun `cannot handle native property is treated as unsupported`() {
+        val snapshot = bridge.parse(
+            arrayOf("1", "-10004", null, "-10004", null),
+        )
+
+        assertEquals(WidevinePropertyStatus.UNSUPPORTED, snapshot.securityLevel.status)
+        assertEquals(WidevinePropertyStatus.UNSUPPORTED, snapshot.systemId.status)
+    }
+
+    @Test
+    fun `successful native status without a value is an error`() {
+        val snapshot = bridge.parse(
+            arrayOf("1", "0", null, "0", "38497"),
+        )
+
+        assertEquals(WidevinePropertyStatus.ERROR, snapshot.securityLevel.status)
+        assertEquals(WidevinePropertyStatus.AVAILABLE, snapshot.systemId.status)
+    }
+
+    @Test
+    fun `native property values enforce bounded printable input`() {
+        val snapshot = bridge.parse(
+            arrayOf(
+                "1",
+                "0",
+                "L1\nspoofed",
+                "0",
+                "9".repeat(MAX_WIDEVINE_PROPERTY_VALUE_LENGTH + 1),
+            ),
+        )
+
+        assertEquals(WidevinePropertyStatus.ERROR, snapshot.securityLevel.status)
+        assertEquals(WidevinePropertyStatus.ERROR, snapshot.systemId.status)
+        assertEquals(null, snapshot.securityLevel.value)
+        assertEquals(null, snapshot.systemId.value)
     }
 
     @Test
@@ -56,5 +94,16 @@ class WidevineNativeBridgeTest {
         val snapshot = bridge.parse(arrayOf("0", null, null, null, null))
 
         assertFalse(snapshot.available)
+    }
+
+    @Test
+    fun `invalid native DRM object is unavailable rather than unsupported`() {
+        val snapshot = bridge.parse(
+            arrayOf("1", "-10003", null, "-10003", null),
+        )
+
+        assertFalse(snapshot.available)
+        assertEquals(-10003, snapshot.securityLevelStatusCode)
+        assertEquals(-10003, snapshot.systemIdStatusCode)
     }
 }

--- a/app/src/test/java/com/eltavine/duckdetector/features/bootloader/presentation/BootloaderCardModelMapperTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/bootloader/presentation/BootloaderCardModelMapperTest.kt
@@ -100,7 +100,7 @@ class BootloaderCardModelMapperTest {
     }
 
     @Test
-    fun `Widevine credential warning is presented without changing verified state`() {
+    fun `Widevine warning colors the card without changing verified state`() {
         val model = mapper.map(
             report = report(
                 findings = listOf(
@@ -120,11 +120,13 @@ class BootloaderCardModelMapperTest {
                         outcome = BootloaderMethodOutcome.WARNING,
                     ),
                 ),
+                consistencyFindingCount = 1,
             ),
         )
 
         assertEquals("Verified", model.headerFacts.single { it.label == "State" }.value)
         assertEquals(DetectorStatus.warning(), model.status)
+        assertEquals("1 DRM consistency signal(s) need review", model.verdict)
         assertEquals(
             DetectorStatus.warning(),
             model.consistencyRows.single { it.label == "Widevine credential" }.status,
@@ -133,6 +135,47 @@ class BootloaderCardModelMapperTest {
             DetectorStatus.warning(),
             model.methodRows.single { it.label == "Widevine credential" }.status,
         )
+        assertEquals(
+            DetectorStatus.warning(),
+            model.scanRows.single { it.label == "Cross-checks" }.status,
+        )
+    }
+
+    @Test
+    fun `Widevine danger colors the card without changing verified state`() {
+        val model = mapper.map(
+            report = report(
+                findings = listOf(
+                    BootloaderFinding(
+                        id = "widevine_credential",
+                        label = "Widevine credential",
+                        value = "Corroborated anomaly",
+                        group = BootloaderFindingGroup.CONSISTENCY,
+                        severity = BootloaderFindingSeverity.DANGER,
+                    ),
+                ),
+                methods = listOf(
+                    BootloaderMethodResult(
+                        label = "Widevine credential",
+                        summary = "DRM inconsistency",
+                        outcome = BootloaderMethodOutcome.DANGER,
+                    ),
+                ),
+                consistencyFindingCount = 1,
+            ),
+        )
+
+        assertEquals("Verified", model.headerFacts.single { it.label == "State" }.value)
+        assertEquals(DetectorStatus.danger(), model.status)
+        assertEquals("1 critical DRM consistency signal(s)", model.verdict)
+        assertEquals(
+            DetectorStatus.danger(),
+            model.consistencyRows.single { it.label == "Widevine credential" }.status,
+        )
+        assertEquals(
+            DetectorStatus.danger(),
+            model.scanRows.single { it.label == "Cross-checks" }.status,
+        )
     }
 
     private fun report(
@@ -140,6 +183,7 @@ class BootloaderCardModelMapperTest {
         attestationChainLength: Int = 2,
         findings: List<BootloaderFinding> = emptyList(),
         methods: List<BootloaderMethodResult> = emptyList(),
+        consistencyFindingCount: Int = 0,
     ): BootloaderReport {
         return BootloaderReport(
             stage = BootloaderStage.READY,
@@ -155,7 +199,7 @@ class BootloaderCardModelMapperTest {
             nativePropertyHitCount = 4,
             rawBootParamHitCount = 2,
             sourceMismatchCount = 0,
-            consistencyFindingCount = 0,
+            consistencyFindingCount = consistencyFindingCount,
             findings = findings,
             impacts = emptyList(),
             methods = methods,

--- a/app/src/test/java/com/eltavine/duckdetector/features/bootloader/presentation/BootloaderCardModelMapperTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/bootloader/presentation/BootloaderCardModelMapperTest.kt
@@ -99,6 +99,42 @@ class BootloaderCardModelMapperTest {
         )
     }
 
+    @Test
+    fun `Widevine credential warning is presented without changing verified state`() {
+        val model = mapper.map(
+            report = report(
+                findings = listOf(
+                    BootloaderFinding(
+                        id = "widevine_credential",
+                        label = "Widevine credential",
+                        value = "Sentinel system ID",
+                        group = BootloaderFindingGroup.CONSISTENCY,
+                        severity = BootloaderFindingSeverity.WARNING,
+                        detail = "DRM credential anomaly; not standalone unlock proof.",
+                    ),
+                ),
+                methods = listOf(
+                    BootloaderMethodResult(
+                        label = "Widevine credential",
+                        summary = "Needs review",
+                        outcome = BootloaderMethodOutcome.WARNING,
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals("Verified", model.headerFacts.single { it.label == "State" }.value)
+        assertEquals(DetectorStatus.warning(), model.status)
+        assertEquals(
+            DetectorStatus.warning(),
+            model.consistencyRows.single { it.label == "Widevine credential" }.status,
+        )
+        assertEquals(
+            DetectorStatus.warning(),
+            model.methodRows.single { it.label == "Widevine credential" }.status,
+        )
+    }
+
     private fun report(
         trustRoot: TeeTrustRoot = TeeTrustRoot.GOOGLE,
         attestationChainLength: Int = 2,

--- a/app/src/test/java/com/eltavine/duckdetector/features/bootloader/presentation/BootloaderCardModelMapperTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/bootloader/presentation/BootloaderCardModelMapperTest.kt
@@ -26,9 +26,12 @@ import com.eltavine.duckdetector.features.bootloader.domain.BootloaderMethodResu
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderReport
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderStage
 import com.eltavine.duckdetector.features.bootloader.domain.BootloaderState
+import com.eltavine.duckdetector.features.bootloader.ui.model.BootloaderCardAssessment
 import com.eltavine.duckdetector.features.tee.domain.TeeTier
 import com.eltavine.duckdetector.features.tee.domain.TeeTrustRoot
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class BootloaderCardModelMapperTest {
@@ -54,6 +57,9 @@ class BootloaderCardModelMapperTest {
         )
 
         assertEquals(DetectorStatus.danger(), model.status)
+        assertEquals(BootloaderCardAssessment.AUTHORITATIVE, model.assessment)
+        assertFalse(model.showConsistencyQuestionIcon)
+        assertEquals(null, model.assessmentStatus)
         assertEquals(
             DetectorStatus.danger(),
             model.headerFacts.single { it.label == "Trust" }.status,
@@ -100,10 +106,9 @@ class BootloaderCardModelMapperTest {
     }
 
     @Test
-    fun `Widevine warning colors the card and renders unknown state`() {
+    fun `Widevine warning adds review assessment without changing verified state`() {
         val model = mapper.map(
             report = report(
-                state = BootloaderState.UNKNOWN,
                 findings = listOf(
                     BootloaderFinding(
                         id = "widevine_credential",
@@ -111,7 +116,7 @@ class BootloaderCardModelMapperTest {
                         value = "Sentinel system ID",
                         group = BootloaderFindingGroup.CONSISTENCY,
                         severity = BootloaderFindingSeverity.WARNING,
-                        detail = "DRM credential anomaly made the state inconclusive.",
+                        detail = "DRM credential anomaly; not standalone unlock proof.",
                     ),
                 ),
                 methods = listOf(
@@ -125,7 +130,14 @@ class BootloaderCardModelMapperTest {
             ),
         )
 
-        assertEquals("Unknown", model.headerFacts.single { it.label == "State" }.value)
+        assertEquals("Verified", model.headerFacts.single { it.label == "State" }.value)
+        assertEquals(
+            DetectorStatus.allClear(),
+            model.headerFacts.single { it.label == "State" }.status,
+        )
+        assertEquals(BootloaderCardAssessment.CONSISTENCY_REVIEW, model.assessment)
+        assertTrue(model.showConsistencyQuestionIcon)
+        assertEquals(DetectorStatus.warning(), model.assessmentStatus)
         assertEquals(DetectorStatus.warning(), model.status)
         assertEquals("1 DRM consistency signal(s) need review", model.verdict)
         assertEquals(
@@ -143,10 +155,9 @@ class BootloaderCardModelMapperTest {
     }
 
     @Test
-    fun `Widevine danger colors the card and renders unlocked state`() {
+    fun `Widevine danger adds conflict assessment without changing verified state`() {
         val model = mapper.map(
             report = report(
-                state = BootloaderState.UNLOCKED,
                 findings = listOf(
                     BootloaderFinding(
                         id = "widevine_credential",
@@ -167,7 +178,14 @@ class BootloaderCardModelMapperTest {
             ),
         )
 
-        assertEquals("Unlocked", model.headerFacts.single { it.label == "State" }.value)
+        assertEquals("Verified", model.headerFacts.single { it.label == "State" }.value)
+        assertEquals(
+            DetectorStatus.allClear(),
+            model.headerFacts.single { it.label == "State" }.status,
+        )
+        assertEquals(BootloaderCardAssessment.CONSISTENCY_CONFLICT, model.assessment)
+        assertTrue(model.showConsistencyQuestionIcon)
+        assertEquals(DetectorStatus.danger(), model.assessmentStatus)
         assertEquals(DetectorStatus.danger(), model.status)
         assertEquals("1 critical DRM consistency signal(s)", model.verdict)
         assertEquals(
@@ -180,8 +198,57 @@ class BootloaderCardModelMapperTest {
         )
     }
 
+    @Test
+    fun `Widevine review badge stays yellow when authoritative evidence makes card red`() {
+        val model = mapper.map(
+            report = report(
+                findings = listOf(
+                    BootloaderFinding(
+                        id = "attestation_contradiction",
+                        label = "Attestation contradiction",
+                        value = "Detected",
+                        group = BootloaderFindingGroup.ATTESTATION,
+                        severity = BootloaderFindingSeverity.DANGER,
+                    ),
+                    BootloaderFinding(
+                        id = "widevine_credential",
+                        label = "Widevine credential",
+                        value = "Sentinel system ID",
+                        group = BootloaderFindingGroup.CONSISTENCY,
+                        severity = BootloaderFindingSeverity.WARNING,
+                    ),
+                ),
+                consistencyFindingCount = 1,
+            ),
+        )
+
+        assertEquals(DetectorStatus.danger(), model.status)
+        assertEquals(BootloaderCardAssessment.CONSISTENCY_REVIEW, model.assessment)
+        assertEquals(DetectorStatus.warning(), model.assessmentStatus)
+    }
+
+    @Test
+    fun `Widevine support coverage does not add a question icon`() {
+        val model = mapper.map(
+            report = report(
+                findings = listOf(
+                    BootloaderFinding(
+                        id = "widevine_credential",
+                        label = "Widevine credential",
+                        value = "Unsupported",
+                        group = BootloaderFindingGroup.CONSISTENCY,
+                        severity = BootloaderFindingSeverity.INFO,
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals(BootloaderCardAssessment.AUTHORITATIVE, model.assessment)
+        assertFalse(model.showConsistencyQuestionIcon)
+        assertEquals(null, model.assessmentStatus)
+    }
+
     private fun report(
-        state: BootloaderState = BootloaderState.VERIFIED,
         trustRoot: TeeTrustRoot = TeeTrustRoot.GOOGLE,
         attestationChainLength: Int = 2,
         findings: List<BootloaderFinding> = emptyList(),
@@ -190,7 +257,7 @@ class BootloaderCardModelMapperTest {
     ): BootloaderReport {
         return BootloaderReport(
             stage = BootloaderStage.READY,
-            state = state,
+            state = BootloaderState.VERIFIED,
             evidenceMode = BootloaderEvidenceMode.ATTESTATION,
             trustRoot = trustRoot,
             tier = TeeTier.TEE,

--- a/app/src/test/java/com/eltavine/duckdetector/features/bootloader/presentation/BootloaderCardModelMapperTest.kt
+++ b/app/src/test/java/com/eltavine/duckdetector/features/bootloader/presentation/BootloaderCardModelMapperTest.kt
@@ -100,9 +100,10 @@ class BootloaderCardModelMapperTest {
     }
 
     @Test
-    fun `Widevine warning colors the card without changing verified state`() {
+    fun `Widevine warning colors the card and renders unknown state`() {
         val model = mapper.map(
             report = report(
+                state = BootloaderState.UNKNOWN,
                 findings = listOf(
                     BootloaderFinding(
                         id = "widevine_credential",
@@ -110,7 +111,7 @@ class BootloaderCardModelMapperTest {
                         value = "Sentinel system ID",
                         group = BootloaderFindingGroup.CONSISTENCY,
                         severity = BootloaderFindingSeverity.WARNING,
-                        detail = "DRM credential anomaly; not standalone unlock proof.",
+                        detail = "DRM credential anomaly made the state inconclusive.",
                     ),
                 ),
                 methods = listOf(
@@ -124,7 +125,7 @@ class BootloaderCardModelMapperTest {
             ),
         )
 
-        assertEquals("Verified", model.headerFacts.single { it.label == "State" }.value)
+        assertEquals("Unknown", model.headerFacts.single { it.label == "State" }.value)
         assertEquals(DetectorStatus.warning(), model.status)
         assertEquals("1 DRM consistency signal(s) need review", model.verdict)
         assertEquals(
@@ -142,9 +143,10 @@ class BootloaderCardModelMapperTest {
     }
 
     @Test
-    fun `Widevine danger colors the card without changing verified state`() {
+    fun `Widevine danger colors the card and renders unlocked state`() {
         val model = mapper.map(
             report = report(
+                state = BootloaderState.UNLOCKED,
                 findings = listOf(
                     BootloaderFinding(
                         id = "widevine_credential",
@@ -165,7 +167,7 @@ class BootloaderCardModelMapperTest {
             ),
         )
 
-        assertEquals("Verified", model.headerFacts.single { it.label == "State" }.value)
+        assertEquals("Unlocked", model.headerFacts.single { it.label == "State" }.value)
         assertEquals(DetectorStatus.danger(), model.status)
         assertEquals("1 critical DRM consistency signal(s)", model.verdict)
         assertEquals(
@@ -179,6 +181,7 @@ class BootloaderCardModelMapperTest {
     }
 
     private fun report(
+        state: BootloaderState = BootloaderState.VERIFIED,
         trustRoot: TeeTrustRoot = TeeTrustRoot.GOOGLE,
         attestationChainLength: Int = 2,
         findings: List<BootloaderFinding> = emptyList(),
@@ -187,7 +190,7 @@ class BootloaderCardModelMapperTest {
     ): BootloaderReport {
         return BootloaderReport(
             stage = BootloaderStage.READY,
-            state = BootloaderState.VERIFIED,
+            state = state,
             evidenceMode = BootloaderEvidenceMode.ATTESTATION,
             trustRoot = trustRoot,
             tier = TeeTier.TEE,


### PR DESCRIPTION
## Summary

- Add a Widevine credential consistency probe to the bootloader consistency checks.
- Detect the exact `L1` plus `systemId == 2147483647` sentinel without flagging unrelated decimal IDs.
- Cross-read `securityLevel` and `systemId` through Java `MediaDrm` and NDK `AMediaDrm`.
- Verify the actual level of an `HW_SECURE_ALL` session and generate a local, non-networked test key request.
- Keep DRM credential anomalies separate from the authoritative bootloader state.

## Detection behavior

- Report the sentinel as a warning unless session, credential, provisioning, or independently attested RootOfTrust evidence makes it a danger.
- Report an advertised L1 session that operates below `HW_SECURE_ALL` as a danger.
- Treat Java/native property disagreement as a warning for possible hooks, spoofing, or framework inconsistency.
- Treat unsupported properties, unavailable native coverage, resource contention, and transient failures as support or inconclusive states.

## Privacy and safety

- Never persist, display, hash, or upload the Widevine device-unique identifier.
- Never retain opaque key-request bytes.
- Never contact a provisioning or license server.
- Close every opened DRM session and `MediaDrm` instance.
- Retain only sanitized error categories and numeric metadata.

## Validation

- [x] Widevine classifier, probe, native parser, repository, and presentation unit tests
- [x] Full `testDebugUnitTest`
- [x] Four-ABI `externalNativeBuildDebug`
- [x] `assembleDebug`
- [ ] Locked L1 device validation
- [ ] Real-world testing across multiple Android devices

Closes #111

Issue: https://github.com/eltavine/Duck-Detector-Refactoring/issues/111

