### PR TITLE
fix(nativeroot): stop emitting INFO finding for clean self-process IOC result

### DIFF
--- a/app/src/main/cpp/nativeroot/probes/self_process_ioc_probe.cpp
+++ b/app/src/main/cpp/nativeroot/probes/self_process_ioc_probe.cpp
@@ -122,18 +122,9 @@ namespace duckdetector::nativeroot {
             );
         }
 
-        if (driver_fd_count == 0 && fdwrapper_count == 0 && result.findings.empty() &&
-            !context.empty()) {
-            result.findings.push_back(
-                    Finding{
-                            .group = "PROCESS",
-                            .label = "Self SELinux context",
-                            .value = context,
-                            .detail = "The current app process context stayed outside the KernelSU su domain.",
-                            .severity = Severity::kInfo,
-                    }
-            );
-        }
+        // A clean result must not become a finding: PROCESS findings are counted as runtime
+        // hits by the Kotlin layer. The context still flows through extra_text -> SELF_CONTEXT.
+        // 干净结果不能生成 finding：PROCESS 组会被 Kotlin 层计为 runtime 命中；context 仍经 SELF_CONTEXT 上报。
 
         result.checked_count = 2;
         result.denied_count = 0;


### PR DESCRIPTION
The self-process IOC probe pushed an INFO `PROCESS` finding stating that the app context "stayed outside the KernelSU su domain" whenever the probe found nothing. PROCESS-group findings are counted as runtime-artifact hits by the Kotlin layer, so every clean device showed "1" under Runtime and the `runtimeArtifacts` method row reported "1 hit(s)" instead of Clean.

A clean result is not a detection, so the clean-path finding is removed. The observed SELinux context is still reported through `extra_text` -> `SELF_CONTEXT` and rendered by the "Self context" scan row and the `selfProcessIoc` method detail, so no evidence is lost. The su-domain and KSU FD detections (DANGER) are unchanged.

## Validation

- Unit tests + `:app:assembleDebug` (includes native build) passed on GitHub Actions: https://github.com/jiugjk/Duck-Detector-Refactoring/actions/runs/32352420103
- Real-device smoke test passed: clean device now shows Runtime "Clean" / `runtimeArtifacts` "Clean"; "Self context" row still shows the SELinux context

## Detector Behavior Impact

- Changed verdict rules: clean devices no longer show a Runtime hit; no severity rules changed
- Expected false-positive impact: removes the "1 hint on clean devices" false positive
- Expected false-negative impact: none - the clean-path INFO finding carried no detection signal